### PR TITLE
absolute position stacks relative to the parent

### DIFF
--- a/examples/flags/finland.rb
+++ b/examples/flags/finland.rb
@@ -1,0 +1,19 @@
+require "scarpe"
+
+Scarpe.app(title: "Finland", width: 360, height: 220, ) do
+  flow width: 360, height: 220 do
+    background "blue"
+    stack width: 100, height: 80 do
+      background "white"
+    end
+    stack width: 100, height: 80, top: 140, left: 0 do
+      background "white"
+    end
+    stack width: 200, height: 80, top: 0, left: 160 do
+      background "white"
+    end
+    stack width: 200, height: 80, top: 140, left: 160 do
+      background "white"
+    end
+  end
+end

--- a/examples/flags/italy.rb
+++ b/examples/flags/italy.rb
@@ -1,0 +1,15 @@
+require "scarpe"
+
+Scarpe.app(height: 300) do
+  flow height: 1.0 do
+    stack width: 0.33, height: 1.0 do
+      background "green"
+    end
+    stack width: 0.34, height: 1.0 do
+      background "white"
+    end
+    stack width: 0.33, height: 1.0 do
+      background "red"
+    end
+  end
+end

--- a/examples/flags/mauritius.rb
+++ b/examples/flags/mauritius.rb
@@ -1,0 +1,18 @@
+require "scarpe"
+
+Scarpe.app(title: "Mauritius", height: 300) do
+  flow height: 1.0 do
+    stack width: 1.0, height: 0.25 do
+      background "red"
+    end
+    stack width: 1.0, height: 0.25 do
+      background "blue"
+    end
+    stack width: 1.0, height: 0.25 do
+      background "yellow"
+    end
+    stack width: 1.0, height: 0.25 do
+      background "green"
+    end
+  end
+end

--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -4,6 +4,7 @@ class Scarpe
   # Scarpe::App must only be used from the main thread, due to GTK+ limitations.
   class App
     VALID_OPTS = [:debug, :test_assertions, :init_code, :result_filename, :periodic_time, :die_after]
+    TITLE_BAR_HEIGHT_PX = 28
 
     def initialize(title: "Scarpe!", width: 480, height: 420, **opts, &app_code_body)
       bad_opts = opts.keys - VALID_OPTS
@@ -11,7 +12,7 @@ class Scarpe
 
       @title = title
       @width = width
-      @height = height
+      @height = height + TITLE_BAR_HEIGHT_PX
       @opts = opts
       @app_code_body = app_code_body
     end

--- a/lib/scarpe/document_root.rb
+++ b/lib/scarpe/document_root.rb
@@ -30,7 +30,7 @@ class Scarpe
     end
 
     def empty
-      "<body id='body-#{html_id}'><div id='wrapper-#{html_id}'></div></body>"
+      "<body id='body-#{html_id}' style='border:0;margin:0;'><div id='wrapper-#{html_id}'></div></body>"
     end
 
     def replace(el)

--- a/lib/scarpe/flow.rb
+++ b/lib/scarpe/flow.rb
@@ -5,7 +5,7 @@ class Scarpe
     include Scarpe::Background
     include Scarpe::Border
 
-    def initialize(width: nil, height: nil, margin: nil, margin_left: nil, margin_top: nil, &block)
+    def initialize(width: nil, height: nil, top: nil, margin: nil, margin_left: nil, margin_top: nil, &block)
       @width = width
       @height = height
       @margin = margin
@@ -29,13 +29,23 @@ class Scarpe
       styles[:display] = "flex"
       styles["flex-direction"] = "row"
       styles["flex-wrap"] = "wrap"
+
+      styles[:position] = positioning? ? "absolute" : "relative"
+
       styles[:margin] = Dimensions.length(@margin) if @margin
       styles["margin-left"] = Dimensions.length(@margin_left) if @margin_left
       styles["margin-top"] = Dimensions.length(@margin_top) if @margin_top
       styles[:width] = Dimensions.length(@width) if @width
       styles[:height] = Dimensions.length(@height) if @height
 
+      styles[:top] = Dimensions.length(@top) if @top
+      styles[:left] = Dimensions.length(@left) if @left
+
       styles
+    end
+
+    def positioning?
+      @top || @left
     end
   end
 end

--- a/lib/scarpe/stack.rb
+++ b/lib/scarpe/stack.rb
@@ -5,9 +5,11 @@ class Scarpe
     include Scarpe::Background
     include Scarpe::Border
 
-    def initialize(width: nil, height: nil, margin: nil, &block)
+    def initialize(width: nil, height: nil, top: nil, left: nil, margin: nil, &block)
       @width = width
       @height = height
+      @top = top
+      @left = left
       @margin = margin
       instance_eval(&block)
       super
@@ -26,11 +28,22 @@ class Scarpe
 
       styles[:display] = "flex"
       styles["flex-direction"] = "column"
-      styles[:margin] = Dimensions.length(@margin) if @margin
+
+      styles[:position] = positioning? ? "absolute" : "relative"
+
       styles[:width] = Dimensions.length(@width) if @width
       styles[:height] = Dimensions.length(@height) if @height
 
+      styles[:top] = Dimensions.length(@top) if @top
+      styles[:left] = Dimensions.length(@left) if @left
+
+      styles[:margin] = Dimensions.length(@margin) if @margin
+
       styles
+    end
+
+    def positioning?
+      @top || @left
     end
   end
 end


### PR DESCRIPTION
Enables the absolute positioning of element (using `top:` and `left:`) relative to its parent.

We do this by setting the every element to relative positioning unless either `top` or `left` are specified, and thus the assumption is the programmer wishes to absolutely position this element relative to its parent.

For clarity, an absolutely positioned element needs to be inside an element that has relative or absolute positioning itself.

_plus_ fun flags to prove it all works. :-)