### PR TITLE
DO NOT MERGE: An attempt at building out a Scarpe testing library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,12 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in scarpe.gemspec
 gemspec
 
+gem "json"
 gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"
 
-gem "rubocop", "~> 1.21"
+gem "rubocop", "~> 1.21", group: :development
 
 gem "ruby-lsp", "~> 0.3.8", group: :development
 

--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -8,6 +8,7 @@ require_relative "scarpe/app"
 require_relative "scarpe/colors"
 require_relative "scarpe/dimensions"
 require_relative "scarpe/html"
+require_relative "scarpe/promises"
 
 require_relative "scarpe/spacing"
 require_relative "scarpe/widget"

--- a/lib/scarpe/control_interface_test.rb
+++ b/lib/scarpe/control_interface_test.rb
@@ -1,0 +1,236 @@
+# The ControlInterface doesn't, by default, include much of a test framework.
+# But writing a test framework in heredocs in test_helper.rb seems bad.
+# So we write a test framework here, but don't include it by default.
+# A running shoes app won't normally include it, but unit tests will.
+
+require "json"
+
+class Scarpe
+  DEFAULT_ASSERTION_TIMEOUT = 1.0
+
+  class ControlInterface
+    def timed_out?
+      @did_time_out
+    end
+
+    def die_after(time)
+      t_start = Time.now
+
+      wrangler.periodic_code("scarpeTestTimeout") do |*_args|
+        if (Time.now - t_start).to_f > time
+          @did_time_out = true
+          app.destroy
+        end
+      end
+    end
+
+    def return_when_assertions_done
+      assertions_may_exist
+
+      wrangler.periodic_code("scarpeReturnWhenAssertionsDone") do |*_args|
+        if @assertions_pending.empty?
+          success = @assertions_failed.empty?
+          return_results [success, assertion_data_as_a_struct]
+          app.destroy
+        end
+      end
+    end
+
+    # This does a final return of results. Don't call it yourself
+    # unless you want any other results that would be returned
+    # to be wiped out.
+    def return_results(result_structs)
+      if @results_returned
+        raise "Returning more than one set of results! Bad!"
+      end
+
+      result_file = ENV['SCARPE_TEST_RESULTS'] || "./scarpe_results.txt"
+      puts "Writing results file #{result_file.inspect} to disk!" if @debug
+      File.open(result_file, "w") { |f| f.write(JSON.pretty_generate(result_structs)); f.flush }
+
+      @results_returned = true
+    end
+
+    private
+
+    def assertions_may_exist
+      @assertions_pending ||= {}
+      @assertions_failed ||= {}
+      @assertions_passed ||= 0
+      @assertion_counter ||= 0
+    end
+
+    def start_assertion(code)
+      assertions_may_exist
+
+      this_assertion = @assertion_counter
+      @assertion_counter += 1
+
+      @assertions_pending[this_assertion] = {
+        id: this_assertion,
+        code: code,
+      }
+
+      this_assertion
+    end
+
+    def pass_assertion(id)
+      @assertions_pending.delete(id)
+      @assertions_passed += 1
+    end
+
+    def fail_assertion(id)
+      item = @assertions_pending.delete(id)
+      @assertions_failed[id] = item
+    end
+
+    def assertions_pending?
+      !@assertions_pending.empty?
+    end
+
+    def assertion_data_as_a_struct
+      {
+        still_pending: @assertions_pending.size,
+        succeeded: @assertions_passed,
+        failed: @assertions_failed.size,
+        failures: @assertions_failed.values.map { |item| item[:code] },
+      }
+    end
+
+    public
+
+    def all_widgets
+      known = [doc_root]
+      to_check = [doc_root]
+
+      until to_check.empty?
+        next_layer = to_check.flat_map(&:children)
+        known += next_layer
+        to_check = next_layer
+      end
+
+      # I don't *think* we'll ever have widget trees that merge back together, but just in case we'll de-dup
+      known.uniq
+    end
+
+    # Shoes doesn't name widgets. I don't know if we can get at instance variables.
+    def find_widgets(*specifiers)
+      widgets = all_widgets
+
+      specifiers.each do |spec|
+        if spec.is_a?(Class)
+          widgets.select! { |w| spec === w }
+        else
+          raise "I don't know how to search for widgets by #{spec.inspect}!"
+        end
+      end
+
+      widgets
+    end
+
+    # Create a promise to do a JS assertion, normally after other ops have finished.
+    def assert_js(js_code, wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT)
+      id = start_assertion(js_code)
+
+      # Note: this isn't a TestPromise, so it doesn't have the additional DSL entries...
+      promise = wrangler.eval_js_async(js_code, wait_for: wait_for, timeout: timeout)
+      promise.on_rejected {
+        fail_assertion(id)
+      }
+      promise.on_fulfilled {
+        pass_assertion(id)
+      }
+
+      # So we wrap it in a no-op TestPromise, to get the DSL entries.
+      TestPromise.new(iface: self, wait_for: [promise]).to_execute {}
+    end
+
+    def assert(value, msg = nil)
+      id = start_assertion("#{caller[0]}: #{msg || "Value should be true!"}")
+
+      if value
+        pass_assertion(id)
+      else
+        fail_assertion(id)
+      end
+    end
+
+    def assert_equal(val1, val2, msg=nil)
+      assert val1 == val2, (msg || "Expected #{val2.inspect} to equal #{val1.inspect}!")
+    end
+
+    # How do we signal an error?
+    def with_js_value(js_code, wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT, &block)
+      unless block
+        raise "Must give a block to with_js_value!"
+      end
+      js_promise = wrangler.eval_js_async(js_code, wait_for: wait_for, timeout: timeout)
+      ruby_promise = TestPromise.new(iface: self, wait_for: [js_promise])
+      ruby_promise.to_execute(&block)
+      ruby_promise
+    end
+
+    def with_js_dom_html(wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT, &block)
+      with_js_value("document.getElementById('wrapper-wvroot').innerHTML", wait_for: wait_for, timeout: timeout, &block)
+    end
+  end
+
+  # A Promise but with helper functions
+  class TestPromise < Promise
+    def initialize(iface:, state: nil, wait_for: [], &scheduler)
+      @iface = iface
+      super(state: state, parents: wait_for, &scheduler)
+    end
+
+    def inspect
+      "<#TestPromise::#{object_id} state=#{state.inspect} parents=#{parents.inspect} value=#{returned_value.inspect} reason=#{reason.inspect}>"
+    end
+
+    def then_assert_js(js_code, wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT)
+      # These (wait_for + [self]) args are sometimes in the other order due to questions about
+      # how they should handle passing returned_values from parents to blocks... That's gonna be difficult to get right :-/
+      assert_js(js_code, wait_for: (wait_for + [self]), timeout: timeout)
+    end
+
+    def then_with_js_dom_html(wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT, &block)
+      @iface.with_js_dom_html(wait_for: (wait_for + [self]), timeout: timeout, &block)
+    end
+
+    # Evaluate the JS, then call a Ruby block with the result
+    def then_ruby_with_js_value(js_code, wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT, &block)
+      js_promise = @iface.wrangler.eval_js_async(js_code, wait_for: [self], timeout: timeout)
+
+      then_ruby(wait_for: [js_promise], &block)
+    end
+
+    def then_ruby(wait_for: [], &block)
+      ruby_promise = TestPromise.new iface: @iface, wait_for: ([self] + wait_for)
+
+      # Once the Ruby promise gets scheduled, we can just call the Ruby code to fulfill or reject it
+      ruby_promise.to_execute(&block)
+      ruby_promise.on_rejected do
+        puts "Ruby promise got an error! #{ruby_promise.reason.full_message}!"
+      end
+    end
+
+    # This method expects to wait for the parent TestPromise and then run a block of Ruby that returns
+    # another promise. This is useful for wrapping Promises like those from replace() that don't have
+    # the test DSL built in. The block will execute when this outer promise is scheduled -- so we don't do
+    # a replace() too early, for instance. And then the outer promise will fulfill when the inner one does.
+    def then_ruby_promise(wait_for: [], &block)
+      ruby_wrapper_promise = TestPromise.new iface: @iface, wait_for: ([self] + wait_for)
+
+      ruby_wrapper_promise.on_scheduled {
+        inner_ruby_promise = block.call
+        inner_ruby_promise.on_fulfilled { ruby_wrapper_promise.fulfilled!(inner_ruby_promise.returned_value) }
+      }
+    end
+
+    # Gives back a no-op promise that depends on the DOM finishing a redraw, plus the parent promise
+    def and_when_fully_updated(wait_for: [])
+      dom_promise = @iface.wrangler.promise_dom_fully_updated
+      p = TestPromise.new(iface: @iface, wait_for: ([self, dom_promise] + wait_for))
+      p.to_execute {}
+    end
+  end
+end

--- a/lib/scarpe/document_root.rb
+++ b/lib/scarpe/document_root.rb
@@ -5,7 +5,6 @@ class Scarpe
     include Scarpe::Background
 
     attr_reader :debug
-    attr_reader :redraw_requested
 
     def initialize(webwrangler, opts = {})
       @callbacks = {}
@@ -13,6 +12,7 @@ class Scarpe
       @debug = opts[:debug] ? true : false
       @webwrangler = webwrangler
 
+      Scarpe::Widget.web_wrangler = webwrangler
       Scarpe::Widget.document_root = self
       super
     end
@@ -35,19 +35,13 @@ class Scarpe
     end
 
     # The document root knows when a frame has finished. It registers end-of-frame callbacks and calls them
-    # when requested. It also tracks when a redraw has been requested. Note that often frames will be
+    # when requested. It also tracks when a redraw has been requested. Note that often redraws will be
     # very rare if nothing is changing, with seconds or minutes passing in between them.
 
-    def request_redraw!
-      return if @redraw_requested
-
-      @webwrangler.js_eval("setTimeout(scarpeRedrawCallback,0)")
-      @redraw_requested = true
+    def request_full_redraw!
+      @webwrangler.replace(self.to_html)
     end
 
-    def end_of_frame
-      @redraw_requested = false
-    end
     alias_method :info, :puts
 
     # The document root manages the connection between widgets and the WebviewWrangler.

--- a/lib/scarpe/edit_box.rb
+++ b/lib/scarpe/edit_box.rb
@@ -23,6 +23,7 @@ class Scarpe
     def text=(text)
       @text = text
       html_element.inner_text = text
+      # Note: text= can't return random objects, so we can't do html_element.promise_update here :-(
     end
 
     def element

--- a/lib/scarpe/edit_line.rb
+++ b/lib/scarpe/edit_line.rb
@@ -24,6 +24,7 @@ class Scarpe
       @text = text
 
       html_element.value = text
+      # Note: text= can't return random objects, so we can't do html_element.promise_update here :-(
     end
 
     def element

--- a/lib/scarpe/promises.rb
+++ b/lib/scarpe/promises.rb
@@ -1,0 +1,397 @@
+# Funny thing... We need promises as an API concept since we have a JS event
+# loop doing its thing, and we need to respond to actions that it takes.
+# But there's not really a Ruby implementation of Promises *without* an
+# attached form of concurrency. So here we are, writing our own :-/
+#
+# In theory you could probably write some kind of "no-op thread pool"
+# for the ruby-concurrency gem, pass it manually to every promise we
+# created and then raise an exception any time we tried to do something
+# in the background. That's probably more code than writing our own, though,
+# and we'd be fighting it constantly.
+#
+# This class is inspired by concurrent-ruby [Promise](https://ruby-concurrency.github.io/concurrent-ruby/1.1.5/Concurrent/Promise.html)
+# which is inspired by Javascript Promises, which is what we actually need
+# for our use case. We can't easily tell when our WebView begins processing
+# our request, which removes the :processing state. This can be used for
+# executing JS, but also generally waiting on events.
+#
+# We don't fully control ordering here, so it *is* conceivable that a
+# child waiting on a parent can be randomly fulfilled, even if we didn't
+# expect it. We don't consider that an error. Similarly, we'll call
+# on_scheduled callbacks if a promise is fulfilled, even though we
+# never explicitly scheduled it. If a promise is *rejected* without
+# ever being scheduled, we won't call those callbacks.
+
+class Scarpe
+  class Promise
+    PROMISE_STATES = [:unscheduled, :pending, :fulfilled, :rejected]
+
+    def self.debug
+      @debug
+    end
+
+    def self.debug=(val)
+      @debug = val
+    end
+
+    attr_reader :state
+    attr_reader :parents
+    attr_reader :returned_value
+    attr_reader :reason
+
+    # These methods are meant to be a prettier interface to promises,
+    # suitable for day-to-day usage.
+
+    # Create a promise and then instantly fulfill it.
+    def self.fulfilled(return_val = nil, parents: [], &block)
+      p = Promise.new(parents: parents, &block)
+      p.fulfilled!(return_val)
+      p
+    end
+
+    # Create a promise and then instantly reject it.
+    def self.rejected(reason = nil, parents: [])
+      p = Promise.new(parents: parents)
+      p.rejected!(reason)
+    end
+
+    # Instance methods
+
+    # This is one way to return a value directly from a schedule block,
+    # which also fulfills the promise.
+    #
+    # This syntax is somewhat awkward, to work around the fact that
+    # we're often not scheduling Ruby, so return values from a
+    # scheduling block aren't usually what we want. When the scheduling
+    # block is run, the calculation has started, not finished.
+    #def return_final_value(val)
+    #  fulfilled!(val)
+    #end
+
+    def fulfilled!(value = nil)
+      set_state(:fulfilled, value)
+    end
+
+    def rejected!(reason = nil)
+      set_state(:rejected, reason)
+    end
+
+    def then(&block)
+      # Create a new promise. It's waiting on us. It runs the
+      # specified code when scheduled.
+      Promise.new(parents: [self], &block)
+    end
+
+    # The Promise.new method, along with all the various handlers,
+    # are pretty raw. They'll do what promises do, but they're not
+    # the prettiest. However, they ensure that guarantees are made
+    # and so on, so they're great as plumbing under the syntactic
+    # sugar above.
+
+    def initialize(state: nil, parents: [], &scheduler)
+      # These are as initially specified, and effectively immutable
+      @state = state
+      @parents = parents
+
+      # These are what we're waiting on, and will be
+      # removed as time goes forward.
+      @waiting_on = parents.select { |p| !p.complete? }
+      @on_fulfilled = []
+      @on_rejected = []
+      @on_scheduled = []
+      @scheduler = scheduler
+      @executor = nil
+      @returned_value = nil
+      @reason = nil
+
+      if complete?
+        # Did we start out already fulfilled or rejected?
+        # If so, we can skip a lot of fiddly checking.
+        # Don't need a scheduler or to care about parents
+        # or anything.
+        @waiting_on = []
+        @scheduler = nil
+      elsif @state == :pending
+        # Did we get an explicit :pending? Then we don't need
+        # to schedule ourselves, or care about the scheduler
+        # in general.
+        @scheduler = nil
+      elsif @state.nil? || @state == :unscheduled
+        # If no state was given or we're unscheduled, we'll
+        # wait until our parents have all completed to
+        # schedule ourselves.
+
+        if @waiting_on.empty?
+          # No further dependencies, we can schedule ourselves
+          @state = :pending
+
+          # We have no on_scheduled handlers yet, but this will
+          # call and clear the scheduler.
+          call_handlers_for(:pending)
+        else
+          # We're still waiting on somebody, no scheduling yet
+          @state = :unscheduled
+          @waiting_on.each do |dep|
+            dep.on_fulfilled { parent_fulfilled!(dep) }
+            dep.on_rejected { parent_rejected!(dep) }
+          end
+        end
+      end
+    end
+
+    def complete?
+      @state == :fulfilled || @state == :rejected
+    end
+
+    # These promises are mostly designed for external execution.
+    # You could put together your own thread-pool, or use RPC,
+    # a WebView, a database or similar source of external calculation.
+    # But in some cases, sure, it's reasonable to execute locally.
+    # In those cases, you can register an executor, which will be
+    # called when the promise is ready to execute but has not yet
+    # done so. Registering an executor on a promise that is
+    # already fulfilled is an error. Registering an executor on
+    # a promise that has already rejected is a no-op.
+    def to_execute(&block)
+      case @state
+      when :fulfilled
+        # Should this be a no-op instead?
+        raise "Registering an executor on an already fulfilled promise means it will never run!"
+      when :rejected
+        return
+      when :unscheduled
+        @executor = block # save for later
+      when :pending
+        @executor = block
+        call_executor
+      else
+        raise "Internal error, illegal state!"
+      end
+
+      self
+    end
+
+    private
+
+    # set_state looks at the old and new states of the promise. It calls handlers and updates tracking
+    # data accordingly.
+    def set_state(new_state, value_or_reason = nil)
+      old_state = @state
+
+      # First, filter out illegal input
+      unless PROMISE_STATES.include?(old_state)
+        raise "Internal Promise error! Internal state was #{old_state.inspect}! Legal states: #{PROMISE_STATES.inspect}"
+      end
+      unless PROMISE_STATES.include?(new_state)
+        raise "Internal Promise error! Internal state was set to #{new_state.inspect}! Legal states: #{PROMISE_STATES.inspect}"
+      end
+      if new_state != :fulfilled && new_state != :rejected && !value_or_reason.nil?
+        raise "Internal promise error! Non-completed state transitions should not specify a value or reason!"
+      end
+
+      # Here's our state-transition grid for what we're doing here.
+      # "From" state is on the left, "to" state is on top.
+      #
+      #    U P F R
+      #
+      # U  - 1 . .
+      # P  X - . .
+      # F  X X - X
+      # R  X X X -
+      #
+      # -  Change from same to same, no effect
+      # X  Illegal for one reason or another, raise error
+      # .  Great, no problem, run handlers but not @scheduler or @executor
+      # 1  Interesting case - if we have an executor, actually change to a *different* state instead
+
+      # Transitioning from our state to our same state? No-op.
+      return if new_state == old_state
+
+      # Transitioning to any *different* state after being fulfilled or rejected? Nope. Those states are final.
+      if complete?
+        raise "Internal Promise error! Trying to change state from #{old_state.inspect} to #{new_state.inspect}!"
+      end
+
+      if old_state == :pending && new_state == :unscheduled
+        raise "Can't change state from :pending to :unscheduled! Scheduling is not reversible!"
+      end
+
+      # The next three checks should all be followed by calling handlers for the newly-changed state.
+      # See call_handlers_for below.
+
+      # Okay, we're getting scheduled.
+      if old_state == :unscheduled && new_state == :pending
+        @state = new_state
+        call_handlers_for(new_state)
+
+        # It's not impossible for the scheduler to do something that fulfills or rejects the promise.
+        # In that case it *also* called the appropriate handlers. Let's get out of here.
+        return if @state == :fulfilled || @state == :rejected
+
+        if @executor
+          # In this case we're still pending, but we have a synchronous executor. Let's do it.
+          call_executor
+        end
+
+        return
+      end
+
+      # Setting to rejected calls the rejected handlers. But no scheduling ever occurs, so on_scheduled handlers
+      # will never be called.
+      if new_state == :rejected
+        @state = :rejected
+        @reason = value_or_reason
+        call_handlers_for(new_state)
+      end
+
+      # If we go straight from :unscheduled to :fulfilled we *will* run the on_scheduled callbacks,
+      # because we pretend the scheduling *did* occur at some point. Normally that'll be no callbacks,
+      # of course.
+      #
+      # Fun-but-unfortunate trivia: you *can* fulfill a promise before all its parents are fulfilled.
+      # If you do, the unfinished parents will result in nil arguments to the on_fulfilled handler,
+      # because we have no other value to provide. The scheduler callback will never be called, but
+      # the on_scheduled callbacks, if any, will be.
+      if new_state == :fulfilled
+        @state = :fulfilled
+        @returned_value = value_or_reason
+        call_handlers_for(new_state)
+      end
+    end
+
+    # This private method calls handlers for a new state, removing those handlers
+    # since they have now been called. This interacts subtly with set_state()
+    # above, particularly in the case of fulfilling a promise without it ever being
+    # properly scheduled.
+    #
+    # The rejected handlers will be cleared if the promise is fulfilled and vice-versa.
+    # After rejection, no on_fulfilled handler should ever be called and vice-versa.
+    #
+    # When we go from :unscheduled to :pending, the scheduler, if any, should be
+    # called and cleared. That should *not* happen when going from :unscheduled to
+    # :fulfilled.
+    def call_handlers_for(state)
+      case state
+      when :fulfilled
+        @on_scheduled.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_fulfilled.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_fulfilled = @on_rejected = @on_fulfilled = []
+        @scheduler = @executor = nil
+      when :rejected
+        @on_rejected.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_fulfilled = @on_scheduled = @on_rejected = []
+        @scheduler = @executor = nil
+      when :pending
+        # A scheduler can get an exception. If so, treat it as rejection
+        # and the exception as the provided reason.
+        if @scheduler
+          begin
+            @scheduler.call(*@parents.map(&:returned_value))
+          rescue => e
+            if Promise.debug
+              puts "Error while running scheduler! #{e.full_message}"
+            end
+            rejected!(e)
+          end
+          @scheduler = nil
+        end
+        @on_scheduled.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_scheduled = []
+      else
+        raise "Internal error! Trying to call handlers for #{state.inspect}!"
+      end
+    end
+
+    def parent_fulfilled!(parent)
+      @waiting_on.delete(parent)
+
+      # Last parent? If so, schedule ourselves.
+      if @waiting_on.empty? && !self.complete?
+        # This will result in :pending if there's no executor,
+        # or fulfilled/rejected if there is an executor.
+        set_state(:pending)
+      end
+    end
+
+    def parent_rejected!(parent)
+      @waiting_on = []
+
+      unless self.complete?
+        # If our parent was rejected and we were waiting on them,
+        # now we're rejected too.
+        set_state(:rejected)
+      end
+    end
+
+    def call_executor
+      raise("Internal error! Should not call_executor with no executor!") unless @executor
+
+      begin
+        result = @executor.call(*@parents.map(&:returned_value))
+        fulfilled!(result)
+      rescue => e
+        if Promise.debug
+          puts "Error running executor! #{e.full_message}"
+        end
+        rejected!(e)
+        return
+      end
+
+    ensure
+      @executor = nil
+    end
+
+    public
+
+    def on_fulfilled(&handler)
+      unless handler
+        raise "You must pass a block to on_fulfilled!"
+      end
+      case @state
+      when :fulfilled
+        handler.call(*@parents.map(&:returned_value))
+      when :pending, :unscheduled
+        @on_fulfilled << handler
+      when :rejected
+        # Do nothing
+      end
+
+      self
+    end
+
+    def on_rejected(&handler)
+      unless handler
+        raise "You must pass a block to on_rejected!"
+      end
+
+      case @state
+      when :rejected
+        handler.call(*@parents.map(&:returned_value))
+      when :pending, :unscheduled
+        @on_rejected << handler
+      when :fulfilled
+        # Do nothing
+      end
+
+      self
+    end
+
+    def on_scheduled(&handler)
+      unless handler
+        raise "You must pass a block to on_scheduled!"
+      end
+
+      # Add a pending handler or call it now
+      case @state
+      when :fulfilled, :pending
+        handler.call(*@parents.map(&:returned_value))
+      when :unscheduled
+        @on_scheduled << handler
+      when :rejected
+        # Do nothing
+      end
+
+      self
+    end
+  end
+end

--- a/lib/scarpe/web_wrangler.rb
+++ b/lib/scarpe/web_wrangler.rb
@@ -10,21 +10,78 @@ require "cgi"
 
 class Scarpe
   class WebWrangler
-    def initialize(title:, width:, height:, resizable:, debug:)
+    attr_reader :is_running
+    attr_reader :heartbeat
+    attr_reader :control_interface
+
+    # This error indicates a problem when running ConfirmedEval
+    # TODO: add a Scarpe::Error parent class and inherit from it
+    class JSEvalError < StandardError
+      def initialize(data)
+        @data = data
+        super(data[:msg] || (self.class.name + "!"))
+      end
+    end
+
+    # We got an error running the supplied JS code string in confirmed_eval
+    class JSRuntimeError < JSEvalError
+    end
+
+    # We got weird or nonsensical results that seem like an error on WebWrangler's part
+    class InternalError < JSEvalError
+    end
+
+    # This is the JS function name for eval results
+    EVAL_RESULT = "scarpeAsyncEvalResult"
+
+    # Allow a half-second for Webview to finish our JS eval before we decide it's not going to
+    EVAL_DEFAULT_TIMEOUT = 0.5
+
+    def initialize(title:, width:, height:, resizable: false, debug: false, heartbeat: 0.1)
+      puts "Creating WebWrangler..." if debug
+
       # For now, always allow inspect element
       @webview = WebviewRuby::Webview.new debug: true
+
+      # this should NOT turn on debug, even with debug option on, for normal debug levels! It's *verbose*.
+      #@dom_wrangler = DOMWrangler.new(self, debug: debug)
+      @dom_wrangler = DOMWrangler.new(self)
 
       @title = title
       @width = width
       @height = height
       @resizable = resizable
       @debug = debug
+      @heartbeat = heartbeat
 
-      puts "Creating WebWrangler..." if debug
+      # Better to have a single setInterval than many when we don't care too much
+      # about the timing.
+      @heartbeat_handlers = []
+
+      # Need to keep track of which WebView Javascript evals are still pending,
+      # what handlers to call when they return, etc.
+      @pending_evals = {}
+      @eval_counter = 0
 
       @webview.bind("puts") do |*args|
         puts(*args)
       end
+
+      @webview.bind(EVAL_RESULT) do |*results|
+        receive_eval_result(*results)
+      end
+
+      @webview.bind("scarpeHeartbeat") do
+        periodic_js_callback
+        @heartbeat_handlers.each { |h| h.call }
+        @control_interface.dispatch_event(:heartbeat)
+      end
+      js_interval = (heartbeat.to_f * 1_000.0).to_i
+      @webview.init("setInterval(scarpeHeartbeat,#{js_interval})")
+    end
+
+    def set_control_interface(val)
+      @control_interface = val
     end
 
     ### Setup-mode Callbacks
@@ -42,19 +99,180 @@ class Scarpe
       @webview.init("#{name}();")
     end
 
-    def periodic_code(name, interval, &block)
-      raise "App is running, javascript periodic-code init no longer works!" if @is_running
-
-      @webview.bind(name, &block)
-      js_interval = (interval.to_f * 1_000.0).to_i
-      @webview.init("setInterval(#{name}, #{js_interval});")
+    # Run the specified code periodically, every "interval" seconds.
+    # If interface is unspecified, run per-heartbeat, which is very
+    # slightly more efficient.
+    def periodic_code(name, interval = heartbeat, &block)
+      if interval == heartbeat
+        @heartbeat_handlers << block
+      else
+        if @is_running
+          # I *think* we need to use init because we want this done for every
+          # new window. But will there ever be a new page/window? Can we just
+          # use eval instead of init to set up a periodic handler and call it
+          # good?
+          raise "App is running, can't set up new periodic handlers with init!"
+        end
+        @webview.bind(name, &block)
+        js_interval = (interval.to_f * 1_000.0).to_i
+        @webview.init("setInterval(#{name}, #{js_interval});")
+      end
     end
 
     # Running callbacks
 
-    def js_eval(code)
+    # js_eventually is a simple JS evaluation. On syntax error, nothing happens.
+    # On runtime error, execution stops at the error with no further
+    # effect or notification. This is rarely what you want.
+    # The js_eventually code is run asynchronously, returning neither error
+    # nor value.
+    #
+    # This method does *not* return a promise, and there is no way to track
+    # its progress or its success or failure.
+    def js_eventually(code)
+      raise "WebWrangler isn't running, eval doesn't work!" unless @is_running
+
+      puts "Deprecated: please do NOT use js_eventually, it's basically never what you want!"
+
       @webview.eval(code)
     end
+
+    EVAL_OPTS = [:timeout, :wait_for]
+
+    # Eval a chunk of JS code asynchronously. This method returns a
+    # promise which will be fulfilled or rejected after the JS executes
+    # or times out.
+    #
+    # Note that we *both* care whether the JS has finished after it was
+    # scheduled *and* whether it ever got scheduled at all. If it
+    # depends on tasks that never fulfill or reject then it may wait
+    # in limbo, potentially forever.
+    #
+    # Right now we can't/don't handle arguments from previous fulfilled
+    # promises. To do that, we'd probably need to know we were passing
+    # in a JS function.
+    def eval_js_async(code, opts = {})
+      bad_opts = opts.keys - EVAL_OPTS
+      raise("Bad options given to eval_with_handler! #{bad_opts.inspect}") unless bad_opts.empty?
+
+      unless @is_running
+        raise "WebWrangler isn't running, so evaluating JS won't work!"
+      end
+
+      this_eval_serial = @eval_counter
+      @eval_counter += 1
+
+      @pending_evals[this_eval_serial] = {
+        id: this_eval_serial,
+        code: code,
+        start_time: Time.now,
+        timeout_if_not_scheduled: Time.now + EVAL_DEFAULT_TIMEOUT,
+      }
+
+      # We'll need this inside the promise-scheduling block
+      pending_evals = @pending_evals
+      timeout = opts[:timeout] || EVAL_DEFAULT_TIMEOUT
+
+      promise = Scarpe::Promise.new(parents: (opts[:wait_for] || [])) do
+        # Are we mid-shutdown?
+        if @webview
+          wrapped_code = js_wrapped_code(code, this_eval_serial)
+
+          # We've been scheduled!
+          t_now = Time.now
+          pending_evals[this_eval_serial][:scheduled_time] = t_now
+          pending_evals[this_eval_serial].delete(:timeout_if_not_scheduled)
+
+          pending_evals[this_eval_serial][:timeout_if_not_finished] = t_now + timeout
+          @webview.eval(wrapped_code)
+          puts "Scheduled JS: (#{this_eval_serial})\n#{wrapped_code}" if @debug
+        else
+          # Yup, we're mid-shutdown.
+        end
+      end
+
+      @pending_evals[this_eval_serial][:promise] = promise
+
+      promise
+    end
+
+    private
+
+    def js_wrapped_code(code, eval_id)
+      <<~JS_CODE
+        (function() {
+          var code_string = #{JSON.dump code};
+          try {
+            result = eval(code_string);
+            #{EVAL_RESULT}("success", #{eval_id}, result);
+          } catch(error) {
+            #{EVAL_RESULT}("error", #{eval_id}, error.message);
+          }
+        })();
+      JS_CODE
+    end
+
+    def periodic_js_callback
+      time_out_eval_results
+    end
+
+    def receive_eval_result(r_type, id, val)
+      entry = @pending_evals.delete(id)
+      unless entry
+        STDERR.puts "Received an eval result for a nonexistent ID #{id.inspect}!"
+        raise "Received an eval result for a nonexistent ID #{id.inspect}!"
+      end
+
+      if @debug
+        puts "Got JS value: #{r_type} / #{id} / #{val.inspect}"
+      end
+
+      promise = entry[:promise]
+
+      case r_type
+      when "success"
+        promise.fulfilled!(val)
+      when "error"
+        promise.rejected! JSRuntimeError.new(msg: "JS runtime error: #{val.inspect}!", code: entry[:code], ret_value: val)
+      else
+        promise.rejected! InternalError.new(msg: "JS eval internal error! r_type: #{r_type.inspect}", code: entry[:code], ret_value: val)
+      end
+    end
+
+    # TODO: would be good to keep 'tombstone' results for awhile after timeout, maybe up to around a minute,
+    # so we can detect if we're timing things out and then having them return successfully after a delay.
+    # Then we could adjust the timeouts. We could also check if later serial numbers have returned, and time
+    # out earlier serial numbers... *if* we're sure Webview will always execute JS evals in order.
+    # This all adds complexity, though. For now, do timeouts on a simple max duration.
+    def time_out_eval_results
+      t_now = Time.now
+      timed_out_from_scheduling = @pending_evals.keys.select do |id|
+        t = @pending_evals[id][:timeout_if_not_scheduled]
+        t && t_now >= t
+      end
+      timed_out_from_finish = @pending_evals.keys.select do |id|
+        t = @pending_evals[id][:timeout_if_not_finished]
+        t && t_now >= t
+      end
+      timed_out_from_scheduling.each do |id|
+        puts("JS timed out because it was never scheduled: #{@pending_evals[id][:code].inspect}") if @debug
+      end
+      timed_out_from_finish.each do |id|
+        puts("JS timed out because it never finished: #{@pending_evals[id][:code].inspect}") if @debug
+      end
+
+      # A plus *should* be fine since nothing should ever be on both lists. But let's be safe.
+      timed_out_ids = timed_out_from_scheduling | timed_out_from_finish
+
+      timed_out_ids.each do |id|
+        STDERR.puts "Timing out JS eval! #{@pending_evals[id][:code]}"
+        entry = @pending_evals.delete(id)
+        err = JSSyntaxError.new(msg: "JS syntax error or handling error!", code: entry[:code], ret_value: nil)
+        entry[:promise].rejected!(err)
+      end
+    end
+
+    public
 
     # After setup, we call run to go to "running" mode.
     # No more setup callbacks, only running callbacks.
@@ -144,39 +362,252 @@ class Scarpe
     # to mess with the HTML DOM. This needs to be turned into a nicer API,
     # but first we'll get it all into one place and see what we're doing.
 
-    # Replace the entire DOM
-    def replace(el)
-      @webview.eval("document.getElementById('wrapper-wvroot').innerHTML = `#{el}`;")
+    # Replace the entire DOM - return a promise for when this has been done.
+    # This will often get rid of smaller changes in the queue, which is
+    # a good thing since they won't have to be run.
+    def replace(html_text)
+      @dom_wrangler.request_replace(html_text)
+    end
+
+    # Request a DOM change - return a promise for when this has been done.
+    def dom_change(js)
+      @dom_wrangler.request_change(js)
+    end
+
+    # Return whether the DOM is, right this moment, confirmed to be fully
+    # up to date or not.
+    def dom_fully_updated?
+      @dom_wrangler.fully_updated?
+    end
+
+    # Return a promise that will be fulfilled when all current DOM changes
+    # have committed (but not necessarily any future DOM changes.)
+    def dom_promise_redraw
+      @dom_wrangler.promise_redraw
+    end
+
+    # Return a promise which will be fulfilled the next time the DOM is
+    # fully up to date. Note that a slow trickle of changes can make this
+    # take a long time, since it is *not* only changes up to this point.
+    # If you want to know that some specific change is done, it's often
+    # easiest to use the promise returned by dom_change(), which will
+    # be fulfilled when that specific change commits.
+    def promise_dom_fully_updated
+      @dom_wrangler.promise_fully_updated
+    end
+
+    def on_every_redraw(&block)
+      @dom_wrangler.on_every_redraw(&block)
+    end
+  end
+end
+
+# Leaving DOM changes as "meh, async, we'll see when it happens" is terrible for testing.
+# Instead, we need to track whether particular changes have committed yet or not.
+# So we add a single gateway for all DOM changes, and we make sure its work is done
+# before we consider a redraw complete.
+#
+# DOMWrangler batches up changes - it's fine to have a redraw "in flight" and have
+# changes waiting to catch the next bus. But We don't want more than one in flight,
+# since it seems like having too many pending RPC requests can crash Webview. So:
+# one redraw scheduled and one redraw promise waiting around, at maximum.
+class Scarpe
+  class WebWrangler
+    class DOMWrangler
+      attr_reader :waiting_changes
+      attr_reader :pending_redraw_promise
+      attr_reader :waiting_redraw_promise
+
+      def initialize(web_wrangler, debug: false)
+        @wrangler = web_wrangler
+
+        @waiting_changes = []
+        @pending_redraw_promise = nil
+        @waiting_redraw_promise = nil
+
+        @fully_up_to_date_promise = nil
+
+        @redraw_handlers = []
+
+        @debug = debug
+      end
+
+      def request_change(js_code)
+        @waiting_changes << js_code
+
+        promise_redraw
+      end
+
+      def request_replace(html_text)
+        # Replace other pending changes, they're not needed any more
+        @waiting_changes = [ "document.getElementById('wrapper-wvroot').innerHTML = `#{html_text}`; true" ]
+
+        puts "Requesting DOM replacement..." if @debug
+        promise_redraw
+      end
+
+      def on_every_redraw(&block)
+        @redraw_handlers << block
+      end
+
+      # What are the states of redraw?
+      # "empty" - no waiting promise, no pending-redraw promise, no pending changes
+      # "pending only" - no waiting promise, but we have a pending redraw with some changes; it hasn't committed yet
+      # "pending and waiting" - we have a waiting promise for our unscheduled changes; we can add more unscheduled
+      #     changes since we haven't scheduled them yet.
+      #
+      # This is often called right after adding a new waiting change or replacing them, so that may need fixing up.
+      def promise_redraw
+        if fully_updated?
+          # No changes to make, nothing in-process or waiting, so just return a pre-fulfilled promise
+          puts "Requesting redraw but there are no pending changes or promises, return pre-fulfilled" if @debug
+          return Promise.fulfilled
+        end
+
+        # Already have a redraw requested *and* one on deck? Then all current changes will have committed
+        # when we (eventually) fulfill the waiting_redraw_promise.
+        if @waiting_redraw_promise
+          puts "Promising eventual redraw of #{@waiting_changes.size} waiting unscheduled changes." if @debug
+          return @waiting_redraw_promise
+        end
+
+        if @waiting_changes.empty?
+          # There's no waiting_redraw_promise. There are no waiting changes. But we're not fully updated. 
+          # So there must be a redraw in flight, and we don't need to schedule a new waiting_redraw_promise.
+          puts "Returning in-flight redraw promise" if @debug
+          return @pending_redraw_promise
+        end
+
+        puts "Requesting redraw with #{@waiting_changes.size} waiting changes - need to schedule something!" if @debug
+
+        # We have at least one waiting change, possibly newly-added. We have no waiting_redraw_promise.
+        # Do we already have a redraw in-flight?
+        if @pending_redraw_promise
+          # Yes we do. Schedule a new waiting promise. When it turns into the pending_redraw_promise it will
+          # grab all waiting changes. In the mean time, it sits here and waits.
+          #
+          # We *could* do a fancy promise thing and have it update @waiting_changes for itself, etc, when it
+          # schedules itself. But we should always be calling promise_redraw or having a redraw commit (see below)
+          # when these things change, and I'd rather keep the logic in this method. It's easier to reason through
+          # all the cases.
+          @waiting_redraw_promise = Promise.new
+
+          return @waiting_redraw_promise
+        end
+
+        # We have no redraw in-flight and no pre-existing waiting line. The new change(s) are presumably right
+        # after things were fully up-to-date. We can schedule them for immediate redraw.
+
+        promise = schedule_waiting_changes
+        @pending_redraw_promise = promise
+
+        promise.on_fulfilled {
+          @redraw_handlers.each(&:call)
+
+          if @waiting_redraw_promise
+            # While this redraw was in flight, more waiting changes got added and we made a promise
+            # about when they'd complete. Now they get scheduled, and we'll fulfill the waiting
+            # promise when that redraw finishes. Clear the old waiting promise. We'll add a new one
+            # when/if more changes are scheduled during this redraw.
+            old_waiting_promise = @waiting_redraw_promise
+            @waiting_redraw_promise = nil
+
+            @pending_redraw_promise = schedule_waiting_changes
+            @pending_redraw_promise.on_fulfilled { old_waiting_promise.fulfilled! }
+          else
+            # The in-flight redraw completed, and there's still no waiting promise. Good! That means
+            # we should be fully up-to-date.
+            @pending_redraw_promise = nil
+            if @waiting_changes.empty?
+              # We're fully up to date! Fulfill the promise. Now we don't need it again until somebody asks
+              # us for another.
+              if @fully_up_to_date_promise
+                @fully_up_to_date_promise.fulfilled!
+                @fully_up_to_date_promise = nil
+              end
+            else
+              STDERR.puts "WHOAH, WHAT? My logic must be wrong, because there's no waiting promise, but waiting changes!"
+            end
+          end
+
+          puts "REDRAW FULLY UP TO DATE" if fully_updated? && @debug
+        }.on_rejected {
+          STDERR.puts "Could not complete JS redraw! #{promise.reason.full_message}"
+          puts "REDRAW FULLY UP TO DATE BUT JS FAILED" if fully_updated? && @debug
+
+          raise "JS Redraw failed! Bailing!"
+
+          # Later we should figure out how to handle this. Clear the promises and queues and request another redraw?
+        }
+      end
+
+      def fully_updated?
+        @pending_redraw_promise.nil? && @waiting_redraw_promise.nil? && @waiting_changes.empty?
+      end
+
+      # Return a promise which will be fulfilled when the DOM is fully up-to-date
+      def promise_fully_updated
+        if fully_updated?
+          # No changes to make, nothing in-process or waiting, so just return a pre-fulfilled promise
+          return Promise.fulfilled
+        end
+
+        # Do we already have a promise for this? Return it. Everybody can share one.
+        if @fully_up_to_date_promise
+          return @fully_up_to_date_promise
+        end
+
+        # We're not fully updated, so we need a promise. Create it, return it.
+        @fully_up_to_date_promise = Promise.new
+      end
+
+      private
+
+      # Put together the waiting changes into a new in-flight redraw request.
+      # Return it as a promise.
+      def schedule_waiting_changes
+        js_code = @waiting_changes.join(";")
+        @waiting_changes = []   # They're not waiting any more!
+        @wrangler.eval_js_async js_code
+      end
     end
   end
 end
 
 # For now we don't need one of these to add DOM elements, just to manipulate them
 # after initial render.
+# TODO: right now we assume all updates to the DOM can just run async whenever.
+#       That's really bad. Need to squish them into one pipeline via a DOMUpdater
+#       to serialise changes, clear changes on replace and otherwise manage access.
 class Scarpe
   class WebWrangler
     class ElementWrangler
       attr_reader :html_id
 
-      def initialize(webwrangler, html_id)
+      def initialize(webwrangler, html_id, widget:)
         @webwrangler = webwrangler
         @html_id = html_id
+        @widget = widget
+      end
+
+      def promise_update
+        @webwrangler.dom_promise_redraw
       end
 
       def value=(new_value)
-        @webwrangler.js_eval("document.getElementById(#{html_id}).value = #{new_value}")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).value = #{new_value}; true")
       end
 
       def inner_text=(new_text)
-        @webwrangler.js_eval("document.getElementById(#{html_id}).innerText = '#{new_text}'")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).innerText = '#{new_text}'; true")
       end
 
       def inner_html=(new_html)
-        @webwrangler.js_eval("document.getElementById(#{html_id}).innerHTML = `#{new_html}`")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).innerHTML = `#{new_html}`; true")
       end
 
       def remove
-        @webwrangler.js_eval("document.getElementById(#{html_id}).remove()")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).remove(); true")
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ require "json"
 
 require "minitest/autorun"
 
+#require "scarpe/control_interface_test"
+
 # Docs for our Webview lib: https://github.com/Maaarcocr/webview_ruby
 
 def with_tempfile(prefix, contents)
@@ -22,7 +24,7 @@ ensure
 end
 
 SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
-TEST_OPTS = [:timeout, :allow_fail, :debug, :exit_immediately]
+TEST_OPTS = [:timeout, :allow_fail, :allow_timeout, :debug, :exit_immediately]
 
 def test_scarpe_code(scarpe_app_code, test_code: "", **opts)
   bad_opts = opts.keys - TEST_OPTS
@@ -39,46 +41,56 @@ def test_scarpe_app(test_app_location, test_code: "", **opts)
 
   with_tempfile("scarpe_test_results.json", "") do |result_path|
     do_debug = opts[:debug] ? true : false
-    die_after = opts[:timeout] ? opts[:timeout].to_f : 0.1
+    timeout = opts[:timeout] ? opts[:timeout].to_f : 1.0
     scarpe_test_code = <<~SCARPE_TEST_CODE
+      require "scarpe/control_interface_test"
+
       override_app_opts debug: #{do_debug}
 
       on_event(:init) do
         t_start = Time.now
-        wrangler.periodic_code("scarpePeriodicCallback", 0.1) do |*_args|
-          if ((Time.now - t_start).to_f > #{die_after})
+        wrangler.periodic_code("scarpeTestTimeout") do |*_args|
+          if (Time.now - t_start).to_f > #{timeout}
+            @did_time_out = true
+            return_results([false, "Timed out!"])
             app.destroy
           end
         end
 
-        result_file = #{result_path.inspect}
+        # scarpeStatusAndExit is barbaric, and ignores all pending assertions and other subtleties.
         wrangler.bind("scarpeStatusAndExit") do |*results|
-          puts "Writing results file \#{result_file.inspect} to disk!" if #{do_debug}
-          File.open(result_file, "w") { |f| f.write(JSON.pretty_generate(results)) }
+          return_results(results)
           app.destroy
         end
       end
     SCARPE_TEST_CODE
 
+    scarpe_test_code += test_code
+
+    # Add this after any user test code, so that their handlers get checked before exit
     if opts[:exit_immediately]
       scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
-        on_event(:frame) do
-          js_eval "scarpeStatusAndExit(true);"
+        # Doing this on next_heartbeat is fine, but doing it on next_redraw crashes Ruby.
+        # Why? Argh, Webview.
+        on_event(:next_heartbeat) do
+          app.destroy
         end
       TEST_EXIT_IMMEDIATELY
     end
-
-    scarpe_test_code += test_code
 
     # No results until we write them
     File.unlink(result_path)
 
     with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
-      system("SCARPE_TEST_CONTROL=#{control_file_path} ruby #{SCARPE_EXE} --dev #{test_app_location}")
+      system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} ruby #{SCARPE_EXE} --dev #{test_app_location}")
     end
 
     # If failure is okay, don't check for status or assertions
     return if opts[:allow_fail]
+
+    # If we exit immediately with no result written, that's fine.
+    # But if we wrote a result, make sure it says pass, not fail.
+    return if opts[:exit_immediately] && !File.exist?(result_path)
 
     unless File.exist?(result_path)
       assert(false, "Scarpe app returned no status code!")
@@ -88,10 +100,22 @@ def test_scarpe_app(test_app_location, test_code: "", **opts)
     begin
       out_data = JSON.parse File.read(result_path)
 
-      assert(
-        out_data.respond_to?(:each) && out_data[0],
-        "Scarpe app returned a non-Arrayish or non-truthy status! #{out_data.inspect}",
-      )
+      unless out_data.respond_to?(:each) && out_data.length > 1
+        raise "Scarpe app returned an unexpected data format! #{out_data.inspect}"
+      end
+
+      unless out_data[0]
+        puts JSON.pretty_generate(out_data[1])
+        assert false, "Some Scarpe tests failed..."
+      end
+
+      if out_data[1].is_a?(Hash)
+        test_data = out_data[1]
+        test_data["succeeded"].times { assert true } # Add to the number of assertions
+        test_data["failures"].each { |failure| assert false, "Failed Scarpe app test: #{failure}" }
+        assert_equal 0, test_data["still_pending"], "Some tests were still pending!"
+      end
+
     rescue
       $stderr.puts "Error parsing JSON data for Scarpe test status!"
       raise

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -97,9 +97,15 @@ class TestPara < Minitest::Test
 
   def stub_document_root
     doc_root = Minitest::Mock.new
-    wrangler = Minitest::Mock.new
-    doc_root.expect :get_element_wrangler, wrangler, [String]
-    wrangler.expect :inner_html=, nil, [String]
+    elt_wrangler = Minitest::Mock.new
+    web_wrangler = Minitest::Mock.new
+    doc_root.expect :get_element_wrangler, elt_wrangler, [String]
+    doc_root.expect :request_full_redraw!, nil
+    elt_wrangler.expect :inner_html=, nil, [String]
+    web_wrangler.expect :dom_change, nil, [String]
+    web_wrangler.expect :dom_promise_redraw, nil
+
     Scarpe::Widget.document_root = doc_root
+    Scarpe::Widget.web_wrangler = web_wrangler
   end
 end

--- a/test/test_promises.rb
+++ b/test/test_promises.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestPromises < Minitest::Test
+  Promise = Scarpe::Promise
+  #Promise.debug = true
+
+  def empty_promise_with_checker(state: nil, parents: [])
+    # Initially, no handlers have been called
+    called = {
+      fulfilled: false,
+      rejected: false,
+      scheduled: false,
+    }
+    p = Promise.new(state: state, parents: parents)
+    p.on_fulfilled { called[:fulfilled] = true }
+    p.on_rejected { called[:rejected] = true }
+    p.on_scheduled { called[:scheduled] = true }
+
+    [p, called]
+  end
+
+  def promise_that_immediately_returns(val, parents: [])
+    Promise.fulfilled(val, parents: parents)
+  end
+
+  def test_simple_promise_fulfillment
+    p, called = empty_promise_with_checker
+
+    p.fulfilled!
+
+    assert_equal true, called[:fulfilled], "Promise fulfilled handler wasn't called successfully on simple fulfillment!"
+    assert_equal false, called[:rejected], "Promise rejection handler was called on simple fulfillment!"
+    assert_equal true, called[:scheduled], "Promise scheduled handler wasn't called on simple fulfillment!"
+  end
+
+  def test_simple_promise_rejection
+    p, called = empty_promise_with_checker
+
+    p.rejected!
+
+    assert_equal false, called[:fulfilled], "Promise wasn't called successfully on simple rejection!"
+    assert_equal true, called[:rejected], "Promise rejection handler wasn't called on simple rejection!"
+
+    # Here's a fun thing - the on_scheduled handler *will* be called, but only if there's no incomplete
+    # parent, because effectively the promise will be scheduled during construction.
+    assert_equal true, called[:scheduled], "Promise scheduled handler wasn't called on simple rejection!"
+  end
+
+  def test_dependent_promise_fulfillment
+    parent_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent_promise])
+
+    # If a promise has an incomplete parent, it will start as unscheduled
+    assert_equal :unscheduled, promise.state
+    assert_equal false, called[:scheduled]
+
+    parent_promise.fulfilled!
+
+    # After the parent is complete, it will be scheduled
+    assert_equal :pending, promise.state
+    assert_equal true, called[:scheduled]
+  end
+
+  def test_dependent_promise_rejection
+    parent_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent_promise])
+
+    # If a promise has an incomplete parent, it will start as unscheduled
+    assert_equal :unscheduled, promise.state
+    assert_equal false, called[:scheduled]
+
+    parent_promise.rejected!
+
+    # After the parent is rejected, it will be rejected
+    assert_equal :rejected, promise.state
+    assert_equal false, called[:scheduled]
+    assert_equal true, called[:rejected]
+  end
+
+  def test_multiparent_fulfillment
+    parent1_promise = Promise.new
+    parent2_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent1_promise, parent2_promise])
+
+    parent1_promise.fulfilled!
+
+    assert_equal :unscheduled, promise.state
+    assert_equal false, called[:scheduled]
+
+    parent2_promise.fulfilled!
+
+    # After the parents are complete, it will be scheduled
+    assert_equal :pending, promise.state
+    assert_equal true, called[:scheduled]
+  end
+
+  def test_multiparent_rejection
+    parent1_promise = Promise.new
+    parent2_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent1_promise, parent2_promise])
+
+    parent1_promise.rejected!
+
+    assert_equal :rejected, promise.state
+    assert_equal false, called[:scheduled]
+    assert_equal true, called[:rejected]
+  end
+
+  def test_instant_fulfillment
+    p = promise_that_immediately_returns(7)
+    assert_equal :fulfilled, p.state
+    assert_equal 7, p.returned_value, "The promise should be fulfilled with a value of 7!"
+  end
+
+  def test_multiparent_instant_fulfillment_with_args
+    parents = [
+      promise_that_immediately_returns(7),
+      promise_that_immediately_returns(5),
+      promise_that_immediately_returns(8),
+    ]
+    assert_equal true, parents.all? { |p| p.complete? && p.returned_value.is_a?(Integer) }
+    sum_up_promise = Promise.new(parents: parents)
+    sum_up_promise.to_execute { |*args| args.sum }
+
+    assert_equal :fulfilled, sum_up_promise.state
+    assert_equal 20, sum_up_promise.returned_value
+  end
+
+  def test_multiparent_delayed_fulfillment_with_args
+    parents = [
+      Promise.new,
+      promise_that_immediately_returns(10),
+      Promise.new,
+      Promise.new,
+    ]
+    sum_up_promise = Promise.new(parents: parents)
+    sum_up_promise.to_execute { |*args| args.sum }
+
+    parents[0].fulfilled!(3)
+    parents[2].fulfilled!(8)
+
+    assert_equal false, sum_up_promise.complete?
+
+    parents[3].fulfilled!(9)
+
+    assert_equal :fulfilled, sum_up_promise.state
+    assert_equal 30, sum_up_promise.returned_value
+  end
+
+  def test_simple_executor_success
+    p = Promise.new
+    p.to_execute { 7 }
+
+    assert_equal :fulfilled, p.state
+    assert_equal 7, p.returned_value
+  end
+
+  def test_simple_executor_failure
+    expected_err = RuntimeError.new "Yup, that's an error"
+    p = Promise.new
+    p.to_execute { raise expected_err }
+
+    assert_equal :rejected, p.state
+    assert_equal expected_err, p.reason
+  end
+
+  def test_delayed_executor_success
+    parent = Promise.new
+    p = Promise.new(parents: [parent])
+    p.to_execute { 7 }
+
+    assert_equal :unscheduled, p.state
+
+    parent.fulfilled!
+
+    assert_equal :fulfilled, p.state
+    assert_equal 7, p.returned_value
+  end
+
+  def test_scheduler_raise_error
+    expected_err = StandardError.new "Yup, that's an error"
+    p = Promise.new { raise expected_err }
+
+    assert_equal :rejected, p.state
+    assert_equal expected_err, p.reason, "Promise should record the raised error as the reason for rejection!"
+  end
+
+  def test_explicit_rejected_error
+    expected_err = StandardError.new "Yup, that's an error"
+    p = Promise.new
+
+    p.rejected!(expected_err)
+
+    assert_equal expected_err, p.reason, "Promise should record the raised error as the reason for rejection!"
+  end
+
+  def test_then_with_success
+    called = {
+      p1_scheduled: false,
+      p2_scheduled: false,
+      p3_scheduled: false,
+    }
+    p1 = Promise.new { called[:p1_scheduled] = true }
+    p1.then { called[:p2_scheduled] = true }.then { called[:p3_scheduled] = true }
+
+    assert_equal true, called[:p1_scheduled]
+    assert_equal false, called[:p2_scheduled]
+
+    p1.fulfilled!
+
+    assert_equal true, called[:p2_scheduled]
+    assert_equal false, called[:p3_scheduled]
+  end
+end

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -24,7 +24,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_button_app
-    test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
+    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Scarpe.app do
         @push = button "Push me", width: 200, height: 50, top: 109, left: 132
         @note = para "Nothing pushed so far"

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestWebWrangler < Minitest::Test
+  def test_trivial_async_assert
+    test_scarpe_code(<<-'SCARPE_APP', test_code:<<-'TEST_CODE', timeout: 0.5)
+      Scarpe.app do
+        para "Hello World"
+      end
+    SCARPE_APP
+      on_event(:next_redraw) do
+        assert_js("true")
+        return_when_assertions_done
+      end
+    TEST_CODE
+  end
+
+  def test_simple_dom_html
+    test_scarpe_code(<<-'SCARPE_APP', test_code:<<-'TEST_CODE')
+      Scarpe.app do
+        para "Hello World"
+      end
+    SCARPE_APP
+      # This prints messages whenever schedulers or executors raise exceptions in Promises
+      Scarpe::Promise.debug = true
+
+      on_event(:next_redraw) do
+        para = find_widgets(Scarpe::Para)[0]
+
+        with_js_dom_html do |html_text|
+          assert html_text.include?("Hello World"), "DOM root should contain the text Hello World!"
+        end.then_ruby_promise { para.replace("goodbye world"); para.promise_update }.then_with_js_dom_html do |html_text|
+          assert html_text.include?("goodbye world"), "DOM root should contain the replacement text goodbye world! Text: #{html_text.inspect}"
+          assert !html_text.include?("Hello World"), "DOM root shouldn't still contain the original text Hello World! Text: #{html_text.inspect}"
+        end.then { return_when_assertions_done }
+      end
+    TEST_CODE
+  end
+end


### PR DESCRIPTION
Okay, this is both too large and too poorly factored. Instead, I'm going to chip away pieces of this to be committed individually. Also, this will interact in weird ways with the Shoes/Webview separation. Much better to separate this into much smaller pieces and figure out how to use them separately. I'm not taking this issue down yet, but I'm leaving it as draft. The intention is that once most of the pieces have turned into separate PRs, this PR and branch can die.

Features that are fully or partially implemented in this branch that are IMO worth extracting and merging:

* <s>Promises implementation and tests</s> Extracted into #130
* <s>Better promises-based redraw</s> Extracted into #131
* <s>Better promises-based JS eval</s> #130
* <s>Control interface: every_redraw/every_heartbeat event vs next_redraw/next_heartbeat</s> #131
* <s>Ctrl Iface: better err checking on app/wrangler/doc_root accessors</s> #130
* ctrl iface: promises-based testing lang - THIS IS THE REMAINING THING *NOT* IN OTHER PRs
* <s>Wrangler: default to single 'heartbeat' callback for periodic code, to allow batching</s> #130
* <s>Wrangler: better debug printing, everywhere</s> In multiple other PRs
* <s>Wrangler: better promises-based DOM-update API w/ DOMWrangler</s> #130
* <s>test_helper: better err-checking for :exit_immediately and timeouts</s> #131
* <s>test_helper: better checking for return values in JSON files</s> #131