### PR TITLE
Better JS eval, Promises lib, promises-enabled widgets

### DIFF
--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -9,8 +9,8 @@ require "securerandom"
 require "json"
 
 require_relative "scarpe/version"
+require_relative "scarpe/promises"
 require_relative "scarpe/display_service"
-require_relative "scarpe/wv/widget" # REMOVE THIS LINE LATER
 require_relative "scarpe/widgets"
 
 # WebView Display Service

--- a/lib/scarpe/promises.rb
+++ b/lib/scarpe/promises.rb
@@ -1,0 +1,397 @@
+# Funny thing... We need promises as an API concept since we have a JS event
+# loop doing its thing, and we need to respond to actions that it takes.
+# But there's not really a Ruby implementation of Promises *without* an
+# attached form of concurrency. So here we are, writing our own :-/
+#
+# In theory you could probably write some kind of "no-op thread pool"
+# for the ruby-concurrency gem, pass it manually to every promise we
+# created and then raise an exception any time we tried to do something
+# in the background. That's probably more code than writing our own, though,
+# and we'd be fighting it constantly.
+#
+# This class is inspired by concurrent-ruby [Promise](https://ruby-concurrency.github.io/concurrent-ruby/1.1.5/Concurrent/Promise.html)
+# which is inspired by Javascript Promises, which is what we actually need
+# for our use case. We can't easily tell when our WebView begins processing
+# our request, which removes the :processing state. This can be used for
+# executing JS, but also generally waiting on events.
+#
+# We don't fully control ordering here, so it *is* conceivable that a
+# child waiting on a parent can be randomly fulfilled, even if we didn't
+# expect it. We don't consider that an error. Similarly, we'll call
+# on_scheduled callbacks if a promise is fulfilled, even though we
+# never explicitly scheduled it. If a promise is *rejected* without
+# ever being scheduled, we won't call those callbacks.
+
+class Scarpe
+  class Promise
+    PROMISE_STATES = [:unscheduled, :pending, :fulfilled, :rejected]
+
+    def self.debug
+      @debug
+    end
+
+    def self.debug=(val)
+      @debug = val
+    end
+
+    attr_reader :state
+    attr_reader :parents
+    attr_reader :returned_value
+    attr_reader :reason
+
+    # These methods are meant to be a prettier interface to promises,
+    # suitable for day-to-day usage.
+
+    # Create a promise and then instantly fulfill it.
+    def self.fulfilled(return_val = nil, parents: [], &block)
+      p = Promise.new(parents: parents, &block)
+      p.fulfilled!(return_val)
+      p
+    end
+
+    # Create a promise and then instantly reject it.
+    def self.rejected(reason = nil, parents: [])
+      p = Promise.new(parents: parents)
+      p.rejected!(reason)
+    end
+
+    # Instance methods
+
+    # This is one way to return a value directly from a schedule block,
+    # which also fulfills the promise.
+    #
+    # This syntax is somewhat awkward, to work around the fact that
+    # we're often not scheduling Ruby, so return values from a
+    # scheduling block aren't usually what we want. When the scheduling
+    # block is run, the calculation has started, not finished.
+    #def return_final_value(val)
+    #  fulfilled!(val)
+    #end
+
+    def fulfilled!(value = nil)
+      set_state(:fulfilled, value)
+    end
+
+    def rejected!(reason = nil)
+      set_state(:rejected, reason)
+    end
+
+    def then(&block)
+      # Create a new promise. It's waiting on us. It runs the
+      # specified code when scheduled.
+      Promise.new(parents: [self], &block)
+    end
+
+    # The Promise.new method, along with all the various handlers,
+    # are pretty raw. They'll do what promises do, but they're not
+    # the prettiest. However, they ensure that guarantees are made
+    # and so on, so they're great as plumbing under the syntactic
+    # sugar above.
+
+    def initialize(state: nil, parents: [], &scheduler)
+      # These are as initially specified, and effectively immutable
+      @state = state
+      @parents = parents
+
+      # These are what we're waiting on, and will be
+      # removed as time goes forward.
+      @waiting_on = parents.select { |p| !p.complete? }
+      @on_fulfilled = []
+      @on_rejected = []
+      @on_scheduled = []
+      @scheduler = scheduler
+      @executor = nil
+      @returned_value = nil
+      @reason = nil
+
+      if complete?
+        # Did we start out already fulfilled or rejected?
+        # If so, we can skip a lot of fiddly checking.
+        # Don't need a scheduler or to care about parents
+        # or anything.
+        @waiting_on = []
+        @scheduler = nil
+      elsif @state == :pending
+        # Did we get an explicit :pending? Then we don't need
+        # to schedule ourselves, or care about the scheduler
+        # in general.
+        @scheduler = nil
+      elsif @state.nil? || @state == :unscheduled
+        # If no state was given or we're unscheduled, we'll
+        # wait until our parents have all completed to
+        # schedule ourselves.
+
+        if @waiting_on.empty?
+          # No further dependencies, we can schedule ourselves
+          @state = :pending
+
+          # We have no on_scheduled handlers yet, but this will
+          # call and clear the scheduler.
+          call_handlers_for(:pending)
+        else
+          # We're still waiting on somebody, no scheduling yet
+          @state = :unscheduled
+          @waiting_on.each do |dep|
+            dep.on_fulfilled { parent_fulfilled!(dep) }
+            dep.on_rejected { parent_rejected!(dep) }
+          end
+        end
+      end
+    end
+
+    def complete?
+      @state == :fulfilled || @state == :rejected
+    end
+
+    # These promises are mostly designed for external execution.
+    # You could put together your own thread-pool, or use RPC,
+    # a WebView, a database or similar source of external calculation.
+    # But in some cases, sure, it's reasonable to execute locally.
+    # In those cases, you can register an executor, which will be
+    # called when the promise is ready to execute but has not yet
+    # done so. Registering an executor on a promise that is
+    # already fulfilled is an error. Registering an executor on
+    # a promise that has already rejected is a no-op.
+    def to_execute(&block)
+      case @state
+      when :fulfilled
+        # Should this be a no-op instead?
+        raise "Registering an executor on an already fulfilled promise means it will never run!"
+      when :rejected
+        return
+      when :unscheduled
+        @executor = block # save for later
+      when :pending
+        @executor = block
+        call_executor
+      else
+        raise "Internal error, illegal state!"
+      end
+
+      self
+    end
+
+    private
+
+    # set_state looks at the old and new states of the promise. It calls handlers and updates tracking
+    # data accordingly.
+    def set_state(new_state, value_or_reason = nil)
+      old_state = @state
+
+      # First, filter out illegal input
+      unless PROMISE_STATES.include?(old_state)
+        raise "Internal Promise error! Internal state was #{old_state.inspect}! Legal states: #{PROMISE_STATES.inspect}"
+      end
+      unless PROMISE_STATES.include?(new_state)
+        raise "Internal Promise error! Internal state was set to #{new_state.inspect}! Legal states: #{PROMISE_STATES.inspect}"
+      end
+      if new_state != :fulfilled && new_state != :rejected && !value_or_reason.nil?
+        raise "Internal promise error! Non-completed state transitions should not specify a value or reason!"
+      end
+
+      # Here's our state-transition grid for what we're doing here.
+      # "From" state is on the left, "to" state is on top.
+      #
+      #    U P F R
+      #
+      # U  - 1 . .
+      # P  X - . .
+      # F  X X - X
+      # R  X X X -
+      #
+      # -  Change from same to same, no effect
+      # X  Illegal for one reason or another, raise error
+      # .  Great, no problem, run handlers but not @scheduler or @executor
+      # 1  Interesting case - if we have an executor, actually change to a *different* state instead
+
+      # Transitioning from our state to our same state? No-op.
+      return if new_state == old_state
+
+      # Transitioning to any *different* state after being fulfilled or rejected? Nope. Those states are final.
+      if complete?
+        raise "Internal Promise error! Trying to change state from #{old_state.inspect} to #{new_state.inspect}!"
+      end
+
+      if old_state == :pending && new_state == :unscheduled
+        raise "Can't change state from :pending to :unscheduled! Scheduling is not reversible!"
+      end
+
+      # The next three checks should all be followed by calling handlers for the newly-changed state.
+      # See call_handlers_for below.
+
+      # Okay, we're getting scheduled.
+      if old_state == :unscheduled && new_state == :pending
+        @state = new_state
+        call_handlers_for(new_state)
+
+        # It's not impossible for the scheduler to do something that fulfills or rejects the promise.
+        # In that case it *also* called the appropriate handlers. Let's get out of here.
+        return if @state == :fulfilled || @state == :rejected
+
+        if @executor
+          # In this case we're still pending, but we have a synchronous executor. Let's do it.
+          call_executor
+        end
+
+        return
+      end
+
+      # Setting to rejected calls the rejected handlers. But no scheduling ever occurs, so on_scheduled handlers
+      # will never be called.
+      if new_state == :rejected
+        @state = :rejected
+        @reason = value_or_reason
+        call_handlers_for(new_state)
+      end
+
+      # If we go straight from :unscheduled to :fulfilled we *will* run the on_scheduled callbacks,
+      # because we pretend the scheduling *did* occur at some point. Normally that'll be no callbacks,
+      # of course.
+      #
+      # Fun-but-unfortunate trivia: you *can* fulfill a promise before all its parents are fulfilled.
+      # If you do, the unfinished parents will result in nil arguments to the on_fulfilled handler,
+      # because we have no other value to provide. The scheduler callback will never be called, but
+      # the on_scheduled callbacks, if any, will be.
+      if new_state == :fulfilled
+        @state = :fulfilled
+        @returned_value = value_or_reason
+        call_handlers_for(new_state)
+      end
+    end
+
+    # This private method calls handlers for a new state, removing those handlers
+    # since they have now been called. This interacts subtly with set_state()
+    # above, particularly in the case of fulfilling a promise without it ever being
+    # properly scheduled.
+    #
+    # The rejected handlers will be cleared if the promise is fulfilled and vice-versa.
+    # After rejection, no on_fulfilled handler should ever be called and vice-versa.
+    #
+    # When we go from :unscheduled to :pending, the scheduler, if any, should be
+    # called and cleared. That should *not* happen when going from :unscheduled to
+    # :fulfilled.
+    def call_handlers_for(state)
+      case state
+      when :fulfilled
+        @on_scheduled.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_fulfilled.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_fulfilled = @on_rejected = @on_fulfilled = []
+        @scheduler = @executor = nil
+      when :rejected
+        @on_rejected.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_fulfilled = @on_scheduled = @on_rejected = []
+        @scheduler = @executor = nil
+      when :pending
+        # A scheduler can get an exception. If so, treat it as rejection
+        # and the exception as the provided reason.
+        if @scheduler
+          begin
+            @scheduler.call(*@parents.map(&:returned_value))
+          rescue => e
+            if Promise.debug
+              puts "Error while running scheduler! #{e.full_message}"
+            end
+            rejected!(e)
+          end
+          @scheduler = nil
+        end
+        @on_scheduled.each { |h| h.call(*@parents.map(&:returned_value)) }
+        @on_scheduled = []
+      else
+        raise "Internal error! Trying to call handlers for #{state.inspect}!"
+      end
+    end
+
+    def parent_fulfilled!(parent)
+      @waiting_on.delete(parent)
+
+      # Last parent? If so, schedule ourselves.
+      if @waiting_on.empty? && !self.complete?
+        # This will result in :pending if there's no executor,
+        # or fulfilled/rejected if there is an executor.
+        set_state(:pending)
+      end
+    end
+
+    def parent_rejected!(parent)
+      @waiting_on = []
+
+      unless self.complete?
+        # If our parent was rejected and we were waiting on them,
+        # now we're rejected too.
+        set_state(:rejected)
+      end
+    end
+
+    def call_executor
+      raise("Internal error! Should not call_executor with no executor!") unless @executor
+
+      begin
+        result = @executor.call(*@parents.map(&:returned_value))
+        fulfilled!(result)
+      rescue => e
+        if Promise.debug
+          puts "Error running executor! #{e.full_message}"
+        end
+        rejected!(e)
+        return
+      end
+
+    ensure
+      @executor = nil
+    end
+
+    public
+
+    def on_fulfilled(&handler)
+      unless handler
+        raise "You must pass a block to on_fulfilled!"
+      end
+      case @state
+      when :fulfilled
+        handler.call(*@parents.map(&:returned_value))
+      when :pending, :unscheduled
+        @on_fulfilled << handler
+      when :rejected
+        # Do nothing
+      end
+
+      self
+    end
+
+    def on_rejected(&handler)
+      unless handler
+        raise "You must pass a block to on_rejected!"
+      end
+
+      case @state
+      when :rejected
+        handler.call(*@parents.map(&:returned_value))
+      when :pending, :unscheduled
+        @on_rejected << handler
+      when :fulfilled
+        # Do nothing
+      end
+
+      self
+    end
+
+    def on_scheduled(&handler)
+      unless handler
+        raise "You must pass a block to on_scheduled!"
+      end
+
+      # Add a pending handler or call it now
+      case @state
+      when :fulfilled, :pending
+        handler.call(*@parents.map(&:returned_value))
+      when :unscheduled
+        @on_scheduled << handler
+      when :rejected
+        # Do nothing
+      end
+
+      self
+    end
+  end
+end

--- a/lib/scarpe/wv/app.rb
+++ b/lib/scarpe/wv/app.rb
@@ -84,12 +84,6 @@ class Scarpe
       @view.run
     end
 
-    def js_bind(name, &code)
-      raise "Cannot js_bind on closed or inactive Scarpe::App!" unless @view
-
-      @view.bind(name, &code)
-    end
-
     def destroy
       if @document_root || @view
         @control_interface.dispatch_event :shutdown

--- a/lib/scarpe/wv/control_interface.rb
+++ b/lib/scarpe/wv/control_interface.rb
@@ -8,7 +8,7 @@
 # created or called, Scarpe apps should run fine with no modifications.
 #
 # And if you depend on this from the framework, I'll add a check-mode that
-# doesn't even create one of these. Do NOT test me on this.
+# never dispatches any events to any handlers. Do NOT test me on this.
 
 class Scarpe
   class ControlInterface
@@ -70,8 +70,10 @@ class Scarpe
       @event_handlers[event] << block
     end
 
-    def js_eval(code)
-      @wrangler.js_eval(code)
+    # This is generally a terrible idea. You get no control over when it runs, no notification
+    # when it does, no timeout if it doesn't, and no error codes.
+    def js_eventually(code)
+      @wrangler.js_eventually(code)
     end
 
     # Send out the specified event

--- a/lib/scarpe/wv/control_interface.rb
+++ b/lib/scarpe/wv/control_interface.rb
@@ -14,10 +14,6 @@ class Scarpe
   class ControlInterface
     EVENTS = [:init, :shutdown, :frame]
 
-    attr_reader :app
-    attr_reader :doc_root
-    attr_reader :wrangler
-
     # The control interface needs to see major system components to hook into their events
     def initialize
       @event_handlers = {}
@@ -29,6 +25,27 @@ class Scarpe
       @app = app
       @doc_root = doc_root
       @wrangler = wrangler
+    end
+
+    def app
+      unless @app
+        raise "ControlInterface code needs to be wrapped in handlers like on_event(:init) to make sure they have access to app, doc_root, wrangler, etc!"
+      end
+      @app
+    end
+
+    def doc_root
+      unless @doc_root
+        raise "ControlInterface code needs to be wrapped in handlers like on_event(:init) to make sure they have access to app, doc_root, wrangler, etc!"
+      end
+      @doc_root
+    end
+
+    def wrangler
+      unless @wrangler
+        raise "ControlInterface code needs to be wrapped in handlers like on_event(:init) to make sure they have access to app, doc_root, wrangler, etc!"
+      end
+      @wrangler
     end
 
     # The control interface has overrides for certain settings. If the override has been specified,

--- a/lib/scarpe/wv/document_root.rb
+++ b/lib/scarpe/wv/document_root.rb
@@ -39,7 +39,7 @@ class Scarpe
 
       wrangler = WebviewDisplayService.instance.wrangler
       if wrangler.is_running
-        wrangler.js_eval("setTimeout(scarpeRedrawCallback,0)")
+        wrangler.js_eventually("scarpeRedrawCallback())")
       end
       @redraw_requested = true
     end

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -11,23 +11,77 @@ require "cgi"
 class Scarpe
   class WebWrangler
     attr_reader :is_running
+    attr_reader :heartbeat
+    attr_reader :control_interface
 
-    def initialize(title:, width:, height:, resizable:, debug:)
+    # This error indicates a problem when running ConfirmedEval
+    # TODO: add a Scarpe::Error parent class and inherit from it
+    class JSEvalError < StandardError
+      def initialize(data)
+        @data = data
+        super(data[:msg] || (self.class.name + "!"))
+      end
+    end
+
+    # We got an error running the supplied JS code string in confirmed_eval
+    class JSRuntimeError < JSEvalError
+    end
+
+    # We got weird or nonsensical results that seem like an error on WebWrangler's part
+    class InternalError < JSEvalError
+    end
+
+    # This is the JS function name for eval results
+    EVAL_RESULT = "scarpeAsyncEvalResult"
+
+    # Allow a half-second for Webview to finish our JS eval before we decide it's not going to
+    EVAL_DEFAULT_TIMEOUT = 0.5
+
+    def initialize(title:, width:, height:, resizable: false, debug: false, heartbeat: 0.1)
+      puts "Creating WebWrangler..." if debug
+
       # For now, always allow inspect element
       @webview = WebviewRuby::Webview.new debug: true
-      @evals = {} # This is a temporary measure, until I re-merge better evals with tracking
+
+      # this should NOT turn on debug, even with debug option on, for normal debug levels! It's *verbose*.
+      #@dom_wrangler = DOMWrangler.new(self, debug: debug)
+      @dom_wrangler = DOMWrangler.new(self)
 
       @title = title
       @width = width
       @height = height
       @resizable = resizable
       @debug = debug
+      @heartbeat = heartbeat
 
-      puts "Creating WebWrangler..." if debug
+      # Better to have a single setInterval than many when we don't care too much
+      # about the timing.
+      @heartbeat_handlers = []
+
+      # Need to keep track of which WebView Javascript evals are still pending,
+      # what handlers to call when they return, etc.
+      @pending_evals = {}
+      @eval_counter = 0
 
       bind("puts") do |*args|
         puts(*args)
       end
+
+      @webview.bind(EVAL_RESULT) do |*results|
+        receive_eval_result(*results)
+      end
+
+      @webview.bind("scarpeHeartbeat") do
+        periodic_js_callback
+        @heartbeat_handlers.each { |h| h.call }
+        #@control_interface.dispatch_event(:heartbeat)
+      end
+      js_interval = (heartbeat.to_f * 1_000.0).to_i
+      @webview.init("setInterval(scarpeHeartbeat,#{js_interval})")
+    end
+
+    def control_interface=(val)
+      @control_interface = val
     end
 
     ### Setup-mode Callbacks
@@ -45,23 +99,180 @@ class Scarpe
       @webview.init("#{name}();")
     end
 
-    def periodic_code(name, interval, &block)
-      raise "App is running, javascript periodic-code init no longer works!" if @is_running
-
-      bind(name, &block)
-      js_interval = (interval.to_f * 1_000.0).to_i
-      @webview.init("setInterval(#{name}, #{js_interval});")
+    # Run the specified code periodically, every "interval" seconds.
+    # If interface is unspecified, run per-heartbeat, which is very
+    # slightly more efficient.
+    def periodic_code(name, interval = heartbeat, &block)
+      if interval == heartbeat
+        @heartbeat_handlers << block
+      else
+        if @is_running
+          # I *think* we need to use init because we want this done for every
+          # new window. But will there ever be a new page/window? Can we just
+          # use eval instead of init to set up a periodic handler and call it
+          # good?
+          raise "App is running, can't set up new periodic handlers with init!"
+        end
+        bind(name, &block)
+        js_interval = (interval.to_f * 1_000.0).to_i
+        @webview.init("setInterval(#{name}, #{js_interval});")
+      end
     end
 
     # Running callbacks
 
-    def js_eval(code)
-      raise "App isn't running, eval won't work!" unless @is_running
+    # js_eventually is a simple JS evaluation. On syntax error, nothing happens.
+    # On runtime error, execution stops at the error with no further
+    # effect or notification. This is rarely what you want.
+    # The js_eventually code is run asynchronously, returning neither error
+    # nor value.
+    #
+    # This method does *not* return a promise, and there is no way to track
+    # its progress or its success or failure.
+    def js_eventually(code)
+      raise "WebWrangler isn't running, eval doesn't work!" unless @is_running
 
-      @evals[code] = true # Guarantee a reference to the eval'd code when it later executes
+      puts "Deprecated: please do NOT use js_eventually, it's basically never what you want!"
 
       @webview.eval(code)
     end
+
+    # Eval a chunk of JS code asynchronously. This method returns a
+    # promise which will be fulfilled or rejected after the JS executes
+    # or times out.
+    #
+    # Note that we *both* care whether the JS has finished after it was
+    # scheduled *and* whether it ever got scheduled at all. If it
+    # depends on tasks that never fulfill or reject then it may wait
+    # in limbo, potentially forever.
+    #
+    # Right now we can't/don't handle arguments from previous fulfilled
+    # promises. To do that, we'd probably need to know we were passing
+    # in a JS function.
+    EVAL_OPTS = [:timeout, :wait_for]
+    def eval_js_async(code, opts = {})
+      bad_opts = opts.keys - EVAL_OPTS
+      raise("Bad options given to eval_with_handler! #{bad_opts.inspect}") unless bad_opts.empty?
+
+      unless @is_running
+        raise "WebWrangler isn't running, so evaluating JS won't work!"
+      end
+
+      this_eval_serial = @eval_counter
+      @eval_counter += 1
+
+      @pending_evals[this_eval_serial] = {
+        id: this_eval_serial,
+        code: code,
+        start_time: Time.now,
+        timeout_if_not_scheduled: Time.now + EVAL_DEFAULT_TIMEOUT,
+      }
+
+      # We'll need this inside the promise-scheduling block
+      pending_evals = @pending_evals
+      timeout = opts[:timeout] || EVAL_DEFAULT_TIMEOUT
+
+      promise = Scarpe::Promise.new(parents: (opts[:wait_for] || [])) do
+        # Are we mid-shutdown?
+        if @webview
+          wrapped_code = js_wrapped_code(code, this_eval_serial)
+
+          # We've been scheduled!
+          t_now = Time.now
+          pending_evals[this_eval_serial][:wrapped_code] = wrapped_code # Hard to be sure Webview keeps a proper reference to this, so we will
+          pending_evals[this_eval_serial][:scheduled_time] = t_now
+          pending_evals[this_eval_serial].delete(:timeout_if_not_scheduled)
+
+          pending_evals[this_eval_serial][:timeout_if_not_finished] = t_now + timeout
+          @webview.eval(wrapped_code)
+          puts "Scheduled JS: (#{this_eval_serial})\n#{wrapped_code}" if @debug
+        else
+          # We're mid-shutdown. No more schedulings things.
+        end
+      end
+
+      @pending_evals[this_eval_serial][:promise] = promise
+
+      promise
+    end
+
+    private
+
+    def js_wrapped_code(code, eval_id)
+      <<~JS_CODE
+        (function() {
+          var code_string = #{JSON.dump code};
+          try {
+            result = eval(code_string);
+            #{EVAL_RESULT}("success", #{eval_id}, result);
+          } catch(error) {
+            #{EVAL_RESULT}("error", #{eval_id}, error.message);
+          }
+        })();
+      JS_CODE
+    end
+
+    def periodic_js_callback
+      time_out_eval_results
+    end
+
+    def receive_eval_result(r_type, id, val)
+      entry = @pending_evals.delete(id)
+      unless entry
+        STDERR.puts "Received an eval result for a nonexistent ID #{id.inspect}!"
+        raise "Received an eval result for a nonexistent ID #{id.inspect}!"
+      end
+
+      if @debug
+        puts "Got JS value: #{r_type} / #{id} / #{val.inspect}"
+      end
+
+      promise = entry[:promise]
+
+      case r_type
+      when "success"
+        promise.fulfilled!(val)
+      when "error"
+        promise.rejected! JSRuntimeError.new(msg: "JS runtime error: #{val.inspect}!", code: entry[:code], ret_value: val)
+      else
+        promise.rejected! InternalError.new(msg: "JS eval internal error! r_type: #{r_type.inspect}", code: entry[:code], ret_value: val)
+      end
+    end
+
+    # TODO: would be good to keep 'tombstone' results for awhile after timeout, maybe up to around a minute,
+    # so we can detect if we're timing things out and then having them return successfully after a delay.
+    # Then we could adjust the timeouts. We could also check if later serial numbers have returned, and time
+    # out earlier serial numbers... *if* we're sure Webview will always execute JS evals in order.
+    # This all adds complexity, though. For now, do timeouts on a simple max duration.
+    def time_out_eval_results
+      t_now = Time.now
+      timed_out_from_scheduling = @pending_evals.keys.select do |id|
+        t = @pending_evals[id][:timeout_if_not_scheduled]
+        t && t_now >= t
+      end
+      timed_out_from_finish = @pending_evals.keys.select do |id|
+        t = @pending_evals[id][:timeout_if_not_finished]
+        t && t_now >= t
+      end
+      timed_out_from_scheduling.each do |id|
+        puts("JS timed out because it was never scheduled: #{@pending_evals[id][:code].inspect}") if @debug
+      end
+      timed_out_from_finish.each do |id|
+        puts("JS timed out because it never finished: #{@pending_evals[id][:code].inspect}") if @debug
+      end
+
+      # A plus *should* be fine since nothing should ever be on both lists. But let's be safe.
+      timed_out_ids = timed_out_from_scheduling | timed_out_from_finish
+
+      timed_out_ids.each do |id|
+        STDERR.puts "Timing out JS eval! #{@pending_evals[id][:code]}"
+        entry = @pending_evals.delete(id)
+        err = JSSyntaxError.new(msg: "JS syntax error or handling error!", code: entry[:code], ret_value: nil)
+        entry[:promise].rejected!(err)
+      end
+    end
+
+    public
 
     # After setup, we call run to go to "running" mode.
     # No more setup callbacks, only running callbacks.
@@ -92,7 +303,6 @@ class Scarpe
       puts "  (But WebWrangler was already inactive)" if @debug && !@webview
       if @webview
         @bindings = {}
-        @evals = {}
         @webview.terminate
         @webview.destroy
         @webview = nil
@@ -153,9 +363,214 @@ class Scarpe
     # to mess with the HTML DOM. This needs to be turned into a nicer API,
     # but first we'll get it all into one place and see what we're doing.
 
-    # Replace the entire DOM
-    def replace(el)
-      js_eval("document.getElementById('wrapper-wvroot').innerHTML = `#{el}`;")
+    # Replace the entire DOM - return a promise for when this has been done.
+    # This will often get rid of smaller changes in the queue, which is
+    # a good thing since they won't have to be run.
+    def replace(html_text)
+      @dom_wrangler.request_replace(html_text)
+    end
+
+    # Request a DOM change - return a promise for when this has been done.
+    def dom_change(js)
+      @dom_wrangler.request_change(js)
+    end
+
+    # Return whether the DOM is, right this moment, confirmed to be fully
+    # up to date or not.
+    def dom_fully_updated?
+      @dom_wrangler.fully_updated?
+    end
+
+    # Return a promise that will be fulfilled when all current DOM changes
+    # have committed (but not necessarily any future DOM changes.)
+    def dom_promise_redraw
+      @dom_wrangler.promise_redraw
+    end
+
+    # Return a promise which will be fulfilled the next time the DOM is
+    # fully up to date. Note that a slow trickle of changes can make this
+    # take a long time, since it is *not* only changes up to this point.
+    # If you want to know that some specific change is done, it's often
+    # easiest to use the promise returned by dom_change(), which will
+    # be fulfilled when that specific change commits.
+    def promise_dom_fully_updated
+      @dom_wrangler.promise_fully_updated
+    end
+
+    def on_every_redraw(&block)
+      @dom_wrangler.on_every_redraw(&block)
+    end
+  end
+end
+
+# Leaving DOM changes as "meh, async, we'll see when it happens" is terrible for testing.
+# Instead, we need to track whether particular changes have committed yet or not.
+# So we add a single gateway for all DOM changes, and we make sure its work is done
+# before we consider a redraw complete.
+#
+# DOMWrangler batches up changes - it's fine to have a redraw "in flight" and have
+# changes waiting to catch the next bus. But We don't want more than one in flight,
+# since it seems like having too many pending RPC requests can crash Webview. So:
+# one redraw scheduled and one redraw promise waiting around, at maximum.
+class Scarpe
+  class WebWrangler
+    class DOMWrangler
+      attr_reader :waiting_changes
+      attr_reader :pending_redraw_promise
+      attr_reader :waiting_redraw_promise
+
+      def initialize(web_wrangler, debug: false)
+        @wrangler = web_wrangler
+
+        @waiting_changes = []
+        @pending_redraw_promise = nil
+        @waiting_redraw_promise = nil
+
+        @fully_up_to_date_promise = nil
+
+        @redraw_handlers = []
+
+        @debug = debug
+      end
+
+      def request_change(js_code)
+        @waiting_changes << js_code
+
+        promise_redraw
+      end
+
+      def request_replace(html_text)
+        # Replace other pending changes, they're not needed any more
+        @waiting_changes = [ "document.getElementById('wrapper-wvroot').innerHTML = `#{html_text}`; true" ]
+
+        puts "Requesting DOM replacement..." if @debug
+        promise_redraw
+      end
+
+      def on_every_redraw(&block)
+        @redraw_handlers << block
+      end
+
+      # What are the states of redraw?
+      # "empty" - no waiting promise, no pending-redraw promise, no pending changes
+      # "pending only" - no waiting promise, but we have a pending redraw with some changes; it hasn't committed yet
+      # "pending and waiting" - we have a waiting promise for our unscheduled changes; we can add more unscheduled
+      #     changes since we haven't scheduled them yet.
+      #
+      # This is often called right after adding a new waiting change or replacing them, so that may need fixing up.
+      def promise_redraw
+        if fully_updated?
+          # No changes to make, nothing in-process or waiting, so just return a pre-fulfilled promise
+          puts "Requesting redraw but there are no pending changes or promises, return pre-fulfilled" if @debug
+          return Promise.fulfilled
+        end
+
+        # Already have a redraw requested *and* one on deck? Then all current changes will have committed
+        # when we (eventually) fulfill the waiting_redraw_promise.
+        if @waiting_redraw_promise
+          puts "Promising eventual redraw of #{@waiting_changes.size} waiting unscheduled changes." if @debug
+          return @waiting_redraw_promise
+        end
+
+        if @waiting_changes.empty?
+          # There's no waiting_redraw_promise. There are no waiting changes. But we're not fully updated. 
+          # So there must be a redraw in flight, and we don't need to schedule a new waiting_redraw_promise.
+          puts "Returning in-flight redraw promise" if @debug
+          return @pending_redraw_promise
+        end
+
+        puts "Requesting redraw with #{@waiting_changes.size} waiting changes - need to schedule something!" if @debug
+
+        # We have at least one waiting change, possibly newly-added. We have no waiting_redraw_promise.
+        # Do we already have a redraw in-flight?
+        if @pending_redraw_promise
+          # Yes we do. Schedule a new waiting promise. When it turns into the pending_redraw_promise it will
+          # grab all waiting changes. In the mean time, it sits here and waits.
+          #
+          # We *could* do a fancy promise thing and have it update @waiting_changes for itself, etc, when it
+          # schedules itself. But we should always be calling promise_redraw or having a redraw commit (see below)
+          # when these things change, and I'd rather keep the logic in this method. It's easier to reason through
+          # all the cases.
+          @waiting_redraw_promise = Promise.new
+
+          return @waiting_redraw_promise
+        end
+
+        # We have no redraw in-flight and no pre-existing waiting line. The new change(s) are presumably right
+        # after things were fully up-to-date. We can schedule them for immediate redraw.
+
+        promise = schedule_waiting_changes
+        @pending_redraw_promise = promise
+
+        promise.on_fulfilled {
+          @redraw_handlers.each(&:call)
+
+          if @waiting_redraw_promise
+            # While this redraw was in flight, more waiting changes got added and we made a promise
+            # about when they'd complete. Now they get scheduled, and we'll fulfill the waiting
+            # promise when that redraw finishes. Clear the old waiting promise. We'll add a new one
+            # when/if more changes are scheduled during this redraw.
+            old_waiting_promise = @waiting_redraw_promise
+            @waiting_redraw_promise = nil
+
+            @pending_redraw_promise = schedule_waiting_changes
+            @pending_redraw_promise.on_fulfilled { old_waiting_promise.fulfilled! }
+          else
+            # The in-flight redraw completed, and there's still no waiting promise. Good! That means
+            # we should be fully up-to-date.
+            @pending_redraw_promise = nil
+            if @waiting_changes.empty?
+              # We're fully up to date! Fulfill the promise. Now we don't need it again until somebody asks
+              # us for another.
+              if @fully_up_to_date_promise
+                @fully_up_to_date_promise.fulfilled!
+                @fully_up_to_date_promise = nil
+              end
+            else
+              STDERR.puts "WHOAH, WHAT? My logic must be wrong, because there's no waiting promise, but waiting changes!"
+            end
+          end
+
+          puts "REDRAW FULLY UP TO DATE" if fully_updated? && @debug
+        }.on_rejected {
+          STDERR.puts "Could not complete JS redraw! #{promise.reason.full_message}"
+          puts "REDRAW FULLY UP TO DATE BUT JS FAILED" if fully_updated? && @debug
+
+          raise "JS Redraw failed! Bailing!"
+
+          # Later we should figure out how to handle this. Clear the promises and queues and request another redraw?
+        }
+      end
+
+      def fully_updated?
+        @pending_redraw_promise.nil? && @waiting_redraw_promise.nil? && @waiting_changes.empty?
+      end
+
+      # Return a promise which will be fulfilled when the DOM is fully up-to-date
+      def promise_fully_updated
+        if fully_updated?
+          # No changes to make, nothing in-process or waiting, so just return a pre-fulfilled promise
+          return Promise.fulfilled
+        end
+
+        # Do we already have a promise for this? Return it. Everybody can share one.
+        if @fully_up_to_date_promise
+          return @fully_up_to_date_promise
+        end
+
+        # We're not fully updated, so we need a promise. Create it, return it.
+        @fully_up_to_date_promise = Promise.new
+      end
+
+      private
+
+      # Put together the waiting changes into a new in-flight redraw request.
+      # Return it as a promise.
+      def schedule_waiting_changes
+        js_code = @waiting_changes.join(";")
+        @waiting_changes = []   # They're not waiting any more!
+        @wrangler.eval_js_async js_code
+      end
     end
   end
 end
@@ -172,20 +587,24 @@ class Scarpe
         @html_id = html_id
       end
 
+      def promise_update
+        @webwrangler.dom_promise_redraw
+      end
+
       def value=(new_value)
-        @webwrangler.js_eval("document.getElementById(#{html_id}).value = #{new_value}")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).value = #{new_value}; true")
       end
 
       def inner_text=(new_text)
-        @webwrangler.js_eval("document.getElementById(#{html_id}).innerText = '#{new_text}'")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).innerText = '#{new_text}'; true")
       end
 
       def inner_html=(new_html)
-        @webwrangler.js_eval("document.getElementById(#{html_id}).innerHTML = `#{new_html}`")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).innerHTML = `#{new_html}`; true")
       end
 
       def remove
-        @webwrangler.js_eval("document.getElementById(#{html_id}).remove()")
+        @webwrangler.dom_change("document.getElementById(#{html_id}).remove(); true")
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,7 +63,7 @@ def test_scarpe_app(test_app_location, test_code: "", **opts)
     if opts[:exit_immediately]
       scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
         on_event(:frame) do
-          js_eval "scarpeStatusAndExit(true);"
+          js_eventually "scarpeStatusAndExit(true);"
         end
       TEST_EXIT_IMMEDIATELY
     end

--- a/test/test_promises.rb
+++ b/test/test_promises.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestPromises < Minitest::Test
+  Promise = Scarpe::Promise
+  #Promise.debug = true
+
+  def empty_promise_with_checker(state: nil, parents: [])
+    # Initially, no handlers have been called
+    called = {
+      fulfilled: false,
+      rejected: false,
+      scheduled: false,
+    }
+    p = Promise.new(state: state, parents: parents)
+    p.on_fulfilled { called[:fulfilled] = true }
+    p.on_rejected { called[:rejected] = true }
+    p.on_scheduled { called[:scheduled] = true }
+
+    [p, called]
+  end
+
+  def promise_that_immediately_returns(val, parents: [])
+    Promise.fulfilled(val, parents: parents)
+  end
+
+  def test_simple_promise_fulfillment
+    p, called = empty_promise_with_checker
+
+    p.fulfilled!
+
+    assert_equal true, called[:fulfilled], "Promise fulfilled handler wasn't called successfully on simple fulfillment!"
+    assert_equal false, called[:rejected], "Promise rejection handler was called on simple fulfillment!"
+    assert_equal true, called[:scheduled], "Promise scheduled handler wasn't called on simple fulfillment!"
+  end
+
+  def test_simple_promise_rejection
+    p, called = empty_promise_with_checker
+
+    p.rejected!
+
+    assert_equal false, called[:fulfilled], "Promise wasn't called successfully on simple rejection!"
+    assert_equal true, called[:rejected], "Promise rejection handler wasn't called on simple rejection!"
+
+    # Here's a fun thing - the on_scheduled handler *will* be called, but only if there's no incomplete
+    # parent, because effectively the promise will be scheduled during construction.
+    assert_equal true, called[:scheduled], "Promise scheduled handler wasn't called on simple rejection!"
+  end
+
+  def test_dependent_promise_fulfillment
+    parent_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent_promise])
+
+    # If a promise has an incomplete parent, it will start as unscheduled
+    assert_equal :unscheduled, promise.state
+    assert_equal false, called[:scheduled]
+
+    parent_promise.fulfilled!
+
+    # After the parent is complete, it will be scheduled
+    assert_equal :pending, promise.state
+    assert_equal true, called[:scheduled]
+  end
+
+  def test_dependent_promise_rejection
+    parent_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent_promise])
+
+    # If a promise has an incomplete parent, it will start as unscheduled
+    assert_equal :unscheduled, promise.state
+    assert_equal false, called[:scheduled]
+
+    parent_promise.rejected!
+
+    # After the parent is rejected, it will be rejected
+    assert_equal :rejected, promise.state
+    assert_equal false, called[:scheduled]
+    assert_equal true, called[:rejected]
+  end
+
+  def test_multiparent_fulfillment
+    parent1_promise = Promise.new
+    parent2_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent1_promise, parent2_promise])
+
+    parent1_promise.fulfilled!
+
+    assert_equal :unscheduled, promise.state
+    assert_equal false, called[:scheduled]
+
+    parent2_promise.fulfilled!
+
+    # After the parents are complete, it will be scheduled
+    assert_equal :pending, promise.state
+    assert_equal true, called[:scheduled]
+  end
+
+  def test_multiparent_rejection
+    parent1_promise = Promise.new
+    parent2_promise = Promise.new
+    promise, called = empty_promise_with_checker(parents: [parent1_promise, parent2_promise])
+
+    parent1_promise.rejected!
+
+    assert_equal :rejected, promise.state
+    assert_equal false, called[:scheduled]
+    assert_equal true, called[:rejected]
+  end
+
+  def test_instant_fulfillment
+    p = promise_that_immediately_returns(7)
+    assert_equal :fulfilled, p.state
+    assert_equal 7, p.returned_value, "The promise should be fulfilled with a value of 7!"
+  end
+
+  def test_multiparent_instant_fulfillment_with_args
+    parents = [
+      promise_that_immediately_returns(7),
+      promise_that_immediately_returns(5),
+      promise_that_immediately_returns(8),
+    ]
+    assert_equal true, parents.all? { |p| p.complete? && p.returned_value.is_a?(Integer) }
+    sum_up_promise = Promise.new(parents: parents)
+    sum_up_promise.to_execute { |*args| args.sum }
+
+    assert_equal :fulfilled, sum_up_promise.state
+    assert_equal 20, sum_up_promise.returned_value
+  end
+
+  def test_multiparent_delayed_fulfillment_with_args
+    parents = [
+      Promise.new,
+      promise_that_immediately_returns(10),
+      Promise.new,
+      Promise.new,
+    ]
+    sum_up_promise = Promise.new(parents: parents)
+    sum_up_promise.to_execute { |*args| args.sum }
+
+    parents[0].fulfilled!(3)
+    parents[2].fulfilled!(8)
+
+    assert_equal false, sum_up_promise.complete?
+
+    parents[3].fulfilled!(9)
+
+    assert_equal :fulfilled, sum_up_promise.state
+    assert_equal 30, sum_up_promise.returned_value
+  end
+
+  def test_simple_executor_success
+    p = Promise.new
+    p.to_execute { 7 }
+
+    assert_equal :fulfilled, p.state
+    assert_equal 7, p.returned_value
+  end
+
+  def test_simple_executor_failure
+    expected_err = RuntimeError.new "Yup, that's an error"
+    p = Promise.new
+    p.to_execute { raise expected_err }
+
+    assert_equal :rejected, p.state
+    assert_equal expected_err, p.reason
+  end
+
+  def test_delayed_executor_success
+    parent = Promise.new
+    p = Promise.new(parents: [parent])
+    p.to_execute { 7 }
+
+    assert_equal :unscheduled, p.state
+
+    parent.fulfilled!
+
+    assert_equal :fulfilled, p.state
+    assert_equal 7, p.returned_value
+  end
+
+  def test_scheduler_raise_error
+    expected_err = StandardError.new "Yup, that's an error"
+    p = Promise.new { raise expected_err }
+
+    assert_equal :rejected, p.state
+    assert_equal expected_err, p.reason, "Promise should record the raised error as the reason for rejection!"
+  end
+
+  def test_explicit_rejected_error
+    expected_err = StandardError.new "Yup, that's an error"
+    p = Promise.new
+
+    p.rejected!(expected_err)
+
+    assert_equal expected_err, p.reason, "Promise should record the raised error as the reason for rejection!"
+  end
+
+  def test_then_with_success
+    called = {
+      p1_scheduled: false,
+      p2_scheduled: false,
+      p3_scheduled: false,
+    }
+    p1 = Promise.new { called[:p1_scheduled] = true }
+    p1.then { called[:p2_scheduled] = true }.then { called[:p3_scheduled] = true }
+
+    assert_equal true, called[:p1_scheduled]
+    assert_equal false, called[:p2_scheduled]
+
+    p1.fulfilled!
+
+    assert_equal true, called[:p2_scheduled]
+    assert_equal false, called[:p3_scheduled]
+  end
+end


### PR DESCRIPTION
This pulls out some of the useful parts from https://github.com/scarpe-team/scarpe/pull/117, but not the whole ball of wax.

It builds on (not-yet-merged as I write this) https://github.com/scarpe-team/scarpe/pull/125, which allows using the Webview display service in an optional child process.

Specifically, this PR adds the following fairly large changes:

* a Promises lib and tests
* better Promises-based JS eval, with timeouts if they don't complete and callbacks if they do
* Wrangler: better promises-based DOM-update API w/ a DOMWrangler to centralise DOM updates

And the following small hygiene changes:

* Control interface: better err checking on app/wrangler/doc_root accessors
* Wrangler: default to single 'heartbeat' callback for periodic code, to allow batching

Promises are required for a *lot* of that PR, and the better JS eval also opens up a lot of good possibilities for testing.