### PR TITLE
No-display tests and other tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,9 @@ Style/ClassMethodsDefinitions:
 
 Style/SpecialGlobalVars:
   Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/RedundantConstantBase:
+  Enabled: false

--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -8,7 +8,15 @@ class Scarpe
 
     display_properties :title, :width, :height, :resizable, :debug, :do_shutdown
 
-    def initialize(title: "Scarpe!", width: 480, height: 420, resizable: true, debug: false, test_code: nil, &app_code_body)
+    def initialize(
+      title: "Scarpe!",
+      width: 480,
+      height: 420,
+      resizable: true,
+      debug: false,
+      test_code: nil,
+      &app_code_body
+    )
       @do_shutdown = false
 
       if Scarpe::App.next_test_code
@@ -31,6 +39,7 @@ class Scarpe
     def init
       send_display_event(event_name: "init")
       return if @do_shutdown
+
       @document_root.instance_eval(&@app_code_body)
     end
 

--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -2,12 +2,23 @@
 
 class Scarpe
   class App < Scarpe::Widget
+    class << self
+      attr_accessor :next_test_code
+    end
+
     display_properties :title, :width, :height, :resizable, :debug, :do_shutdown
 
-    def initialize(title: "Scarpe!", width: 480, height: 420, resizable: true, debug: false, &app_code_body)
+    def initialize(title: "Scarpe!", width: 480, height: 420, resizable: true, debug: false, test_code: nil, &app_code_body)
       @do_shutdown = false
 
+      if Scarpe::App.next_test_code
+        test_code = Scarpe::App.next_test_code
+        Scarpe::App.next_test_code = nil
+      end
+
       super
+
+      test_code&.call(self)
 
       # This creates the DocumentRoot, including its corresponding display widget
       @document_root = Scarpe::DocumentRoot.new(debug: @debug)
@@ -19,7 +30,7 @@ class Scarpe
 
     def init
       send_display_event(event_name: "init")
-
+      return if @do_shutdown
       @document_root.instance_eval(&@app_code_body)
     end
 
@@ -50,6 +61,34 @@ class Scarpe
     def destroy
       @do_shutdown = true
       send_display_event(event_name: "destroy")
+    end
+  end
+
+  # In tests, this will normally be included into App
+  module AppTest
+    def all_widgets
+      out = []
+
+      to_add = @document_root.children
+      until to_add.empty?
+        out.concat(to_add)
+        to_add = to_add.flat_map(&:children).compact
+      end
+
+      out
+    end
+
+    # We can add various ways to find widgets here.
+    def find_widgets_by(*specs)
+      widgets = all_widgets
+      specs.each do |spec|
+        if spec.is_a?(Class)
+          all_widgets.select! { |w| spec === w }
+        else
+          raise("Don't know how to find widgets by #{spec.inspect}!")
+        end
+      end
+      widgets
     end
   end
 end

--- a/lib/scarpe/display_service.rb
+++ b/lib/scarpe/display_service.rb
@@ -50,7 +50,7 @@ class Scarpe
         if DisplayService.json_debug_serialize
           args = JSON.parse JSON.dump(args)
           new_kw = {}
-          kwargs.each do |k,v|
+          kwargs.each do |k, v|
             new_kw[k] = JSON.parse JSON.dump(v)
           end
           kwargs = new_kw
@@ -102,6 +102,7 @@ class Scarpe
 
       def unsub_from_events(unsub_id)
         raise "Must provide an unsubscribe ID!" if unsub_id.nil?
+
         @@display_event_handlers.each do |_type, e_name_hash|
           e_name_hash.each do |_e_name, target_hash|
             target_hash.each do |_target, h_list|

--- a/lib/scarpe/display_service.rb
+++ b/lib/scarpe/display_service.rb
@@ -36,6 +36,8 @@ class Scarpe
     DS_EVENT_TYPES = [:shoes, :display]
 
     class << self
+      attr_accessor :json_debug_serialize
+
       # An event_target may be nil, to indicate there is no target.
       def dispatch_event(event_type, event_name, event_target, *args, **kwargs)
         @@display_event_handlers ||= {}
@@ -45,8 +47,14 @@ class Scarpe
 
         raise "Cannot dispatch on event_name :any!" if event_name == :any
 
-        # TODO: debug mode that JSON-serializes and -deserializes all args to make sure only legal
-        # objects are passed through.
+        if DisplayService.json_debug_serialize
+          args = JSON.parse JSON.dump(args)
+          new_kw = {}
+          kwargs.each do |k,v|
+            new_kw[k] = JSON.parse JSON.dump(v)
+          end
+          kwargs = new_kw
+        end
 
         same_type_handlers = @@display_event_handlers[event_type] || {}
         return if same_type_handlers.empty?
@@ -93,15 +101,19 @@ class Scarpe
       end
 
       def unsub_from_events(unsub_id)
+        raise "Must provide an unsubscribe ID!" if unsub_id.nil?
         @@display_event_handlers.each do |_type, e_name_hash|
           e_name_hash.each do |_e_name, target_hash|
-            target_hash.delete_if { |_target, h_hash| h_hash[:unsub_id] == unsub_id }
+            target_hash.each do |_target, h_list|
+              h_list.delete_if { |item| item[:unsub_id] == unsub_id }
+            end
           end
         end
       end
 
       def full_reset!
         @@display_event_handlers = {}
+        @json_debug_serialize = nil
       end
 
       def display_services
@@ -143,6 +155,32 @@ class Scarpe
 
       def bind_display_event(event_name:, target: nil, &handler)
         DisplayService.subscribe_to_event(:display, event_name, target, &handler)
+      end
+    end
+
+    module LinkableTest
+      def on_next_event(event_type, event_name, target: nil, &block)
+        if event_type == :shoes
+          unsub_id = bind_shoes_event(event_name:, target:) do |*args, **kwargs|
+            block.call(*args, **kwargs)
+            DisplayService.unsub_from_events(unsub_id)
+          end
+        elsif event_type == :display
+          unsub_id = bind_display_event(event_name:, target:) do |*args, **kwargs|
+            block.call(*args, **kwargs)
+            DisplayService.unsub_from_events(unsub_id)
+          end
+        else
+          raise "Attempt to get on_next with unknown event type #{event_type.inspect}, not :display or :shoes!"
+        end
+      end
+
+      def on_next_heartbeat(&block)
+        on_next_event(:display, "heartbeat", &block)
+      end
+
+      def on_init(&block)
+        bind_display_event(event_name: "init", &block)
       end
     end
   end

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -96,6 +96,7 @@ class Scarpe
     end
 
     attr_reader :parent
+    attr_reader :children
 
     def set_parent(new_parent)
       @parent&.remove_child(self)

--- a/lib/scarpe/wv/para.rb
+++ b/lib/scarpe/wv/para.rb
@@ -25,6 +25,11 @@ class Scarpe
         return
       end
 
+      # Not deleting, so this will re-render
+      if changes["size"]
+        size = size.to_sym if SIZES[size.to_sym]
+      end
+
       super
     end
 

--- a/lib/scarpe/wv/para.rb
+++ b/lib/scarpe/wv/para.rb
@@ -26,8 +26,8 @@ class Scarpe
       end
 
       # Not deleting, so this will re-render
-      if changes["size"]
-        size = size.to_sym if SIZES[size.to_sym]
+      if changes["size"] && SIZES[@size.to_sym]
+        @size = @size.to_sym
       end
 
       super

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,7 +29,10 @@ end
 # Temporarily set env vars for the block of code inside
 def with_env_vars(envs)
   old_env = {}
-  envs.each { |k, v| old_env[k] = ENV[k]; ENV[k] = v }
+  envs.each do |k, v|
+    old_env[k] = ENV[k]
+    ENV[k] = v
+  end
   yield
 ensure
   old_env.each { |k, v| ENV[k] = v }

--- a/test/test_no_display.rb
+++ b/test/test_no_display.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestScarpeNoDisplay < Minitest::Test
+  def setup
+    # If we want to be sure we hit a particular line, we can set a boolean when we do.
+    # An assertion is usually better... But an assertion doesn't work if we might not
+    # execute the line at all.
+    TEST_DATA.clear
+  end
+
+  # make sure the test code actually gets called at all
+  def test_app_created
+    test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
+      Scarpe.app do
+        para 'hello world'
+      end
+    SCARPE_APP
+      the_app = self
+      on_init do
+        TEST_DATA[:got_here] = true
+        the_app.destroy
+      end
+    TEST_CODE
+    assert_equal true, TEST_DATA[:got_here]
+  end
+
+  def test_run_event
+    test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
+      Scarpe.app do
+        para 'hello world'
+      end
+    SCARPE_APP
+      the_app = self
+      bind_display_event(event_name: "run") do
+        TEST_DATA[:got_here] = true
+        the_app.destroy
+      end
+    TEST_CODE
+    assert_equal true, TEST_DATA[:got_here]
+  end
+
+  def test_first_heartbeat
+    test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
+      Scarpe.app do
+        para 'hello world'
+      end
+    SCARPE_APP
+      the_app = self
+      on_next_heartbeat do
+        TEST_DATA[:got_here] = true
+        the_app.destroy
+      end
+    TEST_CODE
+    assert_equal true, TEST_DATA[:got_here]
+  end
+
+  def test_para_replace
+    test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
+      Scarpe.app do
+        para 'hello world'
+      end
+    SCARPE_APP
+      the_app = self
+      para = nil
+      # During init, no widgets have yet been created. So that's too early to find our para.
+      on_next_heartbeat do
+        para = find_widgets_by(Scarpe::Para)[0]
+        para.replace("goodbye world")
+
+        # A replace doesn't actually take a hearbeat to happen, but we're testing event handling.
+        on_next_heartbeat do
+          if para.text_items == ["goodbye world"]
+            TEST_DATA[:got_here] = true
+            the_app.destroy
+          else
+            raise "Expected para.text_children to equal ['goodbye world']!"
+          end
+        end
+      end
+    TEST_CODE
+    assert_equal true, TEST_DATA[:got_here]
+  end
+
+  def test_the_test_block
+    TEST_DATA[:the_test] = self
+    @got_here = false
+    test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
+      Scarpe.app do
+        para 'hello world'
+      end
+    SCARPE_APP
+      the_app = self
+      para = nil
+      # During init, no widgets have yet been created. So that's too early to find our para.
+      on_next_heartbeat do
+        para = find_widgets_by(Scarpe::Para)[0]
+        para.replace("goodbye world")
+
+        TEST_DATA[:the_test].instance_eval do
+          @got_here = true
+        end
+        the_app.destroy
+      end
+    TEST_CODE
+    assert_equal true, @got_here
+  end
+end

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -2,12 +2,80 @@
 
 require "test_helper"
 
-# Going to need to rewrite this, or at a minimum heavily modify it :-(
-__END__
+# This method of testing starts up a Scarpe app with no display service
+# that runs in the same process as the test.
+class TestNoDisplayPara < Minitest::Test
+  class << self
+    attr_accessor :ret_val
+  end
+
+  def setup
+    TestNoDisplayPara.ret_val = nil
+  end
+
+  def test_para_text_children
+    test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
+      Scarpe.app do
+        para "Testing test test. ",
+          "Breadsticks. ",
+          "Breadsticks. ",
+          "Breadsticks. ",
+          "Very good."
+      end
+    SCARPE_APP
+      the_app = self
+      # During init, no widgets have yet been created. So that's too early to find our para.
+      on_next_heartbeat do
+        para = find_widgets_by(Scarpe::Para)[0]
+        TestNoDisplayPara.ret_val = para.text_items
+        the_app.destroy
+      end
+    TEST_CODE
+    assert_equal ["Testing test test. ", "Breadsticks. ", "Breadsticks. ", "Breadsticks. ", "Very good."], TestNoDisplayPara.ret_val
+  end
+
+  def test_para_replace
+    test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
+      Scarpe.app do
+        para 'hello world'
+      end
+    SCARPE_APP
+      the_app = self
+      # During init, no widgets have yet been created. So that's too early to find our para.
+      on_next_heartbeat do
+        para = find_widgets_by(Scarpe::Para)[0]
+        para.replace("goodbye world")
+
+        if para.text_items == ["goodbye world"]
+          TestNoDisplayPara.ret_val = true
+          the_app.destroy
+        else
+          raise "Expected para.text_children to equal ['goodbye world']!"
+        end
+      end
+    TEST_CODE
+    assert_equal true, TestNoDisplayPara.ret_val
+  end
+end
 
 class TestWebviewPara < Minitest::Test
+  def setup
+    @default_properties = {
+      "shoes_linkable_id" => 1,
+      "text_items" => ["Hello World"],
+      "stroke" => nil,
+      "size" => :para,
+      "html_attributes" => {},
+    }
+    Scarpe::DisplayService.full_reset!
+  end
+
+  def teardown
+    Scarpe::DisplayService.full_reset!
+  end
+
   def test_renders_paragraph
-    para = Scarpe::WebviewPara.new("Hello World")
+    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => ["Hello World"]))
     html_id = para.html_id
 
     assert_html para.to_html, :p, id: html_id, style: "font-size:12px" do
@@ -16,13 +84,14 @@ class TestWebviewPara < Minitest::Test
   end
 
   def test_renders_paragraph_with_collection_of_arguments
-    para = Scarpe::WebviewPara.new(
+    items = [
       "Testing test test. ",
       "Breadsticks. ",
       "Breadsticks. ",
       "Breadsticks. ",
       "Very good.",
-    )
+    ]
+    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => items))
 
     assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
       "Testing test test. Breadsticks. Breadsticks. Breadsticks. Very good."
@@ -30,23 +99,24 @@ class TestWebviewPara < Minitest::Test
   end
 
   def test_renders_a_magenta_paragraph
-    para = Scarpe::WebviewPara.new("Hello World", stroke: :magenta)
+    para = Scarpe::WebviewPara.new(@default_properties.merge("stroke" => "magenta"))
 
     assert_html para.to_html, :p, id: para.html_id, style: "color:magenta;font-size:12px" do
       "Hello World"
     end
   end
 
-  def test_renders_a_blue_paragraph_with_class_attribute
-    para = Scarpe::WebviewPara.new("Hello World", class: :sea, stroke: :blue)
-
-    assert_html para.to_html, :p, class: "sea", id: para.html_id, style: "color:blue;font-size:12px" do
-      "Hello World"
-    end
-  end
+  # What do we do about HTML class attributes? I'm assuming that's not Shoes-standard...
+  #def test_renders_a_blue_paragraph_with_class_attribute
+  #  para = Scarpe::WebviewPara.new(@default_properties.merge("class" => "sea", "stroke" => "blue"))
+  #
+  #  assert_html para.to_html, :p, class: "sea", id: para.html_id, style: "color:blue;font-size:12px" do
+  #    "Hello World"
+  #  end
+  #end
 
   def test_renders_paragraph_with_size_number
-    para = Scarpe::WebviewPara.new("Oh, to fling and be flung", size: 48)
+    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => ["Oh, to fling and be flung"], "size" => 48))
 
     assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
       "Oh, to fling and be flung"
@@ -54,7 +124,7 @@ class TestWebviewPara < Minitest::Test
   end
 
   def test_renders_paragraph_with_size_symbol
-    para = Scarpe::WebviewPara.new("Oh, to fling and be flung", size: :banner)
+    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => ["Oh, to fling and be flung"], "size" => :banner))
 
     assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
       "Oh, to fling and be flung"
@@ -62,46 +132,46 @@ class TestWebviewPara < Minitest::Test
   end
 
   def test_replace_children
-    stub_document_root
+    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => ["Oh, to fling and be flung"], "size" => :banner))
+    mocked_html_element = Minitest::Mock.new
+    mocked_html_element.expect :inner_html=, nil, [String]
+    para.stub :html_element, mocked_html_element do
+      # We used 1 as the shoes_linkable_id in the properties data above
+      para.send_shoes_event({ "text_items" => [ "Oh, to be flung and to fling" ] }, event_name: "prop_change", target: 1)
 
-    para = Scarpe::WebviewPara.new("Oh, to fling and be flung", size: :banner)
-
-    para.replace("Oh, to be flung and to fling")
-
-    assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
-      "Oh, to be flung and to fling"
+      assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
+        "Oh, to be flung and to fling"
+      end
     end
+    mocked_html_element.verify
   end
 
   def test_children_can_be_text_widgets
-    strong = Scarpe::Strong.new("I am strong")
-    para = Scarpe::WebviewPara.new(strong)
-
-    assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
-      strong.to_html
+    strong = Scarpe::WebviewStrong.new("content" => "I am strong", "shoes_linkable_id" => 2)
+    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => [strong]))
+    para.stub :items_to_display_children, [strong], [2] do
+      assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
+        strong.to_html
+      end
     end
   end
 
   def test_can_replace_widgets_with_other_widgets
-    stub_document_root
+    strong = Scarpe::WebviewStrong.new("content" => "I am strong", "shoes_linkable_id" => 2)
+    em = Scarpe::WebviewEm.new("content" => "I am em", "shoes_linkable_id" => 3)
+    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => [strong]))
+    mocked_html_element = Minitest::Mock.new
+    mocked_html_element.expect :inner_html=, nil, [String]
 
-    strong = Scarpe::Strong.new("I am strong")
-    em = Scarpe::Strong.new("I am em")
-    para = Scarpe::WebviewPara.new(strong)
-
-    para.replace(em)
-
-    assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
-      em.to_html
+    para.stub :html_element, mocked_html_element do
+      para.stub :items_to_display_children, [em], [3] do
+        # Linkable id 3 is em
+        para.send_shoes_event({ "text_items" => [ 3 ] }, event_name: "prop_change", target: 1)
+        assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
+          em.to_html
+        end
+      end
     end
-  end
-
-  private
-
-  def stub_document_root
-    doc_root = Minitest::Mock.new
-    wrangler = Minitest::Mock.new
-    doc_root.expect :get_element_wrangler, wrangler, [String]
-    wrangler.expect :inner_html=, nil, [String]
+    mocked_html_element.verify
   end
 end

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -31,7 +31,8 @@ class TestNoDisplayPara < Minitest::Test
         the_app.destroy
       end
     TEST_CODE
-    assert_equal ["Testing test test. ", "Breadsticks. ", "Breadsticks. ", "Breadsticks. ", "Very good."], TestNoDisplayPara.ret_val
+    assert_equal ["Testing test test. ", "Breadsticks. ", "Breadsticks. ", "Breadsticks. ", "Very good."],
+      TestNoDisplayPara.ret_val
   end
 
   def test_para_replace
@@ -107,16 +108,19 @@ class TestWebviewPara < Minitest::Test
   end
 
   # What do we do about HTML class attributes? I'm assuming that's not Shoes-standard...
-  #def test_renders_a_blue_paragraph_with_class_attribute
-  #  para = Scarpe::WebviewPara.new(@default_properties.merge("class" => "sea", "stroke" => "blue"))
+  # def test_renders_a_blue_paragraph_with_class_attribute
+  #   para = Scarpe::WebviewPara.new(@default_properties.merge("class" => "sea", "stroke" => "blue"))
   #
-  #  assert_html para.to_html, :p, class: "sea", id: para.html_id, style: "color:blue;font-size:12px" do
-  #    "Hello World"
-  #  end
-  #end
+  #   assert_html para.to_html, :p, class: "sea", id: para.html_id, style: "color:blue;font-size:12px" do
+  #     "Hello World"
+  #   end
+  # end
 
   def test_renders_paragraph_with_size_number
-    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => ["Oh, to fling and be flung"], "size" => 48))
+    para = Scarpe::WebviewPara.new(@default_properties.merge(
+      "text_items" => ["Oh, to fling and be flung"],
+      "size" => 48,
+    ))
 
     assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
       "Oh, to fling and be flung"
@@ -124,7 +128,10 @@ class TestWebviewPara < Minitest::Test
   end
 
   def test_renders_paragraph_with_size_symbol
-    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => ["Oh, to fling and be flung"], "size" => :banner))
+    para = Scarpe::WebviewPara.new(@default_properties.merge(
+      "text_items" => ["Oh, to fling and be flung"],
+      "size" => :banner,
+    ))
 
     assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
       "Oh, to fling and be flung"
@@ -132,12 +139,19 @@ class TestWebviewPara < Minitest::Test
   end
 
   def test_replace_children
-    para = Scarpe::WebviewPara.new(@default_properties.merge("text_items" => ["Oh, to fling and be flung"], "size" => :banner))
+    para = Scarpe::WebviewPara.new(@default_properties.merge(
+      "text_items" => ["Oh, to fling and be flung"],
+      "size" => :banner,
+    ))
     mocked_html_element = Minitest::Mock.new
     mocked_html_element.expect :inner_html=, nil, [String]
     para.stub :html_element, mocked_html_element do
       # We used 1 as the shoes_linkable_id in the properties data above
-      para.send_shoes_event({ "text_items" => [ "Oh, to be flung and to fling" ] }, event_name: "prop_change", target: 1)
+      para.send_shoes_event(
+        { "text_items" => ["Oh, to be flung and to fling"] },
+        event_name: "prop_change",
+        target: 1,
+      )
 
       assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
         "Oh, to be flung and to fling"
@@ -166,7 +180,7 @@ class TestWebviewPara < Minitest::Test
     para.stub :html_element, mocked_html_element do
       para.stub :items_to_display_children, [em], [3] do
         # Linkable id 3 is em
-        para.send_shoes_event({ "text_items" => [ 3 ] }, event_name: "prop_change", target: 1)
+        para.send_shoes_event({ "text_items" => [3] }, event_name: "prop_change", target: 1)
         assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
           em.to_html
         end


### PR DESCRIPTION
This is relative to PR #125.

This adds back mocking-based WebviewPara tests, and also adds some no-display-service testing.

Basically, it's not all the testing back (yet), but it shows how to test any component with the new separated-display stuff.