### PR TITLE
edit_line and edit_box editable without error and remove --no-shoes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ From the button example:
 
 ### Quickstart
 
+Scarpe requires [Ruby 3.2](https://www.ruby-lang.org/en/downloads/) or higher! use `rvm` or `rbenv` for version control
+
 This is where most of the action is happening right now, and to have the full Scarpe experience _today_ this is probably what you want to do.
 
 ```

--- a/examples/sleepless.rb
+++ b/examples/sleepless.rb
@@ -3,10 +3,22 @@ Shoes.app title: "Sleepless", width: 80, height: 120 do
   @note = para "😪"
   @push.click {
     if @pid.nil?
-      @pid = spawn("caffeinate -d")
+      if RUBY_PLATFORM =~ /darwin/
+        @pid = spawn("caffeinate -d")
+      elsif RUBY_PLATFORM =~ /linux/
+        @pid = spawn("xset s off -dpms")
+      elsif RUBY_PLATFORM =~ /win32|win64|\.NET/
+        @pid = spawn("powercfg -change -monitor-timeout-ac 0")
+      end
       @note.replace "😳"
     else
-      Process.kill 9, @pid
+      if RUBY_PLATFORM =~ /darwin/
+        system("kill #{@pid}")
+      elsif RUBY_PLATFORM =~ /linux/
+        system("kill -9 #{@pid}")
+      elsif RUBY_PLATFORM =~ /win32|win64|\.NET/
+        system("taskkill /pid #{@pid} /f")
+      end
       @pid = nil
       @note.replace "😪"
     end

--- a/exe/scarpe
+++ b/exe/scarpe
@@ -1,14 +1,12 @@
 #!/usr/bin/env ruby
 
 use_dev = ARGV.delete("--dev") ? true : false
-use_shoes = ARGV.delete("--no-shoes") ? false : true
 
 if ARGV.length != 1
     puts <<USAGE
 Usage: scarpe [OPTIONS] <scarpe app file>
   Options:
       --dev                          Use development local scarpe, not an installed gem
-      --no-shoes                     Do not define a Shoes alias for Shoes compatibility
 USAGE
     exit -1
 end
@@ -20,9 +18,7 @@ end
 
 require "scarpe"
 
-if use_shoes
-    Shoes = Scarpe
-end
+Shoes = Scarpe unless defined?(Shoes)
 
 # Run the Scarpe app file
 load ARGV[0]

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -621,19 +621,19 @@ class Scarpe
       end
 
       def value=(new_value)
-        @webwrangler.dom_change("document.getElementById(#{html_id}).value = #{new_value}; true")
+        @webwrangler.dom_change("document.getElementById('" + html_id.to_s + "').value = '" + new_value.to_s + "'; true")
       end
 
       def inner_text=(new_text)
-        @webwrangler.dom_change("document.getElementById(#{html_id}).innerText = '#{new_text}'; true")
+        @webwrangler.dom_change("document.getElementById('" + html_id.to_s + "').innerText = '" + new_text.to_s + "'; true")
       end
 
       def inner_html=(new_html)
-        @webwrangler.dom_change("document.getElementById(#{html_id}).innerHTML = `#{new_html}`; true")
+        @webwrangler.dom_change("document.getElementById(\"" + html_id.to_s + "\").innerHTML = `" + new_html.to_s + "`; true")
       end
 
       def remove
-        @webwrangler.dom_change("document.getElementById(#{html_id}).remove(); true")
+        @webwrangler.dom_change("document.getElementById('" + html_id.to_s + "').remove(); true")
       end
     end
   end

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -621,19 +621,19 @@ class Scarpe
       end
 
       def value=(new_value)
-        @webwrangler.dom_change("document.getElementById('" + html_id.to_s + "').value = '" + new_value.to_s + "'; true")
+        @webwrangler.dom_change("document.getElementById('" + html_id + "').value = '" + new_value + "'; true")
       end
 
       def inner_text=(new_text)
-        @webwrangler.dom_change("document.getElementById('" + html_id.to_s + "').innerText = '" + new_text.to_s + "'; true")
+        @webwrangler.dom_change("document.getElementById('" + html_id + "').innerText = '" + new_text + "'; true")
       end
 
       def inner_html=(new_html)
-        @webwrangler.dom_change("document.getElementById(\"" + html_id.to_s + "\").innerHTML = `" + new_html.to_s + "`; true")
+        @webwrangler.dom_change("document.getElementById(\"" + html_id + "\").innerHTML = `" + new_html + "`; true")
       end
 
       def remove
-        @webwrangler.dom_change("document.getElementById('" + html_id.to_s + "').remove(); true")
+        @webwrangler.dom_change("document.getElementById('" + html_id + "').remove(); true")
       end
     end
   end


### PR DESCRIPTION
related to #129 
updated Readme to say we need ruby 3.2.0 as its a possible error user will see if he directly go `bundle install` with ruby version less than 3.2

regarding changes in scrape.rb  even when i remove that code i am getting error saying i need ruby 3.2 so do we need it?


```
scarpe [ main][!?][💎 v3.1.2]
❯ bundle install
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Resolving dependencies...
Could not find compatible versions

Because every version of scarpe depends on Ruby >= 3.2.0
  and Gemfile depends on scarpe >= 0,
  Ruby >= 3.2.0 is required.
So, because current Ruby version is = 3.1.2,
  version solving has failed.
```

after that i updated gemfile to use ruby>=3.2

```
scarpe [ main][!?][💎 v3.1.2]
❯ bundle install
Your Ruby version is 3.1.2, but your Gemfile specified >= 3.2
```
