### PR TITLE
Remove Ruby-LSP from the Bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,4 @@ gem "minitest", "~> 5.0"
 
 gem "rubocop", "~> 1.21"
 
-gem "ruby-lsp", "~> 0.3.8", group: :development
-
 gem "rubocop-shopify", group: :development


### PR DESCRIPTION
Great news. The latest version of ruby-lsp doesn't need to be in our Gemfile.

Let's remove it.