### PR TITLE
Title and Resize for GLibUI plus defaults

### DIFF
--- a/lib/scarpe/glibui/README.md
+++ b/lib/scarpe/glibui/README.md
@@ -25,3 +25,8 @@ window {
   }
 }.show
 ```
+
+# GLibUI Finished Examples
+
+* /examples/hello_world.rb
+* /examples/title_and_resize.rb

--- a/lib/scarpe/glibui/app.rb
+++ b/lib/scarpe/glibui/app.rb
@@ -14,7 +14,7 @@ class Scarpe
       super
 
       bind_display_event(event_name: "run") do
-        code = @document_root.display
+        code = @document_root.display(properties)
         puts code
         # This is for if I want to confirm textual output. But not actually fire up the service.
         exit if ENV["NO_RUN"]

--- a/lib/scarpe/glibui/document_root.rb
+++ b/lib/scarpe/glibui/document_root.rb
@@ -8,13 +8,12 @@ class Scarpe
 
     def initialize(properties)
       @callbacks = {}
-
       super
     end
 
-    def display
+    def display(properties = {})
       <<~GTEXT
-        window {
+        window("#{properties["title"] || "Scarpe with GlimmerLibUI"}", #{properties["width"] || 640}, #{properties["height"] || 480}) {
           area {
             #{@children.map(&:display).join}
           }


### PR DESCRIPTION
## Hello world is not enough!

This PR takes GlimmerLibUI display service to the next level. It gives you:

* Default height, width, title
* Ability to set height, width, title
* A checklist in our markdown file to show what examples this display service is running
  * Not our longrun plan but good enough for now

## Screenshots!

<img width="931" alt="Screenshot 2023-03-29 at 19 10 05" src="https://user-images.githubusercontent.com/7865030/228631021-3d60d396-61ab-4669-b526-80676a74424c.png">

<img width="1043" alt="Screenshot 2023-03-29 at 19 14 10" src="https://user-images.githubusercontent.com/7865030/228631036-c0fca009-cc22-4fc4-bc74-8fcc847b98d1.png">

## Tophat it yourself:

```
SCARPE_DISPLAY_SERVICES=Scarpe::GlimmerLibUIDisplayService ./exe/scarpe examples/title_and_resize.rb --dev
```

## For Reviewers

@noahgibbs this is slightly different because no webwrangler. Do you like where I'm setting properties?