### PR TITLE
Use the Shoes.app syntax over Scarpe.app, everywhere

### DIFF
--- a/examples/coffee.rb
+++ b/examples/coffee.rb
@@ -1,6 +1,4 @@
-require "scarpe"
-
-Scarpe.app title: "Sleepless", width: 80, height: 120 do
+Shoes.app title: "Sleepless", width: 80, height: 120 do
   @push = button "☕️"
   @note = para "😪"
   @push.click {

--- a/examples/flow.rb
+++ b/examples/flow.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "scarpe"
-
-Scarpe.app(title: "Flow example") do
+Shoes.app(title: "Flow example") do
   flow do
     %w[One Two Three Four Five Six Seven Eight].each do |num|
       stack width: 100 do

--- a/examples/image/clickable_image.rb
+++ b/examples/image/clickable_image.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "scarpe"
-
-Scarpe.app do
+Shoes.app do
   image "http://shoesrb.com/manual/static/shoes-icon.png", click: "http://github.com/schwad/scarpe"
 end

--- a/examples/link.rb
+++ b/examples/link.rb
@@ -1,6 +1,4 @@
-require "scarpe"
-
-Scarpe.app do
+Shoes.app do
   def collapsed
     @para = para(
       "'Scarpe' means shoes in Italian. 'Scarpe' also means Shoes in...",

--- a/examples/para/strong.rb
+++ b/examples/para/strong.rb
@@ -1,5 +1,3 @@
-require "scarpe"
-
-Scarpe.app do
+Shoes.app do
   para "Hello world, I'm ", strong("strong")
 end

--- a/examples/para_text_widgets.rb
+++ b/examples/para_text_widgets.rb
@@ -1,4 +1,4 @@
-Scarpe.app do
+Shoes.app do
   para "This is simple."
   para "This has ", em("emphasis"), " and great ", strong("strength"), " and ", code("coolness"), "."
 end

--- a/examples/skip_ci/parrot.rb
+++ b/examples/skip_ci/parrot.rb
@@ -1,8 +1,6 @@
-require "scarpe"
-
 # This example is skipped on CI because it makes system calls
 
-Scarpe.app do
+Shoes.app do
   para "What do you want me to say?"
   @phrase = edit_line("Soon it was a comet and, soon, a blazing monstrosity.", width: "100%")
 

--- a/examples/stack/background.rb
+++ b/examples/stack/background.rb
@@ -1,6 +1,4 @@
-require "scarpe"
-
-Scarpe.app do
+Shoes.app do
   stack width: 0.33 do
     background "purple"
     button "a button"

--- a/examples/stack/border.rb
+++ b/examples/stack/border.rb
@@ -1,6 +1,4 @@
-require "scarpe"
-
-Scarpe.app do
+Shoes.app do
   stack do
     border "red", strokewidth: 5, curve: 12
     para "Curved Red"

--- a/examples/stack/gradients.rb
+++ b/examples/stack/gradients.rb
@@ -1,6 +1,4 @@
-require "scarpe"
-
-Scarpe.app do
+Shoes.app do
   stack height: 200, width: 200 do
     border "#090979".."#ac033d", strokewidth: 15
     background "#ac033d".."#090979"

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class TestControlInterface < Minitest::Test
   def test_trivial_async_assert
     test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
-      Scarpe.app do
+      Shoes.app do
         para "Hello World"
       end
     SCARPE_APP
@@ -18,7 +18,7 @@ class TestControlInterface < Minitest::Test
 
   def test_assert_dom_html
     test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para "Hello World"
       end
     SCARPE_APP
@@ -32,7 +32,7 @@ class TestControlInterface < Minitest::Test
 
   def test_assert_widget
     test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para "Hello World"
       end
     SCARPE_APP
@@ -46,7 +46,7 @@ class TestControlInterface < Minitest::Test
 
   def test_assert_dom_html_update
     test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para "Hello World"
       end
     SCARPE_APP

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,11 @@ Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 # We're going to be passing a fair bit of data back and forth across eval boundaries.
 TEST_DATA = {}
 
+# Soon this should go in the framework, not here
+unless Object.constants.include?(:Shoes)
+  Shoes = Scarpe
+end
+
 # Docs for our Webview lib: https://github.com/Maaarcocr/webview_ruby
 
 def with_tempfile(prefix, contents)

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -14,7 +14,7 @@ class TestNoDisplayImage < Minitest::Test
 
   def test_image
     test_scarpe_code_no_display(<<~SCARPE_APP, <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         image #{@url.inspect}
       end
     SCARPE_APP

--- a/test/test_no_display.rb
+++ b/test/test_no_display.rb
@@ -13,7 +13,7 @@ class TestScarpeNoDisplay < Minitest::Test
   # make sure the test code actually gets called at all
   def test_app_created
     test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para 'hello world'
       end
     SCARPE_APP
@@ -28,7 +28,7 @@ class TestScarpeNoDisplay < Minitest::Test
 
   def test_run_event
     test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para 'hello world'
       end
     SCARPE_APP
@@ -43,7 +43,7 @@ class TestScarpeNoDisplay < Minitest::Test
 
   def test_first_heartbeat
     test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para 'hello world'
       end
     SCARPE_APP
@@ -58,7 +58,7 @@ class TestScarpeNoDisplay < Minitest::Test
 
   def test_para_replace
     test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para 'hello world'
       end
     SCARPE_APP
@@ -87,7 +87,7 @@ class TestScarpeNoDisplay < Minitest::Test
     TEST_DATA[:the_test] = self
     @got_here = false
     test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para 'hello world'
       end
     SCARPE_APP

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -13,7 +13,7 @@ class TestNoDisplayPara < Minitest::Test
 
   def test_para_text_children
     test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para "Testing test test. ",
           "Breadsticks. ",
           "Breadsticks. ",
@@ -35,7 +35,7 @@ class TestNoDisplayPara < Minitest::Test
 
   def test_para_replace
     test_scarpe_code_no_display(<<~'SCARPE_APP', <<~'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
         para 'hello world'
       end
     SCARPE_APP

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -9,7 +9,7 @@ class TestScarpe < Minitest::Test
 
   def test_hello_world_app
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      Scarpe.app do
+      Shoes.app do
         para "Hello World"
       end
     SCARPE_APP
@@ -17,7 +17,7 @@ class TestScarpe < Minitest::Test
 
   def test_app_timeout
     test_scarpe_code(<<-'SCARPE_APP', timeout: 0.1, allow_fail: true)
-      Scarpe.app do
+      Shoes.app do
         para "Just waiting for this to time out"
       end
     SCARPE_APP
@@ -25,7 +25,7 @@ class TestScarpe < Minitest::Test
 
   def test_button_app
     test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
-      Scarpe.app do
+      Shoes.app do
         @push = button "Push me", width: 200, height: 50, top: 109, left: 132
         @note = para "Nothing pushed so far"
         @push.click { @note.replace "Aha! Click!" }
@@ -36,7 +36,7 @@ class TestScarpe < Minitest::Test
 
   def test_text_widgets
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      Scarpe.app do
+      Shoes.app do
         para "This is plain."
         para "This has ", em("emphasis"), " and great ", strong("strength"), " and ", code("coolness"), "."
       end
@@ -45,7 +45,7 @@ class TestScarpe < Minitest::Test
 
   def test_button_args_optional
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      Scarpe.app do
+      Shoes.app do
         button "Push me"
       end
     SCARPE_APP
@@ -53,7 +53,7 @@ class TestScarpe < Minitest::Test
 
   def test_stack_args_optional
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      Scarpe.app do
+      Shoes.app do
         stack do
           button "Push me"
         end
@@ -63,7 +63,7 @@ class TestScarpe < Minitest::Test
 
   def test_widgets_exist
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      Scarpe.app do
+      Shoes.app do
         stack do
           para "Here I am"
           button "Push me"


### PR DESCRIPTION
This alters all tests and all examples to use Shoes.app, not Scarpe.app. We're supporting the Shoes API, so we should be using that as the name, everywhere.

I had to add an alias for Shoes to the NoDisplay tests, which weren't using exe/scarpe. Yup, I've had some bad habits because of the Shoes alias not being part of our framework -- time to start fixing them :-)