### PR TITLE
The display service should not use Scarpe:: prefix for widget class names

### DIFF
--- a/lib/scarpe/glibui/local_display.rb
+++ b/lib/scarpe/glibui/local_display.rb
@@ -20,7 +20,7 @@ class Scarpe
     end
 
     def create_display_widget_for(widget_class_name, widget_id, properties)
-      if widget_class_name == "Scarpe::App"
+      if widget_class_name == "App"
         unless @doc_root
           raise "GlimmerLibUIDocumentRoot is supposed to be created before GlimmerLibUIApp!"
         end
@@ -39,7 +39,7 @@ class Scarpe
       display_widget = display_class.new(properties)
       set_widget_pairing(widget_id, display_widget)
 
-      if widget_class_name == "Scarpe::DocumentRoot"
+      if widget_class_name == "DocumentRoot"
         @doc_root = display_widget
       end
 

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -88,10 +88,11 @@ class Scarpe
     def create_display_widget
       # We want to support multiple, or zero, display services later. Thus, we link via events and
       # DisplayService objects.
+      klass_name = self.class.name.delete_prefix("Scarpe::").delete_prefix("Shoes::")
       DisplayService.display_services.each do |display_service|
-        # We DO NOT save a reference to our display widget(s). If they just disappear later, we'll cheerfully
+        # We SHOULD NOT save a reference to our display widget(s). If they just disappear later, we'll cheerfully
         # keep ticking along and not complain.
-        display_service.create_display_widget_for(self.class.name, self.linkable_id, display_properties)
+        display_service.create_display_widget_for(klass_name, self.linkable_id, display_properties)
       end
     end
 

--- a/lib/scarpe/wv/webview_local_display.rb
+++ b/lib/scarpe/wv/webview_local_display.rb
@@ -29,7 +29,7 @@ class Scarpe
     end
 
     def create_display_widget_for(widget_class_name, widget_id, properties)
-      if widget_class_name == "Scarpe::App"
+      if widget_class_name == "App"
         unless @doc_root
           raise "WebviewDocumentRoot is supposed to be created before WebviewApp!"
         end
@@ -51,7 +51,7 @@ class Scarpe
       display_widget = display_class.new(properties)
       set_widget_pairing(widget_id, display_widget)
 
-      if widget_class_name == "Scarpe::DocumentRoot"
+      if widget_class_name == "DocumentRoot"
         # WebviewDocumentRoot is created before WebviewApp. Mostly doc_root is just like any other widget,
         # but we'll want a reference to it when we create WebviewApp.
         @doc_root = display_widget

--- a/lib/scarpe/wv/widget.rb
+++ b/lib/scarpe/wv/widget.rb
@@ -4,7 +4,7 @@ class Scarpe
   class WebviewWidget < DisplayService::Linkable
     class << self
       def display_class_for(scarpe_class_name)
-        scarpe_class = Object.const_get(scarpe_class_name)
+        scarpe_class = Scarpe.const_get(scarpe_class_name)
         unless scarpe_class.ancestors.include?(Scarpe::DisplayService::Linkable)
           raise "Scarpe Webview can only get display classes for Scarpe " +
             "linkable widgets, not #{scarpe_class_name.inspect}!"


### PR DESCRIPTION
We're planning to change Scarpe:: to Shoes:: for those widgets. But the prefix is entirely redundant, so we should remove it instead of changing it.