### PR TITLE
Add signal trap to stop Scarpe app in case of interruption

### DIFF
--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -34,6 +34,11 @@ class Scarpe
       create_display_widget
 
       @app_code_body = app_code_body
+
+      Signal.trap("INT") do
+        puts "\nStopping Scarpe app..."
+        destroy
+      end
     end
 
     def init


### PR DESCRIPTION
After running some examples from the terminal I realized that I can only quit the running app when I click on the (red) close button on the window itself, which I personally found a little unintuitive (especially in development).

That's why this pull request adds a signal trap to stop the Scarpe app when the `SIGINT` signal is received, with this you can easily stop the running Scarpe app from the terminal via <kbd>Ctrl+C</kbd>.

Feel free to close this if it was intentionally left out.


