### PR TITLE
Support #hide and #show for `para`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Huh. Great question. Right now we have a few key things we want to achieve. The 
 
 ![](https://geps.dev/progress/16?dangerColor=800000&warningColor=ff9900&successColor=006600)
 
-__40/256__
+__41/257__
 
 ### GlimmerLibUI Display Service Examples Passing
 
 ![](https://geps.dev/progress/2?dangerColor=800000&warningColor=ff9900&successColor=006600)
 
-__4/256__
+__4/257__
 
 ## Teach me more about Shoes, the DSL, what it is and why it is amazing
 

--- a/examples/para/hide_and_show.rb
+++ b/examples/para/hide_and_show.rb
@@ -1,0 +1,9 @@
+Shoes.app do
+  @banner = banner 'This is a big banner!'
+  para link("Hide banner") {
+    @banner.hide
+  }
+  para link("Show banner") {
+    @banner.show
+  }
+end

--- a/examples/para/hide_and_show.rb
+++ b/examples/para/hide_and_show.rb
@@ -1,5 +1,5 @@
 Shoes.app do
-  @banner = banner 'This is a big banner!'
+  @banner = banner "This is a big banner!", hidden: true
   para link("Hide banner") {
     @banner.hide
   }

--- a/lib/scarpe/para.rb
+++ b/lib/scarpe/para.rb
@@ -17,6 +17,7 @@ class Scarpe
       # Text_children alternates strings and TextWidgets, so we can't just pass
       # it as a display property. It won't serialize.
       @text_items = text_children_to_items(@text_children)
+      @hidden_text_items = []
 
       @html_attributes = html_attributes || {}
 
@@ -34,6 +35,22 @@ class Scarpe
 
       # This should signal the display widget to change
       self.text_items = text_children_to_items(@text_children)
+    end
+
+    def hide
+      # idempotent
+      return unless @hidden_text_items.empty?
+
+      @hidden_text_items = self.text_items
+      self.text_items = []
+    end
+
+    def show
+      # idempotent
+      return unless self.text_items.empty?
+
+      self.text_items = @hidden_text_items
+      @hidden_text_items = []
     end
   end
 

--- a/lib/scarpe/para.rb
+++ b/lib/scarpe/para.rb
@@ -10,14 +10,19 @@ class Scarpe
       end
     end
 
-    display_properties :text_items, :stroke, :size, :html_attributes
+    display_properties :text_items, :stroke, :size, :html_attributes, :hidden
 
-    def initialize(*args, stroke: nil, size: :para, **html_attributes)
+    def initialize(*args, stroke: nil, size: :para, hidden: false, **html_attributes)
       @text_children = args || []
-      # Text_children alternates strings and TextWidgets, so we can't just pass
-      # it as a display property. It won't serialize.
-      @text_items = text_children_to_items(@text_children)
-      @hidden_text_items = []
+      if hidden
+        @hidden_text_items = text_children_to_items(@text_children)
+        @text_items = []
+      else
+        # Text_children alternates strings and TextWidgets, so we can't just pass
+        # it as a display property. It won't serialize.
+        @text_items = text_children_to_items(@text_children)
+        @hidden_text_items = []
+      end
 
       @html_attributes = html_attributes || {}
 


### PR DESCRIPTION
This was fun to get back into writing scarpe features!

Run the new example below to see it work. 

First tried to implement hide in the webview display service, but realized we can implement this at the DSL level (and probably should!).

Kinda wanted to implement a hide for all widgets but might need to do it for each one. No biggie. 

Anyways, some new functionality! enjoy!