### PR TITLE
Add LoggedWrapper class, and use it for Webview API if debug

### DIFF
--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -50,7 +50,8 @@ class Scarpe
 
       # For now, always allow inspect element
       @webview = WebviewRuby::Webview.new debug: true
-      @init_refs = {} # This might or might not be a temporary measure... Inits don't go away, normally.
+      @webview = Scarpe::LoggedWrapper.new(@webview, "WebviewAPI") if debug
+      @init_refs = {} # Inits don't go away so keep a reference to them
 
       @title = title
       @width = width


### PR DESCRIPTION
Hey, @schwad! Remember when we were talking about adapting display services and I said something like, "yeah, you could just log all the LibUI calls and then use that to write a different display service?"

That's kind of glib. I didn't say *how* you'd log all the calls. I've just added a logging wrapper object, so you can wrap e.g. a Webview instance in it and then automatically log all calls to it. But it would work for LibUI too.

You set a Scarpe log component with it, so if you want to turn logging on or off per-wrapper, you'd do it in the log config file (SCARPE_LOG_CONFIG).