### PR TITLE
WIP: limit max number and size of JS statement evals to Webview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test failure logs
-          path: logger/test_failure_*_out.log
+          path: logger/test_failure*.out.log
   linter:
     name: Linter
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Run tests
         run: CI_RUN='true' bundle exec rake test
       - name: upload test-fail logs
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           name: test failure logs

--- a/exe/scarpe
+++ b/exe/scarpe
@@ -30,8 +30,11 @@ def print_env
     Scarpe environment:
       #{env_or_default("SCARPE_DISPLAY_SERVICE", "(default)wv_local")}
       #{env_or_default("SCARPE_LOG_CONFIG", "(default)#{Scarpe::Log::DEFAULT_LOG_CONFIG.inspect}")}
+    Scarpe::WV environment:
       #{env_or_none("SCARPE_TEST_CONTROL")}
       #{env_or_none("SCARPE_TEST_RESULTS")}
+      #{env_or_default("SWV_MAX_MSG_BYTES", "(default)4096")}
+      #{env_or_default("SWV_MAX_MSG_STATEMENTS", "(default)10")}
     Ruby and shell environment:
       RUBY_DESCRIPTION: #{RUBY_DESCRIPTION.inspect}
       RUBY_PLATFORM: #{RUBY_PLATFORM.inspect}

--- a/lib/scarpe/logger.rb
+++ b/lib/scarpe/logger.rb
@@ -91,10 +91,15 @@ class Scarpe
       public
 
       def configure_logger(log_config)
+        if log_config.is_a?(String) && File.exist?(log_config)
+          log_config = JSON.load_file(log_config)
+        end
+
         log_config = freeze_log_config(log_config) unless log_config.nil?
         @current_log_config = log_config # Save a copy for later
 
         Logging.reset # Reset all Logging settings to defaults
+        Logging.reopen # For log-reconfig (e.g. test failures), often important to *not* store an open handle to a moved file
         return if log_config.nil?
 
         Logging.logger.root.appenders = [Logging.appenders.stdout]

--- a/lib/scarpe/wv/widget.rb
+++ b/lib/scarpe/wv/widget.rb
@@ -99,7 +99,7 @@ class Scarpe
     # Convert an [r, g, b, a] array to an HTML hex color code
     # Arrays support alpha. HTML hex does not. So premultiply.
     def rgb_to_hex(color)
-      return nil if color.nil?
+      return color if color.nil?
 
       r, g, b, a = *color
       if r.is_a?(Float)

--- a/test/test_colors.rb
+++ b/test/test_colors.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestColors < Minitest::Test
+class TestColors < ScarpeTest
   class Dummy
     include Scarpe::Colors
   end

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestControlInterface < ScarpeTest
+class TestControlInterface < LoggedScarpeTest
   def test_trivial_async_assert
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
       Shoes.app do

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -2,9 +2,9 @@
 
 require "test_helper"
 
-class TestControlInterface < Minitest::Test
+class TestControlInterface < ScarpeTest
   def test_trivial_async_assert
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
       Shoes.app do
         para "Hello World"
       end
@@ -17,7 +17,7 @@ class TestControlInterface < Minitest::Test
   end
 
   def test_assert_dom_html
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do
         para "Hello World"
       end
@@ -31,7 +31,7 @@ class TestControlInterface < Minitest::Test
   end
 
   def test_assert_widget
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do
         para "Hello World"
       end
@@ -45,7 +45,7 @@ class TestControlInterface < Minitest::Test
   end
 
   def test_assert_dom_html_update
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do
         para "Hello World"
       end

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -44,6 +44,8 @@ class TestControlInterface < ScarpeTest
     TEST_CODE
   end
 
+  # This test can occasionally still fail on CI -- need to replicate that and figure it out.
+  # Failure is a "returned no status code" in 2.9 seconds (long), which probably means a timeout.
   def test_assert_dom_html_update
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do

--- a/test/test_dimensions.rb
+++ b/test/test_dimensions.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestDimensions < Minitest::Test
+class TestDimensions < ScarpeTest
   def test_no_value_returns_nil
     assert_nil ::Scarpe::Dimensions.length(nil)
   end

--- a/test/test_edit_box.rb
+++ b/test/test_edit_box.rb
@@ -5,7 +5,7 @@ require "test_helper"
 # Going to need to rewrite this, or at a minimum heavily modify it :-(
 __END__
 
-class TestEditBox < Minitest::Test
+class TestEditBox < ScarpeTest
   def setup
     app = Minitest::Mock.new
     Scarpe::Widget.document_root = app

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestExamplesWithWebview < ScarpeTest
+class TestExamplesWithWebview < LoggedScarpeTest
   match_str = ENV["EXAMPLES_MATCHING"] || ""
 
   examples_to_test = Dir["examples/**/*.rb"]
@@ -13,7 +13,7 @@ class TestExamplesWithWebview < ScarpeTest
   examples_to_test.each do |example_filename|
     example = example_filename.gsub("/", "_").gsub("-", "_").gsub(/.rb\Z/, "")
     define_method("test_webview_#{example}") do
-      run_test_scarpe_app(example_filename, exit_immediately: true, test_name: example)
+      run_test_scarpe_app(example_filename, exit_immediately: true)
     end
   end
 end

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestExamplesWithWebview < Minitest::Test
+class TestExamplesWithWebview < ScarpeTest
   match_str = ENV["EXAMPLES_MATCHING"] || ""
 
   examples_to_test = Dir["examples/**/*.rb"]
@@ -13,7 +13,7 @@ class TestExamplesWithWebview < Minitest::Test
   examples_to_test.each do |example_filename|
     example = example_filename.gsub("/", "_").gsub("-", "_").gsub(/.rb\Z/, "")
     define_method("test_webview_#{example}") do
-      test_scarpe_app(example_filename, exit_immediately: true, test_name: example)
+      run_test_scarpe_app(example_filename, exit_immediately: true, test_name: example)
     end
   end
 end

--- a/test/test_flow.rb
+++ b/test/test_flow.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestWebviewFlow < Minitest::Test
+class TestWebviewFlow < ScarpeTest
   def test_it_accepts_a_height
     flow = Scarpe::WebviewFlow.new("width" => 7, "height" => 25, "margin" => 4, "padding" => 5, "shoes_linkable_id" => 1) do
       "fishes that flop"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,9 +14,6 @@ require "minitest/autorun"
 require "minitest/reporters"
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
-# We're going to be passing a fair bit of data back and forth across eval boundaries.
-TEST_DATA = {}
-
 # Soon this should go in the framework, not here
 unless Object.constants.include?(:Shoes)
   Shoes = Scarpe
@@ -24,201 +21,203 @@ end
 
 # Docs for our Webview lib: https://github.com/Maaarcocr/webview_ruby
 
-def with_tempfile(prefix, contents)
-  t = Tempfile.new(prefix)
-  t.write(contents)
-  t.flush # Make sure the contents are written out
+class ScarpeTest < Minitest::Test
+  def with_tempfile(prefix, contents)
+    t = Tempfile.new(prefix)
+    t.write(contents)
+    t.flush # Make sure the contents are written out
 
-  yield(t.path)
-ensure
-  t.close
-  t.unlink
-end
-
-# Temporarily set env vars for the block of code inside
-def with_env_vars(envs)
-  old_env = {}
-  envs.each do |k, v|
-    old_env[k] = ENV[k]
-    ENV[k] = v
+    yield(t.path)
+  ensure
+    t.close
+    t.unlink
   end
-  yield
-ensure
-  old_env.each { |k, v| ENV[k] = v }
-end
 
-SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
-TEST_OPTS = [:timeout, :allow_fail, :allow_timeout, :debug, :exit_immediately]
-
-def test_scarpe_code(scarpe_app_code, test_code: "", test_name: nil, **opts)
-  test_name ||= caller_locations[0].label
-
-  bad_opts = opts.keys - TEST_OPTS
-  raise "Bad options passed to test_scarpe_code: #{bad_opts.inspect}!" unless bad_opts.empty?
-
-  with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
-    test_scarpe_app(test_app_location, test_code:, test_name:, **opts)
-  end
-end
-
-LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
-# Using an instance variable doesn't work for ALREADY_SET_UP(etc) and I'm not sure why not
-ALREADY_SET_UP_TEST_FAILURES = { setup: false }
-TEST_SCARPE_LOG_CONFIG = File.expand_path("#{LOGGER_DIR}/scarpe_wv_test.json")
-log_out = JSON.load_file(TEST_SCARPE_LOG_CONFIG).values.map { |_level, locs| locs }
-TEST_SAVE_FILES = log_out.select { |s| s.start_with?("logger/") }.map { |s| s.gsub(%r{\Alogger\/}, "") }
-def set_up_test_failures
-  return if ALREADY_SET_UP_TEST_FAILURES[:setup]
-
-  ALREADY_SET_UP_TEST_FAILURES[:setup] = true
-  # Delete stale test failures, if any, before starting test run
-  Dir["#{LOGGER_DIR}/test_failure*.log"].each { |fn| File.unlink(fn) }
-
-  Minitest.after_run do
-    # Remove un-saved test logs
-    TEST_SAVE_FILES.each do |f|
-      path = "#{LOGGER_DIR}/#{f}"
-      File.unlink(path) if File.exist?(path)
+  # Temporarily set env vars for the block of code inside
+  def with_env_vars(envs)
+    old_env = {}
+    envs.each do |k, v|
+      old_env[k] = ENV[k]
+      ENV[k] = v
     end
+    yield
+  ensure
+    old_env.each { |k, v| ENV[k] = v }
+  end
 
-    # Print test failure logs to console for CI
-    unless Dir["#{LOGGER_DIR}/test_failure*_out.log"].empty?
-      puts "Some tests have failed! See #{LOGGER_DIR}/test_failure*_out.log for test logs!"
+  SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
+  TEST_OPTS = [:timeout, :allow_fail, :allow_timeout, :debug, :exit_immediately]
+
+  def run_test_scarpe_code(scarpe_app_code, test_code: "", test_name: nil, **opts)
+    test_name ||= caller_locations[0].label
+
+    bad_opts = opts.keys - TEST_OPTS
+    raise "Bad options passed to run_test_scarpe_code: #{bad_opts.inspect}!" unless bad_opts.empty?
+
+    with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
+      run_test_scarpe_app(test_app_location, test_code:, test_name:, **opts)
     end
   end
-end
 
-def logfail_out_loc(filepath, test_name:)
-  dir, filename = File.split(filepath)
-  all_exts = filename.split(".", 2)[1]
-  base = File.basename(filename, "." + all_exts)
+  LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
+  # Using an instance variable doesn't work for ALREADY_SET_UP(etc) and I'm not sure why not
+  ALREADY_SET_UP_TEST_FAILURES = { setup: false }
+  TEST_SCARPE_LOG_CONFIG = File.expand_path("#{LOGGER_DIR}/scarpe_wv_test.json")
+  log_out = JSON.load_file(TEST_SCARPE_LOG_CONFIG).values.map { |_level, locs| locs }
+  TEST_SAVE_FILES = log_out.select { |s| s.start_with?("logger/") }.map { |s| s.gsub(%r{\Alogger\/}, "") }
+  def set_up_test_failures
+    return if ALREADY_SET_UP_TEST_FAILURES[:setup]
 
-  "#{dir}/#{base}_#{test_name}_out.#{all_exts}"
-end
+    ALREADY_SET_UP_TEST_FAILURES[:setup] = true
+    # Delete stale test failures, if any, before starting test run
+    Dir["#{LOGGER_DIR}/test_failure*.log"].each { |fn| File.unlink(fn) }
 
-def save_failure_logs(test_name:)
-  TEST_SAVE_FILES.each do |log_file|
-    full_loc = File.expand_path("#{LOGGER_DIR}/#{log_file}")
-    log_out_spot = logfail_out_loc(full_loc, test_name:)
-    next unless File.exist?(full_loc)
+    Minitest.after_run do
+      # Remove un-saved test logs
+      TEST_SAVE_FILES.each do |f|
+        path = "#{LOGGER_DIR}/#{f}"
+        File.unlink(path) if File.exist?(path)
+      end
 
-    FileUtils.mv full_loc, log_out_spot
+      # Print test failure logs to console for CI
+      unless Dir["#{LOGGER_DIR}/test_failure*_out.log"].empty?
+        puts "Some tests have failed! See #{LOGGER_DIR}/test_failure*_out.log for test logs!"
+      end
+    end
   end
-end
 
-def test_scarpe_app(test_app_location, test_name: nil, test_code: "", **opts)
-  test_name ||= caller_locations[0].label
+  def logfail_out_loc(filepath, test_name:)
+    dir, filename = File.split(filepath)
+    all_exts = filename.split(".", 2)[1]
+    base = File.basename(filename, "." + all_exts)
 
-  bad_opts = opts.keys - TEST_OPTS
-  raise "Bad options passed to test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
+    "#{dir}/#{base}_#{test_name}_out.#{all_exts}"
+  end
 
-  set_up_test_failures
+  def save_failure_logs(test_name:)
+    TEST_SAVE_FILES.each do |log_file|
+      full_loc = File.expand_path("#{LOGGER_DIR}/#{log_file}")
+      log_out_spot = logfail_out_loc(full_loc, test_name:)
+      next unless File.exist?(full_loc)
 
-  with_tempfile("scarpe_test_results.json", "") do |result_path|
-    do_debug = opts[:debug] ? true : false
-    timeout = opts[:timeout] ? opts[:timeout].to_f : 1.5
-    scarpe_test_code = <<~SCARPE_TEST_CODE
-      require "scarpe/wv/control_interface_test"
+      FileUtils.mv full_loc, log_out_spot
+    end
+  end
 
-      override_app_opts debug: #{do_debug}
+  def run_test_scarpe_app(test_app_location, test_name: nil, test_code: "", **opts)
+    test_name ||= caller_locations[0].label
 
-      on_event(:init) do
-        die_after #{timeout}
+    bad_opts = opts.keys - TEST_OPTS
+    raise "Bad options passed to run_test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
 
-        # scarpeStatusAndExit is barbaric, and ignores all pending assertions and other subtleties.
-        wrangler.bind("scarpeStatusAndExit") do |*results|
-          return_results(results)
-          app.destroy
+    set_up_test_failures
+
+    with_tempfile("scarpe_test_results.json", "") do |result_path|
+      do_debug = opts[:debug] ? true : false
+      timeout = opts[:timeout] ? opts[:timeout].to_f : 1.5
+      scarpe_test_code = <<~SCARPE_TEST_CODE
+        require "scarpe/wv/control_interface_test"
+
+        override_app_opts debug: #{do_debug}
+
+        on_event(:init) do
+          die_after #{timeout}
+
+          # scarpeStatusAndExit is barbaric, and ignores all pending assertions and other subtleties.
+          wrangler.bind("scarpeStatusAndExit") do |*results|
+            return_results(results)
+            app.destroy
+          end
         end
-      end
-    SCARPE_TEST_CODE
+      SCARPE_TEST_CODE
 
-    scarpe_test_code += test_code
+      scarpe_test_code += test_code
 
-    if opts[:exit_immediately]
-      scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
-        on_event(:next_heartbeat) do
-          app.destroy
-        end
-      TEST_EXIT_IMMEDIATELY
-    end
-
-    # Remove old results, if any
-    File.unlink(result_path)
-
-    with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
-      # Start the application using the exe/scarpe utility
-      system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} " +
-        "SCARPE_LOG_CONFIG=\"#{TEST_SCARPE_LOG_CONFIG}\" " +
-        "ruby #{SCARPE_EXE} --dev #{test_app_location}")
-
-      # Check if the process exited normally or crashed (segfault, failure, timeout)
-      if $?.exitstatus != 0
-        save_failure_logs(test_name:)
-        assert(false, "Scarpe app crashed with exit code: #{$?.exitstatus}")
-        return
-      end
-    end
-
-    # If failure is okay, don't check for status or assertions
-    return if opts[:allow_fail]
-
-    # If we exit immediately with no result written, that's fine.
-    # But if we wrote a result, make sure it says pass, not fail.
-    return if opts[:exit_immediately] && !File.exist?(result_path)
-
-    unless File.exist?(result_path)
-      save_failure_logs(test_name:)
-      assert(false, "Scarpe app returned no status code!")
-      return
-    end
-
-    begin
-      out_data = JSON.parse File.read(result_path)
-
-      unless out_data.respond_to?(:each) && out_data.length > 1
-        raise "Scarpe app returned an unexpected data format! #{out_data.inspect}"
-      end
-
-      # If we exit immediately we still need a results file and a true value.
-      # We were getting exit_immediately being fine with apps segfaulting,
-      # so we need to check.
       if opts[:exit_immediately]
-        if out_data[0]
-          # That's all we needed!
+        scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
+          on_event(:next_heartbeat) do
+            app.destroy
+          end
+        TEST_EXIT_IMMEDIATELY
+      end
+
+      # Remove old results, if any
+      File.unlink(result_path)
+
+      with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
+        # Start the application using the exe/scarpe utility
+        system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} " +
+          "SCARPE_LOG_CONFIG=\"#{TEST_SCARPE_LOG_CONFIG}\" " +
+          "ruby #{SCARPE_EXE} --dev #{test_app_location}")
+
+        # Check if the process exited normally or crashed (segfault, failure, timeout)
+        if $?.exitstatus != 0
+          save_failure_logs(test_name:)
+          assert(false, "Scarpe app crashed with exit code: #{$?.exitstatus}")
           return
         end
-
-        save_failure_logs(test_name:)
-        assert false, "App exited immediately, but its results were false! #{out_data.inspect}"
       end
 
-      unless out_data[0]
-        puts JSON.pretty_generate(out_data[1])
+      # If failure is okay, don't check for status or assertions
+      return if opts[:allow_fail]
+
+      # If we exit immediately with no result written, that's fine.
+      # But if we wrote a result, make sure it says pass, not fail.
+      return if opts[:exit_immediately] && !File.exist?(result_path)
+
+      unless File.exist?(result_path)
         save_failure_logs(test_name:)
-        assert false, "Some Scarpe tests failed..."
+        assert(false, "Scarpe app returned no status code!")
+        return
       end
 
-      if out_data[1].is_a?(Hash)
-        test_data = out_data[1]
-        test_data["succeeded"].times { assert true } # Add to the number of assertions
-        test_data["failures"].each { |failure| assert false, "Failed Scarpe app test: #{failure}" }
-        if test_data["still_pending"] != 0
-          save_failure_logs(test_name:)
-          assert false, "Some tests were still pending!"
+      begin
+        out_data = JSON.parse File.read(result_path)
+
+        unless out_data.respond_to?(:each) && out_data.length > 1
+          raise "Scarpe app returned an unexpected data format! #{out_data.inspect}"
         end
+
+        # If we exit immediately we still need a results file and a true value.
+        # We were getting exit_immediately being fine with apps segfaulting,
+        # so we need to check.
+        if opts[:exit_immediately]
+          if out_data[0]
+            # That's all we needed!
+            return
+          end
+
+          save_failure_logs(test_name:)
+          assert false, "App exited immediately, but its results were false! #{out_data.inspect}"
+        end
+
+        unless out_data[0]
+          puts JSON.pretty_generate(out_data[1])
+          save_failure_logs(test_name:)
+          assert false, "Some Scarpe tests failed..."
+        end
+
+        if out_data[1].is_a?(Hash)
+          test_data = out_data[1]
+          test_data["succeeded"].times { assert true } # Add to the number of assertions
+          test_data["failures"].each { |failure| assert false, "Failed Scarpe app test: #{failure}" }
+          if test_data["still_pending"] != 0
+            save_failure_logs(test_name:)
+            assert false, "Some tests were still pending!"
+          end
+        end
+      rescue
+        $stderr.puts "Error parsing JSON data for Scarpe test status!"
+        raise
       end
-    rescue
-      $stderr.puts "Error parsing JSON data for Scarpe test status!"
-      raise
     end
   end
-end
 
-def assert_html(actual_html, expected_tag, **opts, &block)
-  expected_html = Scarpe::HTML.render do |h|
-    h.public_send(expected_tag, opts, &block)
+  def assert_html(actual_html, expected_tag, **opts, &block)
+    expected_html = Scarpe::HTML.render do |h|
+      h.public_send(expected_tag, opts, &block)
+    end
+
+    assert_equal expected_html, actual_html
   end
-
-  assert_equal expected_html, actual_html
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,8 +22,8 @@ end
 # Docs for our Webview lib: https://github.com/Maaarcocr/webview_ruby
 
 class ScarpeTest < Minitest::Test
-  def with_tempfile(prefix, contents)
-    t = Tempfile.new(prefix)
+  def with_tempfile(prefix, contents, dir: Dir.tmpdir)
+    t = Tempfile.new(prefix, dir)
     t.write(contents)
     t.flush # Make sure the contents are written out
 
@@ -47,75 +47,20 @@ class ScarpeTest < Minitest::Test
 
   SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
   TEST_OPTS = [:timeout, :allow_fail, :allow_timeout, :debug, :exit_immediately]
+  LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
 
-  def run_test_scarpe_code(scarpe_app_code, test_code: "", test_name: nil, **opts)
-    test_name ||= caller_locations[0].label
-
+  def run_test_scarpe_code(scarpe_app_code, test_code: "", **opts)
     bad_opts = opts.keys - TEST_OPTS
     raise "Bad options passed to run_test_scarpe_code: #{bad_opts.inspect}!" unless bad_opts.empty?
 
     with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
-      run_test_scarpe_app(test_app_location, test_code:, test_name:, **opts)
+      run_test_scarpe_app(test_app_location, test_code:, **opts)
     end
   end
 
-  LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
-  # Using an instance variable doesn't work for ALREADY_SET_UP(etc) and I'm not sure why not
-  ALREADY_SET_UP_TEST_FAILURES = { setup: false }
-  TEST_SCARPE_LOG_CONFIG = File.expand_path("#{LOGGER_DIR}/scarpe_wv_test.json")
-  log_out = JSON.load_file(TEST_SCARPE_LOG_CONFIG).values.map { |_level, locs| locs }
-  TEST_SAVE_FILES = log_out.select { |s| s.start_with?("logger/") }.map { |s| s.gsub(%r{\Alogger\/}, "") }
-  def set_up_test_failures
-    return if ALREADY_SET_UP_TEST_FAILURES[:setup]
-
-    ALREADY_SET_UP_TEST_FAILURES[:setup] = true
-    # Delete stale test failures, if any, before starting test run
-    Dir["#{LOGGER_DIR}/test_failure*.log"].each { |fn| File.unlink(fn) }
-
-    Minitest.after_run do
-      # Remove un-saved test logs
-      TEST_SAVE_FILES.each do |f|
-        path = "#{LOGGER_DIR}/#{f}"
-        File.unlink(path) if File.exist?(path)
-      end
-
-      # Print test failure logs to console for CI
-      unless Dir["#{LOGGER_DIR}/test_failure*_out.log"].empty?
-        puts "Some tests have failed! See #{LOGGER_DIR}/test_failure*_out.log for test logs!"
-      end
-    end
-  end
-
-  def logfail_out_loc(filepath, test_name:)
-    dir, filename = File.split(filepath)
-    all_exts = filename.split(".", 2)[1]
-    base = File.basename(filename, "." + all_exts)
-
-    out_loc = "#{dir}/#{base}_#{test_name}_out.#{all_exts}"
-
-    if File.exist?(out_loc)
-      raise "Duplicate test name #{test_name.inspect}? This file should *not* already exist!"
-    end
-
-    out_loc
-  end
-
-  def save_failure_logs(test_name:)
-    TEST_SAVE_FILES.each do |log_file|
-      full_loc = File.expand_path("#{LOGGER_DIR}/#{log_file}")
-      next unless File.exist?(full_loc)
-
-      FileUtils.mv full_loc, logfail_out_loc(full_loc, test_name:)
-    end
-  end
-
-  def run_test_scarpe_app(test_app_location, test_name: nil, test_code: "", **opts)
-    test_name ||= caller_locations[0].label
-
+  def run_test_scarpe_app(test_app_location, test_code: "", **opts)
     bad_opts = opts.keys - TEST_OPTS
     raise "Bad options passed to run_test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
-
-    set_up_test_failures
 
     with_tempfile("scarpe_test_results.json", "") do |result_path|
       do_debug = opts[:debug] ? true : false
@@ -150,16 +95,17 @@ class ScarpeTest < Minitest::Test
       File.unlink(result_path)
 
       with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
-        # Start the application using the exe/scarpe utility
-        system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} " +
-          "SCARPE_LOG_CONFIG=\"#{TEST_SCARPE_LOG_CONFIG}\" " +
-          "ruby #{SCARPE_EXE} --dev #{test_app_location}")
+        with_tempfile("scarpe_log_config.json", JSON.dump(log_config_for_test), dir: LOGGER_DIR) do |scarpe_log_config|
+          # Start the application using the exe/scarpe utility
+          system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} " +
+            "SCARPE_LOG_CONFIG=\"#{scarpe_log_config}\" " +
+            "ruby #{SCARPE_EXE} --dev #{test_app_location}")
 
-        # Check if the process exited normally or crashed (segfault, failure, timeout)
-        if $?.exitstatus != 0
-          save_failure_logs(test_name:)
-          assert(false, "Scarpe app crashed with exit code: #{$?.exitstatus}")
-          return
+          # Check if the process exited normally or crashed (segfault, failure, timeout)
+          unless $?.success?
+            assert(false, "Scarpe app crashed with exit code: #{$?.exitstatus}")
+            return
+          end
         end
       end
 
@@ -171,9 +117,7 @@ class ScarpeTest < Minitest::Test
       return if opts[:exit_immediately] && !File.exist?(result_path)
 
       unless File.exist?(result_path)
-        save_failure_logs(test_name:)
-        assert(false, "Scarpe app returned no status code!")
-        return
+        return assert(false, "Scarpe app returned no status code!")
       end
 
       begin
@@ -192,13 +136,11 @@ class ScarpeTest < Minitest::Test
             return
           end
 
-          save_failure_logs(test_name:)
           assert false, "App exited immediately, but its results were false! #{out_data.inspect}"
         end
 
         unless out_data[0]
           puts JSON.pretty_generate(out_data[1])
-          save_failure_logs(test_name:)
           assert false, "Some Scarpe tests failed..."
         end
 
@@ -207,7 +149,6 @@ class ScarpeTest < Minitest::Test
           test_data["succeeded"].times { assert true } # Add to the number of assertions
           test_data["failures"].each { |failure| assert false, "Failed Scarpe app test: #{failure}" }
           if test_data["still_pending"] != 0
-            save_failure_logs(test_name:)
             assert false, "Some tests were still pending!"
           end
         end
@@ -228,18 +169,20 @@ class ScarpeTest < Minitest::Test
 end
 
 # This test will save extensive logs in case of test failure.
-# We don't use this class for run_test_scarpe_code since we
-# handle the log config with the env variable instead of per-test
-# re-configuration. I assume it's possible to refactor that to use
-# this class.
 class LoggedScarpeTest < ScarpeTest
+  def file_id
+    "#{self.class.name}_#{self.name}"
+  end
+
   def setup
     # Make sure test failures will be saved at the end of the run.
     # Delete stale test failures and logging only the *first* time this is called.
     set_up_test_failures
 
     @normal_log_config = Scarpe::Logger.current_log_config
-    Scarpe::Logger.configure_logger(TEST_SCARPE_LOG_CONFIG)
+    Scarpe::Logger.configure_logger(log_config_for_test)
+
+    Scarpe::Logger.logger("LoggedScarpeTest").info("Test: #{self.class.name}##{self.name}")
   end
 
   def teardown
@@ -247,8 +190,84 @@ class LoggedScarpeTest < ScarpeTest
     Scarpe::Logger.configure_logger(@normal_log_config)
 
     if self.failure
-      test_name = "#{self.class.name}_#{self.name}"
-      save_failure_logs(test_name:)
+      save_failure_logs
+    else
+      remove_unsaved_logs
+    end
+  end
+
+  def log_config_for_test
+    {
+      "default" => ["debug", "logger/test_failure_#{file_id}.log"],
+      "WebviewAPI" => ["debug", "logger/test_failure_wv_api_#{file_id}.log"],
+    }
+  end
+
+  # This could be a lot simpler except I want to only update the file list in one place,
+  # log_config_for_test(). Having a single spot should (I hope) make it a lot friendlier to
+  # add more logfiles for different components, logged API objects, etc.
+  def saved_log_files
+    lc = log_config_for_test
+    log_outfiles = lc.values.map { |_level, loc| loc }
+    log_outfiles.select { |s| s.start_with?("logger/") }.map { |s| s.delete_prefix("logger/") }
+  end
+
+  # We want test failures set up once *total*, not per Minitest::Test. So an instance var
+  # doesn't do it.
+  ALREADY_SET_UP_TEST_FAILURES = { setup: false }
+
+  def set_up_test_failures
+    return if ALREADY_SET_UP_TEST_FAILURES[:setup]
+
+    ALREADY_SET_UP_TEST_FAILURES[:setup] = true
+    # Delete stale test failures, if any, before starting the first failure-logged test
+    Dir["#{LOGGER_DIR}/test_failure*.log"].each { |fn| File.unlink(fn) }
+
+    Minitest.after_run do
+      # Print test failure notice to console
+      unless Dir["#{LOGGER_DIR}/test_failure*.out.log"].empty?
+        puts "Some tests have failed! See #{LOGGER_DIR}/test_failure*.out.log for test logs!"
+      end
+
+      # Remove un-saved test logs
+      Dir["#{LOGGER_DIR}/test_failure*.log"].each do |f|
+        next if f.include?(".out.log")
+
+        File.unlink(f) if File.exist?(f)
+      end
+    end
+  end
+
+  def logfail_out_loc(filepath)
+    # Add a .out prefix before final .log
+    out_loc = filepath.gsub(%r{.log\Z}, ".out.log")
+
+    if out_loc == filepath
+      raise "Something is wrong! Could not figure out failure-log output path for #{filepath.inspect}!"
+    end
+
+    if File.exist?(out_loc)
+      raise "Duplicate test name #{test_name.inspect}? This file should *not* already exist!"
+    end
+
+    out_loc
+  end
+
+  def save_failure_logs
+    saved_log_files.each do |log_file|
+      full_loc = File.expand_path("#{LOGGER_DIR}/#{log_file}")
+      # TODO: we'd like to skip 0-length logfiles. But also Logging doesn't flush. For now, ignore.
+      next unless File.exist?(full_loc)
+
+      FileUtils.mv full_loc, logfail_out_loc(full_loc)
+    end
+  end
+
+  def remove_unsaved_logs
+    Dir["#{LOGGER_DIR}/test_failure*.log"].each do |f|
+      next if f.include?(".out.log") # Don't delete saved logs
+
+      File.unlink(f)
     end
   end
 end

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestHTML < Minitest::Test
+class TestHTML < ScarpeTest
   def test_works_without_content
     subject = ::Scarpe::HTML.render(&:div)
 

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -2,9 +2,7 @@
 
 require "test_helper"
 
-TEST_VALUES = {}
-
-class TestWebviewImage < Minitest::Test
+class TestWebviewImage < ScarpeTest
   def setup
     @url = "http://shoesrb.com/manual/static/shoes-icon.png"
     @default_properties = {

--- a/test/test_link.rb
+++ b/test/test_link.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 # Link display properties: text, click, has_block
 
-class TestWebviewLink < Minitest::Test
+class TestWebviewLink < ScarpeTest
   def setup
     @default_properties = {
       "text" => "click here",

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -2,9 +2,7 @@
 
 require "test_helper"
 
-TEST_VALUES = {}
-
-class TestWebviewPara < Minitest::Test
+class TestWebviewPara < ScarpeTest
   def setup
     @default_properties = {
       "shoes_linkable_id" => 1,

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -2,13 +2,13 @@
 
 require "test_helper"
 
-class TestScarpe < Minitest::Test
+class TestScarpe < ScarpeTest
   def test_that_it_has_a_version_number
     refute_nil ::Scarpe::VERSION
   end
 
   def test_hello_world_app
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         para "Hello World"
       end
@@ -16,7 +16,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_app_timeout
-    test_scarpe_code(<<-'SCARPE_APP', timeout: 0.1, allow_fail: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', timeout: 0.1, allow_fail: true)
       Shoes.app do
         para "Just waiting for this to time out"
       end
@@ -24,7 +24,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_button_app
-    test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
       Shoes.app do
         @push = button "Push me", width: 200, height: 50, top: 109, left: 132
         @note = para "Nothing pushed so far"
@@ -35,7 +35,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_text_widgets
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         para "This is plain."
         para "This has ", em("emphasis"), " and great ", strong("strength"), " and ", code("coolness"), "."
@@ -44,7 +44,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_button_args_optional
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         button "Push me"
       end
@@ -52,7 +52,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_stack_args_optional
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         stack do
           button "Push me"
@@ -62,7 +62,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_widgets_exist
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         stack do
           para "Here I am"

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestScarpe < ScarpeTest
+class TestScarpe < LoggedScarpeTest
   def test_that_it_has_a_version_number
     refute_nil ::Scarpe::VERSION
   end

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestWebWrangler < ScarpeTest
+class TestWebWranglerInScarpeApp < LoggedScarpeTest
   # Need to make sure that even with no widgets we still get at least one redraw
   def test_empty_app
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
@@ -17,52 +17,54 @@ class TestWebWrangler < ScarpeTest
 
   # We've had problems with dirty-tracking where the DOM stops updating after
   # the first change.
-  #def test_assert_multiple_dom_updates
-  #  test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
-  #    Shoes.app do
-  #      para "Hello"
-  #    end
-  #  SCARPE_APP
-  #    on_event(:next_redraw) do
-  #      para = find_wv_widgets(Scarpe::WebviewPara)[0]
-  #      with_js_dom_html do |html_text|
-  #        assert html_text.include?("Hello"), "DOM HTML should include initial para text!"
-  #      end.then_ruby_promise do
-  #        # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
-  #        change = { "text_items" => [ "Goodbye" ] }
-  #        doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
-  #        wrangler.promise_dom_fully_updated
-  #      end.then_with_js_dom_html do |html_text|
-  #        assert html_text.include?("Goodbye"), "DOM root should contain the first replacement text! Text: #{html_text.inspect}"
-  #        assert !html_text.include?("Hello"), "DOM root shouldn't still contain the original text! Text: #{html_text.inspect}"
-  #      end.then_ruby_promise do
-  #        # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
-  #        change = { "text_items" => [ "Borzoi" ] }
-  #        doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
-  #        wrangler.promise_dom_fully_updated
-  #      end.then_with_js_dom_html do |html_text|
-  #        assert html_text.include?("Borzoi"), "DOM root should contain the second replacement text! Text: #{html_text.inspect}"
-  #      end.then { return_when_assertions_done }
-  #    end
-  #  TEST_CODE
-  #end
+  def test_assert_multiple_dom_updates
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+      Shoes.app do
+        para "Hello"
+      end
+    SCARPE_APP
+      on_event(:next_redraw) do
+        para = find_wv_widgets(Scarpe::WebviewPara)[0]
+        with_js_dom_html do |html_text|
+          assert html_text.include?("Hello"), "DOM HTML should include initial para text!"
+        end.then_ruby_promise do
+          # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
+          change = { "text_items" => [ "Goodbye" ] }
+          doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
+          wrangler.promise_dom_fully_updated
+        end.then_with_js_dom_html do |html_text|
+          assert html_text.include?("Goodbye"), "DOM root should contain the first replacement text! Text: #{html_text.inspect}"
+          assert !html_text.include?("Hello"), "DOM root shouldn't still contain the original text! Text: #{html_text.inspect}"
+        end.then_ruby_promise do
+          # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
+          change = { "text_items" => [ "Borzoi" ] }
+          doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
+          wrangler.promise_dom_fully_updated
+        end.then_with_js_dom_html do |html_text|
+          assert html_text.include?("Borzoi"), "DOM root should contain the second replacement text! Text: #{html_text.inspect}"
+        end.then { return_when_assertions_done }
+      end
+    TEST_CODE
+  end
+end
 
-  def with_mocked_webview(&block)
+class TestWebWranglerMocked < LoggedScarpeTest
+  def with_mocked_webview(wrangler_opts: {}, &block)
     @mocked_webview = Minitest::Mock.new
     ["puts", "scarpeAsyncEvalResult", "scarpeHeartbeat"].each do |bound_method|
       @mocked_webview.expect :bind, nil, [bound_method]
     end
     @mocked_webview.expect :init, nil, [String]
     WebviewRuby::Webview.stub :new, @mocked_webview do
-      @web_wrangler = Scarpe::WebWrangler.new title: "A Window", width: 300, height: 200
+      @web_wrangler = Scarpe::WebWrangler.new title: "A Window", width: 300, height: 200, **wrangler_opts
       block.call
     end
-    #@mocked_webview.verify
+    @mocked_webview.verify
   end
 
   CHEAT_CONSTS = {}
-  def with_running_mocked_webview(&block)
-    with_mocked_webview do
+  def with_running_mocked_webview(wrangler_opts: {}, &block)
+    with_mocked_webview(wrangler_opts:) do
       @mocked_webview.expect :set_title, nil, [String]
       @mocked_webview.expect :set_size, nil, [300, 200, 3]
       @mocked_webview.expect :navigate, nil, [String]
@@ -92,15 +94,16 @@ class TestWebWrangler < ScarpeTest
   end
 
   def replacement_js_code(new_body, eval_serial)
-    wrapped_js_code(Scarpe::WebWrangler::DOMWrangler.replacement_code("<body>Bobo</body>"), eval_serial)
+    wrapped_js_code(Scarpe::WebWrangler::DOMWrangler.replacement_code(new_body), eval_serial)
   end
 
   def test_ww_redraw_basic
     with_running_mocked_webview do
+      new_body_code = "<body>Bobo</body>"
       # On the first call to replace, this will schedule a code replacement
-      replacement_code = replacement_js_code("<body>Bobo</body>", 0)
+      replacement_code = replacement_js_code(new_body_code, 0)
       @mocked_webview.expect :eval, nil, [replacement_code]
-      @web_wrangler.replace("<body>Bobo</body>")
+      @web_wrangler.replace(new_body_code)
 
       # Until WebWrangler gets an acknowledgement, it won't schedule more JS
       # We don't really care what's in this JS - these would be element modifications in real code
@@ -112,6 +115,31 @@ class TestWebWrangler < ScarpeTest
       update_code = wrapped_js_code("func1();func2();func3()", 1)
       @mocked_webview.expect :eval, nil, [update_code]
       @web_wrangler.send(:receive_eval_result, "success", 0, true)
+    end
+  end
+
+  def test_ww_redraw_statement_limit
+    with_running_mocked_webview(wrangler_opts: { max_msg_statements: 1 }) do
+      new_body_code = "<body>Bobo</body>"
+      # On the first call to replace, this will schedule a code replacement
+      replacement_code = replacement_js_code(new_body_code, 0)
+      @mocked_webview.expect :eval, nil, [replacement_code]
+      @web_wrangler.replace(new_body_code)
+
+      # Until WebWrangler gets an acknowledgement, it won't schedule more JS
+      # We don't really care what's in this JS - these would be element modifications in real code
+      @web_wrangler.dom_change("func1()")
+      @web_wrangler.dom_change("func2()")
+      @web_wrangler.dom_change("func3()")
+
+      # After WebWrangler gets a success on the first update it will schedule the other ones
+      update_code = wrapped_js_code("func1()", 1)
+      @mocked_webview.expect :eval, nil, [update_code]
+      @web_wrangler.send(:receive_eval_result, "success", 0, true)
+
+      update_code = wrapped_js_code("func2()", 1)
+      @mocked_webview.expect :eval, nil, [update_code]
+      @web_wrangler.send(:receive_eval_result, "success", 1, true)
     end
   end
 end

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -2,10 +2,10 @@
 
 require "test_helper"
 
-class TestWebWrangler < Minitest::Test
+class TestWebWrangler < ScarpeTest
   # Need to make sure that even with no widgets we still get at least one redraw
   def test_empty_app
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
       Scarpe.app do
       end
     SCARPE_APP


### PR DESCRIPTION
In #200, I wrote about limiting the number of JS statements per async eval, maybe even all the way down to 1. We actually know that Webview gets errors (often segfaults!) with too large, or too numerous, evals. So probably the best choice is to limit the number and size of JS statements. This PR adds environment variables to do that.

The default limits are 4kb of Javascript or 10 JS statements per message -- fairly lenient. But we can potentially tighten it down if we want to make tests behave more uniformly, or loosen it up if we have a form with a *lot* of widgets that get modified, since every 10 DOM modifications adds a Scarpe->Webview round trip by default. I didn't add an API to change the limit per-test or per-app, but that wouldn't be hard to do.

As the complexity of this file goes up, we need some tests. I've been talking about that for awhile. Since Webview timing is finicky, I think that means some mocked tests where I use a fake Webview object to test WebWrangler and DOMWrangler. Working on it. This is draft while I debug and test this, and until I can do that.