### PR TITLE
Improve test-fail logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: CI_RUN='true' bundle exec rake test
+      - name: upload test-fail logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: test failure logs
+          path: logger/test_failure_*_out.log
   linter:
     name: Linter
     runs-on: macos-latest

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -13,7 +13,7 @@ class TestExamplesWithWebview < Minitest::Test
   examples_to_test.each do |example_filename|
     example = example_filename.gsub("/", "_").gsub("-", "_").gsub(/.rb\Z/, "")
     define_method("test_webview_#{example}") do
-      test_scarpe_app(example_filename, exit_immediately: true)
+      test_scarpe_app(example_filename, exit_immediately: true, test_name: example)
     end
   end
 end


### PR DESCRIPTION
Save them in GitHub Actions CI
Don't report logs from non-failing tests
Use test names, not integer offsets, in file names Fail a test if multiple results are returned

This fixes #212. I've tested locally with these failure types (but not yet GitHub Actions CI) and they do the right thing.