### PR TITLE
Move test_helper top-level methods into a ScarpeTest helper class

### DIFF
--- a/test/test_colors.rb
+++ b/test/test_colors.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestColors < Minitest::Test
+class TestColors < ScarpeTest
   class Dummy
     include Scarpe::Colors
   end

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -2,9 +2,9 @@
 
 require "test_helper"
 
-class TestControlInterface < Minitest::Test
+class TestControlInterface < ScarpeTest
   def test_trivial_async_assert
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
       Shoes.app do
         para "Hello World"
       end
@@ -17,7 +17,7 @@ class TestControlInterface < Minitest::Test
   end
 
   def test_assert_dom_html
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do
         para "Hello World"
       end
@@ -31,7 +31,7 @@ class TestControlInterface < Minitest::Test
   end
 
   def test_assert_widget
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do
         para "Hello World"
       end
@@ -45,7 +45,7 @@ class TestControlInterface < Minitest::Test
   end
 
   def test_assert_dom_html_update
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do
         para "Hello World"
       end

--- a/test/test_dimensions.rb
+++ b/test/test_dimensions.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestDimensions < Minitest::Test
+class TestDimensions < ScarpeTest
   def test_no_value_returns_nil
     assert_nil ::Scarpe::Dimensions.length(nil)
   end

--- a/test/test_edit_box.rb
+++ b/test/test_edit_box.rb
@@ -5,7 +5,7 @@ require "test_helper"
 # Going to need to rewrite this, or at a minimum heavily modify it :-(
 __END__
 
-class TestEditBox < Minitest::Test
+class TestEditBox < ScarpeTest
   def setup
     app = Minitest::Mock.new
     Scarpe::Widget.document_root = app

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestExamplesWithWebview < Minitest::Test
+class TestExamplesWithWebview < ScarpeTest
   match_str = ENV["EXAMPLES_MATCHING"] || ""
 
   examples_to_test = Dir["examples/**/*.rb"]
@@ -13,7 +13,7 @@ class TestExamplesWithWebview < Minitest::Test
   examples_to_test.each do |example_filename|
     example = example_filename.gsub("/", "_").gsub("-", "_").gsub(/.rb\Z/, "")
     define_method("test_webview_#{example}") do
-      test_scarpe_app(example_filename, exit_immediately: true, test_name: example)
+      run_test_scarpe_app(example_filename, exit_immediately: true, test_name: example)
     end
   end
 end

--- a/test/test_flow.rb
+++ b/test/test_flow.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestWebviewFlow < Minitest::Test
+class TestWebviewFlow < ScarpeTest
   def test_it_accepts_a_height
     flow = Scarpe::WebviewFlow.new("width" => 7, "height" => 25, "margin" => 4, "padding" => 5, "shoes_linkable_id" => 1) do
       "fishes that flop"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,9 +14,6 @@ require "minitest/autorun"
 require "minitest/reporters"
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
-# We're going to be passing a fair bit of data back and forth across eval boundaries.
-TEST_DATA = {}
-
 # Soon this should go in the framework, not here
 unless Object.constants.include?(:Shoes)
   Shoes = Scarpe
@@ -24,201 +21,203 @@ end
 
 # Docs for our Webview lib: https://github.com/Maaarcocr/webview_ruby
 
-def with_tempfile(prefix, contents)
-  t = Tempfile.new(prefix)
-  t.write(contents)
-  t.flush # Make sure the contents are written out
+class ScarpeTest < Minitest::Test
+  def with_tempfile(prefix, contents)
+    t = Tempfile.new(prefix)
+    t.write(contents)
+    t.flush # Make sure the contents are written out
 
-  yield(t.path)
-ensure
-  t.close
-  t.unlink
-end
-
-# Temporarily set env vars for the block of code inside
-def with_env_vars(envs)
-  old_env = {}
-  envs.each do |k, v|
-    old_env[k] = ENV[k]
-    ENV[k] = v
+    yield(t.path)
+  ensure
+    t.close
+    t.unlink
   end
-  yield
-ensure
-  old_env.each { |k, v| ENV[k] = v }
-end
 
-SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
-TEST_OPTS = [:timeout, :allow_fail, :allow_timeout, :debug, :exit_immediately]
-
-def test_scarpe_code(scarpe_app_code, test_code: "", test_name: nil, **opts)
-  test_name ||= caller_locations[0].label
-
-  bad_opts = opts.keys - TEST_OPTS
-  raise "Bad options passed to test_scarpe_code: #{bad_opts.inspect}!" unless bad_opts.empty?
-
-  with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
-    test_scarpe_app(test_app_location, test_code:, test_name:, **opts)
-  end
-end
-
-LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
-# Using an instance variable doesn't work for ALREADY_SET_UP(etc) and I'm not sure why not
-ALREADY_SET_UP_TEST_FAILURES = { setup: false }
-TEST_SCARPE_LOG_CONFIG = File.expand_path("#{LOGGER_DIR}/scarpe_wv_test.json")
-log_out = JSON.load_file(TEST_SCARPE_LOG_CONFIG).values.map { |_level, locs| locs }
-TEST_SAVE_FILES = log_out.select { |s| s.start_with?("logger/") }.map { |s| s.gsub(%r{\Alogger\/}, "") }
-def set_up_test_failures
-  return if ALREADY_SET_UP_TEST_FAILURES[:setup]
-
-  ALREADY_SET_UP_TEST_FAILURES[:setup] = true
-  # Delete stale test failures, if any, before starting test run
-  Dir["#{LOGGER_DIR}/test_failure*.log"].each { |fn| File.unlink(fn) }
-
-  Minitest.after_run do
-    # Remove un-saved test logs
-    TEST_SAVE_FILES.each do |f|
-      path = "#{LOGGER_DIR}/#{f}"
-      File.unlink(path) if File.exist?(path)
+  # Temporarily set env vars for the block of code inside
+  def with_env_vars(envs)
+    old_env = {}
+    envs.each do |k, v|
+      old_env[k] = ENV[k]
+      ENV[k] = v
     end
+    yield
+  ensure
+    old_env.each { |k, v| ENV[k] = v }
+  end
 
-    # Print test failure logs to console for CI
-    unless Dir["#{LOGGER_DIR}/test_failure*_out.log"].empty?
-      puts "Some tests have failed! See #{LOGGER_DIR}/test_failure*_out.log for test logs!"
+  SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
+  TEST_OPTS = [:timeout, :allow_fail, :allow_timeout, :debug, :exit_immediately]
+
+  def run_test_scarpe_code(scarpe_app_code, test_code: "", test_name: nil, **opts)
+    test_name ||= caller_locations[0].label
+
+    bad_opts = opts.keys - TEST_OPTS
+    raise "Bad options passed to run_test_scarpe_code: #{bad_opts.inspect}!" unless bad_opts.empty?
+
+    with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
+      run_test_scarpe_app(test_app_location, test_code:, test_name:, **opts)
     end
   end
-end
 
-def logfail_out_loc(filepath, test_name:)
-  dir, filename = File.split(filepath)
-  all_exts = filename.split(".", 2)[1]
-  base = File.basename(filename, "." + all_exts)
+  LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
+  # Using an instance variable doesn't work for ALREADY_SET_UP(etc) and I'm not sure why not
+  ALREADY_SET_UP_TEST_FAILURES = { setup: false }
+  TEST_SCARPE_LOG_CONFIG = File.expand_path("#{LOGGER_DIR}/scarpe_wv_test.json")
+  log_out = JSON.load_file(TEST_SCARPE_LOG_CONFIG).values.map { |_level, locs| locs }
+  TEST_SAVE_FILES = log_out.select { |s| s.start_with?("logger/") }.map { |s| s.gsub(%r{\Alogger\/}, "") }
+  def set_up_test_failures
+    return if ALREADY_SET_UP_TEST_FAILURES[:setup]
 
-  "#{dir}/#{base}_#{test_name}_out.#{all_exts}"
-end
+    ALREADY_SET_UP_TEST_FAILURES[:setup] = true
+    # Delete stale test failures, if any, before starting test run
+    Dir["#{LOGGER_DIR}/test_failure*.log"].each { |fn| File.unlink(fn) }
 
-def save_failure_logs(test_name:)
-  TEST_SAVE_FILES.each do |log_file|
-    full_loc = File.expand_path("#{LOGGER_DIR}/#{log_file}")
-    log_out_spot = logfail_out_loc(full_loc, test_name:)
-    next unless File.exist?(full_loc)
+    Minitest.after_run do
+      # Remove un-saved test logs
+      TEST_SAVE_FILES.each do |f|
+        path = "#{LOGGER_DIR}/#{f}"
+        File.unlink(path) if File.exist?(path)
+      end
 
-    FileUtils.mv full_loc, log_out_spot
+      # Print test failure logs to console for CI
+      unless Dir["#{LOGGER_DIR}/test_failure*_out.log"].empty?
+        puts "Some tests have failed! See #{LOGGER_DIR}/test_failure*_out.log for test logs!"
+      end
+    end
   end
-end
 
-def test_scarpe_app(test_app_location, test_name: nil, test_code: "", **opts)
-  test_name ||= caller_locations[0].label
+  def logfail_out_loc(filepath, test_name:)
+    dir, filename = File.split(filepath)
+    all_exts = filename.split(".", 2)[1]
+    base = File.basename(filename, "." + all_exts)
 
-  bad_opts = opts.keys - TEST_OPTS
-  raise "Bad options passed to test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
+    "#{dir}/#{base}_#{test_name}_out.#{all_exts}"
+  end
 
-  set_up_test_failures
+  def save_failure_logs(test_name:)
+    TEST_SAVE_FILES.each do |log_file|
+      full_loc = File.expand_path("#{LOGGER_DIR}/#{log_file}")
+      log_out_spot = logfail_out_loc(full_loc, test_name:)
+      next unless File.exist?(full_loc)
 
-  with_tempfile("scarpe_test_results.json", "") do |result_path|
-    do_debug = opts[:debug] ? true : false
-    timeout = opts[:timeout] ? opts[:timeout].to_f : 1.5
-    scarpe_test_code = <<~SCARPE_TEST_CODE
-      require "scarpe/wv/control_interface_test"
+      FileUtils.mv full_loc, log_out_spot
+    end
+  end
 
-      override_app_opts debug: #{do_debug}
+  def run_test_scarpe_app(test_app_location, test_name: nil, test_code: "", **opts)
+    test_name ||= caller_locations[0].label
 
-      on_event(:init) do
-        die_after #{timeout}
+    bad_opts = opts.keys - TEST_OPTS
+    raise "Bad options passed to run_test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
 
-        # scarpeStatusAndExit is barbaric, and ignores all pending assertions and other subtleties.
-        wrangler.bind("scarpeStatusAndExit") do |*results|
-          return_results(results)
-          app.destroy
+    set_up_test_failures
+
+    with_tempfile("scarpe_test_results.json", "") do |result_path|
+      do_debug = opts[:debug] ? true : false
+      timeout = opts[:timeout] ? opts[:timeout].to_f : 1.5
+      scarpe_test_code = <<~SCARPE_TEST_CODE
+        require "scarpe/wv/control_interface_test"
+
+        override_app_opts debug: #{do_debug}
+
+        on_event(:init) do
+          die_after #{timeout}
+
+          # scarpeStatusAndExit is barbaric, and ignores all pending assertions and other subtleties.
+          wrangler.bind("scarpeStatusAndExit") do |*results|
+            return_results(results)
+            app.destroy
+          end
         end
-      end
-    SCARPE_TEST_CODE
+      SCARPE_TEST_CODE
 
-    scarpe_test_code += test_code
+      scarpe_test_code += test_code
 
-    if opts[:exit_immediately]
-      scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
-        on_event(:next_heartbeat) do
-          app.destroy
-        end
-      TEST_EXIT_IMMEDIATELY
-    end
-
-    # Remove old results, if any
-    File.unlink(result_path)
-
-    with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
-      # Start the application using the exe/scarpe utility
-      system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} " +
-        "SCARPE_LOG_CONFIG=\"#{TEST_SCARPE_LOG_CONFIG}\" " +
-        "ruby #{SCARPE_EXE} --dev #{test_app_location}")
-
-      # Check if the process exited normally or crashed (segfault, failure, timeout)
-      if $?.exitstatus != 0
-        save_failure_logs(test_name:)
-        assert(false, "Scarpe app crashed with exit code: #{$?.exitstatus}")
-        return
-      end
-    end
-
-    # If failure is okay, don't check for status or assertions
-    return if opts[:allow_fail]
-
-    # If we exit immediately with no result written, that's fine.
-    # But if we wrote a result, make sure it says pass, not fail.
-    return if opts[:exit_immediately] && !File.exist?(result_path)
-
-    unless File.exist?(result_path)
-      save_failure_logs(test_name:)
-      assert(false, "Scarpe app returned no status code!")
-      return
-    end
-
-    begin
-      out_data = JSON.parse File.read(result_path)
-
-      unless out_data.respond_to?(:each) && out_data.length > 1
-        raise "Scarpe app returned an unexpected data format! #{out_data.inspect}"
-      end
-
-      # If we exit immediately we still need a results file and a true value.
-      # We were getting exit_immediately being fine with apps segfaulting,
-      # so we need to check.
       if opts[:exit_immediately]
-        if out_data[0]
-          # That's all we needed!
+        scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
+          on_event(:next_heartbeat) do
+            app.destroy
+          end
+        TEST_EXIT_IMMEDIATELY
+      end
+
+      # Remove old results, if any
+      File.unlink(result_path)
+
+      with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
+        # Start the application using the exe/scarpe utility
+        system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} " +
+          "SCARPE_LOG_CONFIG=\"#{TEST_SCARPE_LOG_CONFIG}\" " +
+          "ruby #{SCARPE_EXE} --dev #{test_app_location}")
+
+        # Check if the process exited normally or crashed (segfault, failure, timeout)
+        if $?.exitstatus != 0
+          save_failure_logs(test_name:)
+          assert(false, "Scarpe app crashed with exit code: #{$?.exitstatus}")
           return
         end
-
-        save_failure_logs(test_name:)
-        assert false, "App exited immediately, but its results were false! #{out_data.inspect}"
       end
 
-      unless out_data[0]
-        puts JSON.pretty_generate(out_data[1])
+      # If failure is okay, don't check for status or assertions
+      return if opts[:allow_fail]
+
+      # If we exit immediately with no result written, that's fine.
+      # But if we wrote a result, make sure it says pass, not fail.
+      return if opts[:exit_immediately] && !File.exist?(result_path)
+
+      unless File.exist?(result_path)
         save_failure_logs(test_name:)
-        assert false, "Some Scarpe tests failed..."
+        assert(false, "Scarpe app returned no status code!")
+        return
       end
 
-      if out_data[1].is_a?(Hash)
-        test_data = out_data[1]
-        test_data["succeeded"].times { assert true } # Add to the number of assertions
-        test_data["failures"].each { |failure| assert false, "Failed Scarpe app test: #{failure}" }
-        if test_data["still_pending"] != 0
-          save_failure_logs(test_name:)
-          assert false, "Some tests were still pending!"
+      begin
+        out_data = JSON.parse File.read(result_path)
+
+        unless out_data.respond_to?(:each) && out_data.length > 1
+          raise "Scarpe app returned an unexpected data format! #{out_data.inspect}"
         end
+
+        # If we exit immediately we still need a results file and a true value.
+        # We were getting exit_immediately being fine with apps segfaulting,
+        # so we need to check.
+        if opts[:exit_immediately]
+          if out_data[0]
+            # That's all we needed!
+            return
+          end
+
+          save_failure_logs(test_name:)
+          assert false, "App exited immediately, but its results were false! #{out_data.inspect}"
+        end
+
+        unless out_data[0]
+          puts JSON.pretty_generate(out_data[1])
+          save_failure_logs(test_name:)
+          assert false, "Some Scarpe tests failed..."
+        end
+
+        if out_data[1].is_a?(Hash)
+          test_data = out_data[1]
+          test_data["succeeded"].times { assert true } # Add to the number of assertions
+          test_data["failures"].each { |failure| assert false, "Failed Scarpe app test: #{failure}" }
+          if test_data["still_pending"] != 0
+            save_failure_logs(test_name:)
+            assert false, "Some tests were still pending!"
+          end
+        end
+      rescue
+        $stderr.puts "Error parsing JSON data for Scarpe test status!"
+        raise
       end
-    rescue
-      $stderr.puts "Error parsing JSON data for Scarpe test status!"
-      raise
     end
   end
-end
 
-def assert_html(actual_html, expected_tag, **opts, &block)
-  expected_html = Scarpe::HTML.render do |h|
-    h.public_send(expected_tag, opts, &block)
+  def assert_html(actual_html, expected_tag, **opts, &block)
+    expected_html = Scarpe::HTML.render do |h|
+      h.public_send(expected_tag, opts, &block)
+    end
+
+    assert_equal expected_html, actual_html
   end
-
-  assert_equal expected_html, actual_html
 end

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestHTML < Minitest::Test
+class TestHTML < ScarpeTest
   def test_works_without_content
     subject = ::Scarpe::HTML.render(&:div)
 

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -2,9 +2,7 @@
 
 require "test_helper"
 
-TEST_VALUES = {}
-
-class TestWebviewImage < Minitest::Test
+class TestWebviewImage < ScarpeTest
   def setup
     @url = "http://shoesrb.com/manual/static/shoes-icon.png"
     @default_properties = {

--- a/test/test_link.rb
+++ b/test/test_link.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 # Link display properties: text, click, has_block
 
-class TestWebviewLink < Minitest::Test
+class TestWebviewLink < ScarpeTest
   def setup
     @default_properties = {
       "text" => "click here",

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -2,9 +2,7 @@
 
 require "test_helper"
 
-TEST_VALUES = {}
-
-class TestWebviewPara < Minitest::Test
+class TestWebviewPara < ScarpeTest
   def setup
     @default_properties = {
       "shoes_linkable_id" => 1,

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -2,13 +2,13 @@
 
 require "test_helper"
 
-class TestScarpe < Minitest::Test
+class TestScarpe < ScarpeTest
   def test_that_it_has_a_version_number
     refute_nil ::Scarpe::VERSION
   end
 
   def test_hello_world_app
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         para "Hello World"
       end
@@ -16,7 +16,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_app_timeout
-    test_scarpe_code(<<-'SCARPE_APP', timeout: 0.1, allow_fail: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', timeout: 0.1, allow_fail: true)
       Shoes.app do
         para "Just waiting for this to time out"
       end
@@ -24,7 +24,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_button_app
-    test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
       Shoes.app do
         @push = button "Push me", width: 200, height: 50, top: 109, left: 132
         @note = para "Nothing pushed so far"
@@ -35,7 +35,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_text_widgets
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         para "This is plain."
         para "This has ", em("emphasis"), " and great ", strong("strength"), " and ", code("coolness"), "."
@@ -44,7 +44,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_button_args_optional
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         button "Push me"
       end
@@ -52,7 +52,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_stack_args_optional
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         stack do
           button "Push me"
@@ -62,7 +62,7 @@ class TestScarpe < Minitest::Test
   end
 
   def test_widgets_exist
-    test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         stack do
           para "Here I am"

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -2,10 +2,10 @@
 
 require "test_helper"
 
-class TestWebWrangler < Minitest::Test
+class TestWebWrangler < ScarpeTest
   # Need to make sure that even with no widgets we still get at least one redraw
   def test_empty_app
-    test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
       Scarpe.app do
       end
     SCARPE_APP


### PR DESCRIPTION
Also rename methods that would become tests, since they shouldn't.

This will help us to not pollute the top-level namespace.