### PR TITLE
Rework how I handle logging for failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
       - name: Run tests
         run: CI_RUN='true' bundle exec rake test
       - name: upload test-fail logs
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           name: test failure logs
-          path: logger/test_failure_*_out.log
+          path: logger/test_failure*.out.log
   linter:
     name: Linter
     runs-on: macos-latest

--- a/exe/scarpe
+++ b/exe/scarpe
@@ -31,6 +31,7 @@ def print_env
     Scarpe environment:
       #{env_or_default("SCARPE_DISPLAY_SERVICE", "(default)wv_local")}
       #{env_or_default("SCARPE_LOG_CONFIG", "(default)#{Scarpe::Log::DEFAULT_LOG_CONFIG.inspect}")}
+    Scarpe::WV environment:
       #{env_or_none("SCARPE_TEST_CONTROL")}
       #{env_or_none("SCARPE_TEST_RESULTS")}
     Ruby and shell environment:

--- a/lib/scarpe/logger.rb
+++ b/lib/scarpe/logger.rb
@@ -91,10 +91,15 @@ class Scarpe
       public
 
       def configure_logger(log_config)
+        if log_config.is_a?(String) && File.exist?(log_config)
+          log_config = JSON.load_file(log_config)
+        end
+
         log_config = freeze_log_config(log_config) unless log_config.nil?
         @current_log_config = log_config # Save a copy for later
 
         Logging.reset # Reset all Logging settings to defaults
+        Logging.reopen # For log-reconfig (e.g. test failures), often important to *not* store an open handle to a moved file
         return if log_config.nil?
 
         Logging.logger.root.appenders = [Logging.appenders.stdout]
@@ -124,6 +129,7 @@ class Scarpe
       self.singleton_class.define_method(method) do |*args, **kwargs, &block|
         ret = @instance.send(method, *args, **kwargs, &block)
         @log.info("Method: #{method} Args: #{args.inspect} KWargs: #{kwargs.inspect} Block: #{block ? "y" : "n"} Return: #{ret.inspect}")
+        ret
       end
       send(method, ...)
     end

--- a/lib/scarpe/wv/control_interface_test.rb
+++ b/lib/scarpe/wv/control_interface_test.rb
@@ -21,6 +21,7 @@ class Scarpe
       wrangler.periodic_code("scarpeTestTimeout") do |*_args|
         if (Time.now - t_start).to_f > time
           @did_time_out = true
+          @log.warn("die_after - timed out after #{time.inspect}")
           app.destroy
         end
       end

--- a/lib/scarpe/wv/widget.rb
+++ b/lib/scarpe/wv/widget.rb
@@ -99,7 +99,7 @@ class Scarpe
     # Convert an [r, g, b, a] array to an HTML hex color code
     # Arrays support alpha. HTML hex does not. So premultiply.
     def rgb_to_hex(color)
-      return nil if color.nil?
+      return color if color.nil?
 
       r, g, b, a = *color
       if r.is_a?(Float)

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestControlInterface < ScarpeTest
+class TestControlInterface < LoggedScarpeTest
   def test_trivial_async_assert
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
       Shoes.app do
@@ -44,6 +44,8 @@ class TestControlInterface < ScarpeTest
     TEST_CODE
   end
 
+  # This test can occasionally still fail on CI -- need to replicate that and figure it out.
+  # Failure is a "returned no status code" in 2.9 seconds (long), which probably means a timeout.
   def test_assert_dom_html_update
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestExamplesWithWebview < ScarpeTest
+class TestExamplesWithWebview < LoggedScarpeTest
   match_str = ENV["EXAMPLES_MATCHING"] || ""
 
   examples_to_test = Dir["examples/**/*.rb"]
@@ -13,7 +13,7 @@ class TestExamplesWithWebview < ScarpeTest
   examples_to_test.each do |example_filename|
     example = example_filename.gsub("/", "_").gsub("-", "_").gsub(/.rb\Z/, "")
     define_method("test_webview_#{example}") do
-      run_test_scarpe_app(example_filename, exit_immediately: true, test_name: example)
+      run_test_scarpe_app(example_filename, exit_immediately: true)
     end
   end
 end

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestScarpe < ScarpeTest
+class TestScarpe < LoggedScarpeTest
   def test_that_it_has_a_version_number
     refute_nil ::Scarpe::VERSION
   end


### PR DESCRIPTION
Add convenience class for logging failures outside test_scarpe_code. Logs weren't getting uploaded as build artifacts - fix in workflow. Mention a failure in CI I'm still tracking down.

Use the new convenience class for logging webview scarpe code - this lets me separate the code better into multiple test classes.

For GHActions fix, see: https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f