### PR TITLE
Sort out debug options

### DIFF
--- a/exe/scarpe
+++ b/exe/scarpe
@@ -15,6 +15,7 @@ Usage: scarpe [OPTIONS] <scarpe app file>           # Same as "scarpe run"
        scarpe -v                                    # print the Scarpe gem version and exit
   Options:
       --dev                          Use development local scarpe, not an installed gem
+      --debug                        Turn on application debug mode
 USAGE
 end
 
@@ -34,6 +35,7 @@ def print_env
     Scarpe::WV environment:
       #{env_or_none("SCARPE_TEST_CONTROL")}
       #{env_or_none("SCARPE_TEST_RESULTS")}
+      #{env_or_none("SCARPE_DEBUG")}
     Ruby and shell environment:
       RUBY_DESCRIPTION: #{RUBY_DESCRIPTION.inspect}
       RUBY_PLATFORM: #{RUBY_PLATFORM.inspect}
@@ -50,6 +52,7 @@ end
 
 # --dev option applies to all actions
 use_dev = ARGV.delete("--dev") ? true : false
+use_debug = ARGV.delete("--debug") ? true : false
 
 verb = "run"
 verb_target = nil
@@ -80,6 +83,9 @@ else
   verb_target = ARGV[0]
 end
 
+if use_debug
+  ENV['SCARPE_DEBUG'] = 'true'
+end
 if use_dev
   dev_path = File.expand_path("../lib", __dir__)
   $LOAD_PATH.prepend dev_path

--- a/lib/scarpe/document_root.rb
+++ b/lib/scarpe/document_root.rb
@@ -4,9 +4,7 @@ class Scarpe
   class DocumentRoot < Scarpe::Widget
     include Scarpe::Background
 
-    display_property :debug
-
-    def initialize(debug: false)
+    def initialize
       super
 
       create_display_widget

--- a/lib/scarpe/wv/control_interface.rb
+++ b/lib/scarpe/wv/control_interface.rb
@@ -34,8 +34,8 @@ class Scarpe
     # This should get called once, from Scarpe::App
     def set_system_components(app:, doc_root:, wrangler:)
       unless app && wrangler
-        puts "app is false!" unless app
-        puts "wrangler is false!" unless wrangler
+        @log.error("False app passed to set_system_components!") unless app
+        @log.error("False wrangler passed to set_system_components!") unless wrangler
         raise "Must pass non-nil app and wrangler to ControlInterface#set_system_components!"
       end
       @app = app

--- a/lib/scarpe/wv/document_root.rb
+++ b/lib/scarpe/wv/document_root.rb
@@ -4,8 +4,6 @@ class Scarpe
   class WebviewDocumentRoot < Scarpe::WebviewWidget
     include Scarpe::WebviewBackground
 
-    attr_reader :debug
-
     def initialize(properties)
       @callbacks = {}
 

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -24,7 +24,7 @@ class TestScarpe < LoggedScarpeTest
   end
 
   def test_button_app
-    run_test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
       Shoes.app do
         @push = button "Push me", width: 200, height: 50, top: 109, left: 132
         @note = para "Nothing pushed so far"

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -15,39 +15,37 @@ class TestWebWranglerInScarpeApp < LoggedScarpeTest
     TEST_CODE
   end
 
-  ## We've had problems with dirty-tracking where the DOM stops updating after
-  ## the first change. But this test is unstable in CI, so it's commented out :-(
-  ## In CI, not even the initial para Hello goes through... We don't get a success
-  ## from it (at least once.)
-  #def test_assert_multiple_dom_updates
-  #  run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
-  #    Shoes.app do
-  #      para "Hello"
-  #    end
-  #  SCARPE_APP
-  #    on_event(:next_redraw) do
-  #      para = find_wv_widgets(Scarpe::WebviewPara)[0]
-  #      with_js_dom_html do |html_text|
-  #        assert html_text.include?("Hello"), "DOM HTML should include initial para text!"
-  #      end.then_ruby_promise do
-  #        # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
-  #        change = { "text_items" => [ "Goodbye" ] }
-  #        doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
-  #        wrangler.promise_dom_fully_updated
-  #      end.then_with_js_dom_html do |html_text|
-  #        assert html_text.include?("Goodbye"), "DOM root should contain the first replacement text! Text: #{html_text.inspect}"
-  #        assert !html_text.include?("Hello"), "DOM root shouldn't still contain the original text! Text: #{html_text.inspect}"
-  #      end.then_ruby_promise do
-  #        # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
-  #        change = { "text_items" => [ "Borzoi" ] }
-  #        doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
-  #        wrangler.promise_dom_fully_updated
-  #      end.then_with_js_dom_html do |html_text|
-  #        assert html_text.include?("Borzoi"), "DOM root should contain the second replacement text! Text: #{html_text.inspect}"
-  #      end.then { return_when_assertions_done }
-  #    end
-  #  TEST_CODE
-  #end
+  # We've had problems with dirty-tracking where the DOM stops updating after
+  # the first change.
+  def test_assert_multiple_dom_updates
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+      Shoes.app do
+        para "Hello"
+      end
+    SCARPE_APP
+      on_event(:next_redraw) do
+        para = find_wv_widgets(Scarpe::WebviewPara)[0]
+        with_js_dom_html do |html_text|
+          assert html_text.include?("Hello"), "DOM HTML should include initial para text!"
+        end.then_ruby_promise do
+          # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
+          change = { "text_items" => [ "Goodbye" ] }
+          doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
+          wrangler.promise_dom_fully_updated
+        end.then_with_js_dom_html do |html_text|
+          assert html_text.include?("Goodbye"), "DOM root should contain the first replacement text! Text: #{html_text.inspect}"
+          assert !html_text.include?("Hello"), "DOM root shouldn't still contain the original text! Text: #{html_text.inspect}"
+        end.then_ruby_promise do
+          # We'll send the signal that changes the para text, as though we called Scarpe's para.replace
+          change = { "text_items" => [ "Borzoi" ] }
+          doc_root.send_shoes_event(change, event_name: "prop_change", target: para.shoes_linkable_id)
+          wrangler.promise_dom_fully_updated
+        end.then_with_js_dom_html do |html_text|
+          assert html_text.include?("Borzoi"), "DOM root should contain the second replacement text! Text: #{html_text.inspect}"
+        end.then { return_when_assertions_done }
+      end
+    TEST_CODE
+  end
 end
 
 class TestWebWranglerMocked < LoggedScarpeTest


### PR DESCRIPTION
Sort out how "debug" fields should work, including adding a --debug CLI option and SCARPE_DEBUG env var.

Make sure we always use debug for logged tests so that we'll preserve Webview API calls for CI test failures.

Convert some console printing to log messages. Remove a chunk of debug library for NoDisplay that is no longer used.

This builds on an existing PR. It could change before being merged, so I've marked this draft for now.

Fixes issue #221 . Fixes issue #104 .