### PR TITLE
Merge shoes and display events into just one event type

### DIFF
--- a/lib/scarpe/button.rb
+++ b/lib/scarpe/button.rb
@@ -2,9 +2,13 @@
 
 class Scarpe
   class Button < Scarpe::Widget
+    include Scarpe::Log
+
     display_properties :text, :width, :height, :top, :left
 
     def initialize(text, width: nil, height: nil, top: nil, left: nil, &block)
+      log_init("Button")
+
       # Properties passed as positional args, not keywords, don't get auto-set
       @text = text
       @block = block
@@ -13,6 +17,7 @@ class Scarpe
 
       # Bind to a handler named "click"
       bind_self_event("click") do
+        @log.debug("Button clicked, calling handler") if @block
         @block&.call
       end
 

--- a/lib/scarpe/display_service.rb
+++ b/lib/scarpe/display_service.rb
@@ -3,7 +3,20 @@
 # Scarpe Shoes apps operate in multiple layers. A Shoes widget tree exists as fairly
 # plain, simple Ruby objects. And then a display-service widget tree integrates with
 # the display technology, initially Webview. This lets us use Ruby as our API while
-# not tying it too closely to some fairly serious limitations of Webview.
+# not tying it too closely to the limitations of Webview.
+#
+# ## Choosing Display Services
+#
+# Before running a Scarpe app, you can set SCARPE_DISPLAY_SERVICE. If you
+# set it to "whatever_service", Scarpe will require "scarpe/whatever_service",
+# which can be supplied by the Scarpe gem or another Scarpe-based gem.
+# Currently leaving the environment variable empty is equivalent to requesting
+# local Webview.
+#
+# ## Events
+#
+# Events are a lot of what tie the Shoes widgets and the display service together.
+#
 # Scarpe widgets *expect* to operate in a fairly "hands off" mode where they record
 # to an event queue to send to the display service, and the display service records
 # events to send back.
@@ -25,27 +38,25 @@
 # you want both. But internally they're immediately dispatched as events
 # rather than keeping a literal array of items.
 #
-# ## Choosing Display Services
-#
-# Before running a Scarpe app, you can set SCARPE_DISPLAY_SERVICE. A single
-# dash means no display service. A list of class names will cause Scarpe
-# to instantiate that class or those classes as the display service(s).
-# Leaving the variable unset is equivalent to "Scarpe::WebviewDisplayService".
 class Scarpe
   class DisplayService
-    DS_EVENT_TYPES = [:shoes, :display]
-
     class << self
+      # This is in the eigenclass/metaclass, *not* instances of DisplayService
+      include Scarpe::Log
+
       attr_accessor :json_debug_serialize
 
       # An event_target may be nil, to indicate there is no target.
-      def dispatch_event(event_type, event_name, event_target, *args, **kwargs)
+      def dispatch_event(event_name, event_target, *args, **kwargs)
         @@display_event_handlers ||= {}
-        unless DS_EVENT_TYPES.include?(event_type)
-          raise("Unknown event type #{event_type.inspect}! Known types are #{DS_EVENT_TYPES.inspect}!")
+
+        unless @log
+          log_init("DisplayService")
         end
 
         raise "Cannot dispatch on event_name :any!" if event_name == :any
+
+        @log.debug("Dispatch event: #{event_name.inspect} T: #{event_target.inspect} A: #{args.inspect} KW: #{kwargs.inspect}")
 
         if DisplayService.json_debug_serialize
           args = JSON.parse JSON.dump(args)
@@ -56,11 +67,8 @@ class Scarpe
           kwargs = new_kw
         end
 
-        same_type_handlers = @@display_event_handlers[event_type] || {}
-        return if same_type_handlers.empty?
-
-        same_name_handlers = same_type_handlers[event_name] || {}
-        any_name_handlers = same_type_handlers[:any] || {}
+        same_name_handlers = @@display_event_handlers[event_name] || {}
+        any_name_handlers = @@display_event_handlers[:any] || {}
 
         # Do we have any keys, in same_name_handlers or any_name_handlers, matching the target or :any?
         # Note that "nil" is a target like any other for these purposes -- subscribing to a nil target
@@ -71,7 +79,6 @@ class Scarpe
           any_name_handlers[:any],            # Any name, any target
           any_name_handlers[event_target],    # Any name, same target
         ].compact.inject([], &:+)
-
         kwargs[:event_name] = event_name
         kwargs[:event_target] = event_target if event_target
         handlers.each { |h| h[:handler].call(*args, **kwargs) }
@@ -79,23 +86,25 @@ class Scarpe
 
       # It's permitted to subscribe to event_name :any for all event names, and event_target :any for all targets.
       # An event_target of nil means "no target", and only matches events dispatched with a nil target.
-      def subscribe_to_event(event_type, event_name, event_target, &handler)
+      def subscribe_to_event(event_name, event_target, &handler)
         @@display_event_handlers ||= {}
         @@display_event_unsub_id ||= 0
-        unless DS_EVENT_TYPES.include?(event_type)
-          raise("Unknown event type #{event_type.inspect}! Known types are #{DS_EVENT_TYPES.inspect}!")
-        end
         unless handler
           raise "Must pass a block as a handler to DisplayService.subscribe_to_event!"
         end
 
+        unless @log
+          log_init("DisplayService")
+        end
+
+        @log.debug("Subscribe to event: #{event_name.inspect} T: #{event_target.inspect}")
+
         id = @@display_event_unsub_id
         @@display_event_unsub_id += 1
 
-        @@display_event_handlers[event_type] ||= {}
-        @@display_event_handlers[event_type][event_name] ||= {}
-        @@display_event_handlers[event_type][event_name][event_target] ||= []
-        @@display_event_handlers[event_type][event_name][event_target] << { handler:, unsub_id: id }
+        @@display_event_handlers[event_name] ||= {}
+        @@display_event_handlers[event_name][event_target] ||= []
+        @@display_event_handlers[event_name][event_target] << { handler:, unsub_id: id }
 
         id
       end
@@ -103,11 +112,9 @@ class Scarpe
       def unsub_from_events(unsub_id)
         raise "Must provide an unsubscribe ID!" if unsub_id.nil?
 
-        @@display_event_handlers.each do |_type, e_name_hash|
-          e_name_hash.each do |_e_name, target_hash|
-            target_hash.each do |_target, h_list|
-              h_list.delete_if { |item| item[:unsub_id] == unsub_id }
-            end
+        @@display_event_handlers.each do |_e_name, target_hash|
+          target_hash.each do |_target, h_list|
+            h_list.delete_if { |item| item[:unsub_id] == unsub_id }
           end
         end
       end
@@ -132,6 +139,9 @@ class Scarpe
       end
     end
 
+    # This is for objects that can be referred to via events, using their
+    # IDs. There are also convenience functions for binding and sending
+    # events.
     class Linkable
       attr_reader :linkable_id
 
@@ -139,21 +149,41 @@ class Scarpe
         @linkable_id = linkable_id
       end
 
-      def send_shoes_event(*args, event_name:, target: nil, **kwargs)
-        DisplayService.dispatch_event(:shoes, event_name, target, *args, **kwargs)
+      def send_self_event(*args, event_name:, **kwargs)
+        DisplayService.dispatch_event(event_name, self.linkable_id, *args, **kwargs)
       end
 
-      def send_display_event(*args, event_name:, target: nil, **kwargs)
-        DisplayService.dispatch_event(:display, event_name, target, *args, **kwargs)
+      def send_shoes_event(*args, event_name:, target: nil, **kwargs)
+        DisplayService.dispatch_event(event_name, target, *args, **kwargs)
       end
 
       def bind_shoes_event(event_name:, target: nil, &handler)
-        DisplayService.subscribe_to_event(:shoes, event_name, target, &handler)
+        DisplayService.subscribe_to_event(event_name, target, &handler)
+      end
+    end
+
+    # These methods are an interface to DisplayService objects.
+
+    def create_display_widget_for(widget_class_name, widget_id, properties)
+      raise "Override in DisplayService implementation!"
+    end
+
+    def set_widget_pairing(id, display_widget)
+      @display_widget_for ||= {}
+      @display_widget_for[id] = display_widget
+    end
+
+    def query_display_widget_for(id, nil_ok: false)
+      display_widget = @display_widget_for[id]
+      unless display_widget || nil_ok
+        raise "Could not find display widget for linkable ID #{id.inspect}!"
       end
 
-      def bind_display_event(event_name:, target: nil, &handler)
-        DisplayService.subscribe_to_event(:display, event_name, target, &handler)
-      end
+      display_widget
+    end
+
+    def destroy
+      raise "Override in DisplayService implementation!"
     end
   end
 end

--- a/lib/scarpe/glibui/alert.rb
+++ b/lib/scarpe/glibui/alert.rb
@@ -6,7 +6,7 @@ class Scarpe
       super
 
       bind("click") do
-        send_display_event(event_name: "click", target: shoes_linkable_id)
+        send_self_event(event_name: "click")
       end
     end
 

--- a/lib/scarpe/glibui/app.rb
+++ b/lib/scarpe/glibui/app.rb
@@ -13,7 +13,7 @@ class Scarpe
     def initialize(properties)
       super
 
-      bind_display_event(event_name: "run") do
+      bind_shoes_event(event_name: "run") do
         code = @document_root.display(properties)
         puts code
         # This is for if I want to confirm textual output. But not actually fire up the service.

--- a/lib/scarpe/glibui/button.rb
+++ b/lib/scarpe/glibui/button.rb
@@ -8,7 +8,7 @@ class Scarpe
       # Bind to display-side handler for "click"
       bind("click") do
         # This will be sent to the bind_self_event in Button
-        send_display_event(event_name: "click", target: shoes_linkable_id)
+        send_self_event(event_name: "click")
       end
     end
 

--- a/lib/scarpe/glibui/edit_box.rb
+++ b/lib/scarpe/glibui/edit_box.rb
@@ -9,7 +9,7 @@ class Scarpe
 
       # The JS handler sends a "change" event, which we forward to the Shoes widget tree
       bind("change") do |new_text|
-        send_display_event(new_text, event_name: "change", target: shoes_linkable_id)
+        send_self_event(new_text, event_name: "change")
       end
     end
 

--- a/lib/scarpe/glibui/edit_line.rb
+++ b/lib/scarpe/glibui/edit_line.rb
@@ -9,7 +9,7 @@ class Scarpe
 
       # The JS handler sends a "change" event, which we forward to the Shoes widget tree
       bind("change") do |new_text|
-        send_display_event(new_text, event_name: "change", target: shoes_linkable_id)
+        send_self_event(new_text, event_name: "change")
       end
     end
 

--- a/lib/scarpe/glibui/link.rb
+++ b/lib/scarpe/glibui/link.rb
@@ -6,7 +6,7 @@ class Scarpe
       super
 
       bind("click") do
-        send_display_event(event_name: "click", target: shoes_linkable_id)
+        send_self_event(event_name: "click")
       end
     end
 

--- a/lib/scarpe/logger.rb
+++ b/lib/scarpe/logger.rb
@@ -10,7 +10,10 @@ class Scarpe
   # configured component.
   module Log
     DEFAULT_LOG_CONFIG = {
-      "default": "info",
+      "default" => "info",
+    }
+    DEFAULT_DEBUG_LOG_CONFIG = {
+      "default" => "debug",
     }
 
     def log_init(component = self)
@@ -136,6 +139,10 @@ class Scarpe
   end
 end
 
-log_config = ENV["SCARPE_LOG_CONFIG"] ? JSON.load_file(ENV["SCARPE_LOG_CONFIG"]) : Scarpe::Log::DEFAULT_LOG_CONFIG
+log_config = if ENV["SCARPE_LOG_CONFIG"]
+  JSON.load_file(ENV["SCARPE_LOG_CONFIG"])
+else
+  ENV["SCARPE_DEBUG"] ? Scarpe::Log::DEFAULT_DEBUG_LOG_CONFIG : Scarpe::Log::DEFAULT_LOG_CONFIG
+end
 
 Scarpe::Logger.configure_logger(log_config)

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -78,17 +78,17 @@ class Scarpe
         end
       end
 
-      super() # Can specify linkable_id, but no reason to
+      super() # linkable_id defaults to object_id
     end
 
     def bind_self_event(event_name, &block)
       raise("Widget has no linkable_id! #{inspect}") unless linkable_id
 
-      bind_display_event(event_name: event_name, target: linkable_id, &block)
+      bind_shoes_event(event_name: event_name, target: linkable_id, &block)
     end
 
     def bind_no_target_event(event_name, &block)
-      bind_display_event(event_name:, &block)
+      bind_shoes_event(event_name:, &block)
     end
 
     def display_properties

--- a/lib/scarpe/wv/alert.rb
+++ b/lib/scarpe/wv/alert.rb
@@ -6,7 +6,7 @@ class Scarpe
       super
 
       bind("click") do
-        send_display_event(event_name: "click", target: shoes_linkable_id)
+        send_self_event(event_name: "click")
       end
     end
 

--- a/lib/scarpe/wv/app.rb
+++ b/lib/scarpe/wv/app.rb
@@ -39,9 +39,9 @@ class Scarpe
       # ControlInterface.new.
       @control_interface.set_system_components app: self, doc_root: nil, wrangler: @view
 
-      bind_display_event(event_name: "init") { init }
-      bind_display_event(event_name: "run") { run }
-      bind_display_event(event_name: "destroy") { destroy }
+      bind_shoes_event(event_name: "init") { init }
+      bind_shoes_event(event_name: "run") { run }
+      bind_shoes_event(event_name: "destroy") { destroy }
     end
 
     attr_writer :document_root

--- a/lib/scarpe/wv/button.rb
+++ b/lib/scarpe/wv/button.rb
@@ -8,7 +8,7 @@ class Scarpe
       # Bind to display-side handler for "click"
       bind("click") do
         # This will be sent to the bind_self_event in Button
-        send_display_event(event_name: "click", target: shoes_linkable_id)
+        send_self_event(event_name: "click")
       end
     end
 

--- a/lib/scarpe/wv/control_interface_test.rb
+++ b/lib/scarpe/wv/control_interface_test.rb
@@ -193,6 +193,10 @@ class Scarpe
     def with_js_dom_html(wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT, &block)
       with_js_value("document.getElementById('wrapper-wvroot').innerHTML", wait_for: wait_for, timeout: timeout, &block)
     end
+
+    def fully_updated(wait_for: [])
+      wrangler.promise_dom_fully_updated
+    end
   end
 
   # A Promise but with helper functions

--- a/lib/scarpe/wv/edit_box.rb
+++ b/lib/scarpe/wv/edit_box.rb
@@ -9,7 +9,7 @@ class Scarpe
 
       # The JS handler sends a "change" event, which we forward to the Shoes widget tree
       bind("change") do |new_text|
-        send_display_event(new_text, event_name: "change", target: shoes_linkable_id)
+        send_self_event(new_text, event_name: "change")
       end
     end
 

--- a/lib/scarpe/wv/edit_line.rb
+++ b/lib/scarpe/wv/edit_line.rb
@@ -9,7 +9,7 @@ class Scarpe
 
       # The JS handler sends a "change" event, which we forward to the Shoes widget tree
       bind("change") do |new_text|
-        send_display_event(new_text, event_name: "change", target: shoes_linkable_id)
+        send_self_event(new_text, event_name: "change")
       end
     end
 

--- a/lib/scarpe/wv/link.rb
+++ b/lib/scarpe/wv/link.rb
@@ -6,7 +6,7 @@ class Scarpe
       super
 
       bind("click") do
-        send_display_event(event_name: "click", target: shoes_linkable_id)
+        send_self_event(event_name: "click")
       end
     end
 

--- a/lib/scarpe/wv/list_box.rb
+++ b/lib/scarpe/wv/list_box.rb
@@ -9,7 +9,7 @@ class Scarpe
 
       # The JS handler sends a "change" event, which we forward to the Shoes widget tree
       bind("change") do |new_item|
-        send_display_event(new_item, event_name: "change", target: shoes_linkable_id)
+        send_event(new_item, event_name: "change")
       end
     end
 

--- a/lib/scarpe/wv/webview_local_display.rb
+++ b/lib/scarpe/wv/webview_local_display.rb
@@ -6,14 +6,15 @@ class Scarpe
   # process, too many or too large evals can crash the process, etc.
   # Normally the intention is to use a RelayDisplayService to a second
   # process containing one of these.
-  class WebviewDisplayService
+  class WebviewDisplayService < Scarpe::DisplayService
+    include Scarpe::Log
+
     class << self
       attr_accessor :instance
     end
 
     # TODO: re-think the list of top-level singleton objects.
     attr_reader :control_interface
-    attr_reader :app
     attr_reader :doc_root
     attr_reader :wrangler
 
@@ -24,6 +25,9 @@ class Scarpe
       end
 
       WebviewDisplayService.instance = self
+
+      super()
+      log_init("WV::WebviewDisplayService")
 
       @display_widget_for = {}
     end
@@ -55,19 +59,6 @@ class Scarpe
         # WebviewDocumentRoot is created before WebviewApp. Mostly doc_root is just like any other widget,
         # but we'll want a reference to it when we create WebviewApp.
         @doc_root = display_widget
-      end
-
-      display_widget
-    end
-
-    def set_widget_pairing(id, display_widget)
-      @display_widget_for[id] = display_widget
-    end
-
-    def query_display_widget_for(id, nil_ok: false)
-      display_widget = @display_widget_for[id]
-      unless display_widget || nil_ok
-        raise "Could not find display widget for linkable ID #{id.inspect}!"
       end
 
       display_widget

--- a/lib/scarpe/wv/widget.rb
+++ b/lib/scarpe/wv/widget.rb
@@ -61,7 +61,7 @@ class Scarpe
         destroy_self
       end
 
-      super()
+      super(linkable_id: @shoes_linkable_id)
     end
 
     # This exists to be overridden by children watching for changes

--- a/lib/scarpe/wv/wv_display_worker.rb
+++ b/lib/scarpe/wv/wv_display_worker.rb
@@ -37,7 +37,7 @@ class WebviewContainedService < Scarpe::DisplayService::Linkable
     @init_done = false
 
     # Wait to register our periodic_code until the wrangler exists
-    @event_subs << bind_display_event(event_name: "init") do
+    @event_subs << bind_shoes_event(event_name: "init") do
       @wv_display.wrangler.periodic_code("datagramProcessor", 0.1) do
         respond_to_datagram while ready_to_read?(0.0)
       end
@@ -47,14 +47,6 @@ class WebviewContainedService < Scarpe::DisplayService::Linkable
     # Subscribe to all event notifications and relay them to the opposite side
     @event_subs << bind_shoes_event(event_name: :any, target: :any) do |*args, **kwargs|
       unless kwargs[:relayed] || kwargs["relayed"]
-        kwargs[:event_type] = :shoes
-        kwargs[:relayed] = true
-        send_datagram({ type: :event, args:, kwargs: })
-      end
-    end
-    @event_subs << bind_display_event(event_name: :any, target: :any) do |*args, **kwargs|
-      unless kwargs[:relayed]
-        kwargs[:event_type] = :display
         kwargs[:relayed] = true
         send_datagram({ type: :event, args:, kwargs: })
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -189,7 +189,12 @@ class LoggedScarpeTest < ScarpeTest
   def log_config_for_test
     {
       "default" => ["debug", "logger/test_failure_#{file_id}.log"],
+
       "WebviewAPI" => ["debug", "logger/test_failure_wv_api_#{file_id}.log"],
+
+      "DisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
+      "WV::RelayDisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
+      "WV::WebviewDisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
     }
   end
 


### PR DESCRIPTION
Also add a DisplayService parent class and interface.

Log events subscribed-to and sent when testing or in debug mode.

Add a test for the Webview->Shoes event direction so we'll notice if that's ever completely broken.