### PR TITLE
Simplify destroy-event handling and heartbeats

### DIFF
--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -7,7 +7,7 @@ class Scarpe
     end
     include Scarpe::Log
 
-    display_properties :title, :width, :height, :resizable, :debug, :do_shutdown
+    display_properties :title, :width, :height, :resizable, :debug
 
     def initialize(
       title: "Scarpe!",
@@ -64,15 +64,6 @@ class Scarpe
     # of the main thread. Local Webview even stops any background threads.
     def run
       send_shoes_event(event_name: "run")
-
-      # The display service should take control when it receives the run event.
-      # If it return immediately here, that normally means a failure.
-
-      # TODO: remove this loop after fixing the Webview relay service not to require it.
-      until @do_shutdown
-        send_shoes_event(event_name: "heartbeat")
-        sleep 0.1
-      end
     end
 
     def destroy(send_event: true)

--- a/lib/scarpe/wv/control_interface_test.rb
+++ b/lib/scarpe/wv/control_interface_test.rb
@@ -22,6 +22,7 @@ class Scarpe
         if (Time.now - t_start).to_f > time
           @did_time_out = true
           @log.warn("die_after - timed out after #{time.inspect}")
+          return_results([false, "Timed out!", time])
           app.destroy
         end
       end

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -13,7 +13,7 @@ class Scarpe
     include Scarpe::Log
 
     attr_reader :is_running
-    attr_reader :heartbeat
+    attr_reader :heartbeat # This is the heartbeat duration in seconds, usually fractional
     attr_reader :control_interface
 
     # This error indicates a problem when running ConfirmedEval

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestControlInterface < LoggedScarpeTest
   def test_trivial_async_assert
-    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 1.0)
       Shoes.app do
         para "Hello World"
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,24 +46,29 @@ class ScarpeTest < Minitest::Test
   end
 
   SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
-  TEST_OPTS = [:timeout, :allow_fail, :allow_timeout, :exit_immediately]
+  TEST_OPTS = [:timeout, :allow_fail, :exit_immediately]
   LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
 
-  def run_test_scarpe_code(scarpe_app_code, test_code: "", **opts)
-    bad_opts = opts.keys - TEST_OPTS
-    raise "Bad options passed to run_test_scarpe_code: #{bad_opts.inspect}!" unless bad_opts.empty?
+  def run_test_scarpe_code(
+    scarpe_app_code,
+    **opts
+  )
 
     with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
-      run_test_scarpe_app(test_app_location, test_code:, **opts)
+      run_test_scarpe_app(test_app_location, **opts)
     end
   end
 
-  def run_test_scarpe_app(test_app_location, test_code: "", **opts)
-    bad_opts = opts.keys - TEST_OPTS
-    raise "Bad options passed to run_test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
+  def run_test_scarpe_app(
+    test_app_location,
+    test_code: "",
+    timeout: 1.5,
+    allow_fail: false,
+    exit_immediately: false,
+    display_service: "wv_local"
+  )
 
     with_tempfile("scarpe_test_results.json", "") do |result_path|
-      timeout = opts[:timeout] ? opts[:timeout].to_f : 1.5
       scarpe_test_code = <<~SCARPE_TEST_CODE
         require "scarpe/wv/control_interface_test"
 
@@ -74,7 +79,7 @@ class ScarpeTest < Minitest::Test
 
       scarpe_test_code += test_code
 
-      if opts[:exit_immediately]
+      if exit_immediately
         scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
           on_event(:next_heartbeat) do
             Scarpe::Logger.logger("ScarpeTest").info("Dying on heartbeat because :exit_immediately is set")
@@ -103,11 +108,11 @@ class ScarpeTest < Minitest::Test
       end
 
       # If failure is okay, don't check for status or assertions
-      return if opts[:allow_fail]
+      return if allow_fail
 
       # If we exit immediately with no result written, that's fine.
       # But if we wrote a result, make sure it says pass, not fail.
-      return if opts[:exit_immediately] && !File.exist?(result_path)
+      return if exit_immediately && !File.exist?(result_path)
 
       unless File.exist?(result_path)
         return assert(false, "Scarpe app returned no status code!")
@@ -123,13 +128,13 @@ class ScarpeTest < Minitest::Test
       # If we exit immediately we still need a results file and a true value.
       # We were getting exit_immediately being fine with apps segfaulting,
       # so we need to check.
-      if opts[:exit_immediately]
+      if exit_immediately
         if out_data[0]
           # That's all we needed!
           return
         end
 
-        save_failure_logs(test_name:)
+        save_failure_logs
         assert false, "App exited immediately, but its results were false! #{out_data.inspect}"
       end
 
@@ -242,7 +247,7 @@ class LoggedScarpeTest < ScarpeTest
     end
 
     if File.exist?(out_loc)
-      raise "Duplicate test name #{test_name.inspect}? This file should *not* already exist!"
+      raise "Duplicate test file #{out_loc.inspect}? This file should *not* already exist!"
     end
 
     out_loc

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,6 @@ class ScarpeTest < Minitest::Test
   end
 
   SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
-  TEST_OPTS = [:timeout, :allow_fail, :exit_immediately]
   LOGGER_DIR = File.expand_path("#{__dir__}/../logger")
 
   def run_test_scarpe_code(
@@ -62,7 +61,7 @@ class ScarpeTest < Minitest::Test
   def run_test_scarpe_app(
     test_app_location,
     test_code: "",
-    timeout: 1.5,
+    timeout: 2.5,
     allow_fail: false,
     exit_immediately: false,
     display_service: "wv_local"
@@ -134,12 +133,11 @@ class ScarpeTest < Minitest::Test
           return
         end
 
-        save_failure_logs
         assert false, "App exited immediately, but its results were false! #{out_data.inspect}"
       end
 
       unless out_data[0]
-        puts JSON.pretty_generate(out_data[1])
+        puts JSON.pretty_generate(out_data[1..-1])
         assert false, "Some Scarpe tests failed..."
       end
 

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -2,13 +2,21 @@
 
 require "test_helper"
 
-class TestScarpe < LoggedScarpeTest
+class TestWebviewScarpe < LoggedScarpeTest
   def test_that_it_has_a_version_number
     refute_nil ::Scarpe::VERSION
   end
 
   def test_hello_world_app
     run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+      Shoes.app do
+        para "Hello World"
+      end
+    SCARPE_APP
+  end
+
+  def test_hello_world_app_wv_relay
+    run_test_scarpe_code(<<-'SCARPE_APP', display_service: "wv_relay", exit_immediately: true)
       Shoes.app do
         para "Hello World"
       end
@@ -63,6 +71,20 @@ class TestScarpe < LoggedScarpeTest
 
   def test_widgets_exist
     run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+      Shoes.app do
+        stack do
+          para "Here I am"
+          button "Push me"
+          alert "I am an alert!"
+          edit_line "edit_line here", width: 450
+          image "http://shoesrb.com/manual/static/shoes-icon.png"
+        end
+      end
+    SCARPE_APP
+  end
+
+  def test_widgets_exist_wv_relay
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true, display_service: "wv_relay")
       Shoes.app do
         stack do
           para "Here I am"

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -71,6 +71,20 @@ class TestWebWranglerInScarpeApp < LoggedScarpeTest
       end
     TEST_CODE
   end
+
+  # When the Display Service side sends a destroy event, everything should shut down.
+  def test_destroy_from_display_service
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
+      Shoes.app do
+        para "Hello"
+      end
+    SCARPE_APP
+      on_event(:next_redraw) do
+        return_results([true, "Destroy and exit"])
+        DisplayService.dispatch_event("destroy", nil)
+      end
+    TEST_CODE
+  end
 end
 
 class TestWebWranglerMocked < LoggedScarpeTest

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class TestWebWranglerInScarpeApp < LoggedScarpeTest
   # Need to make sure that even with no widgets we still get at least one redraw
   def test_empty_app
-    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 0.5)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE', timeout: 1.0)
       Scarpe.app do
       end
     SCARPE_APP


### PR DESCRIPTION
Add a test for destroying from the display lib side. Add a couple of simple Webview-Relay tests

Fixes #232

### Description

See issue #232 for more details. There are also Wiki pages summarising our desired event loops, heartbeats, etc.

Since event handling affects Webview-relay pretty heavily, it was way past time for some tests verifying the very basics.

I also added a test to verify that we can stop the app using the "destroy" event from the display service side. That hasn't always been true, and so we've had to exit the process with exit (etc.)

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
