### PR TITLE
Add simple round-trip tests for async JS and tracking

### DIFF
--- a/lib/scarpe/logger.rb
+++ b/lib/scarpe/logger.rb
@@ -53,11 +53,11 @@ class Scarpe
       def json_to_appender(data)
         case data.downcase
         when "stdout"
-          Logging.appenders.stdout
+          Logging.appenders.stdout layout: @custom_log_layout
         when "stderr"
-          Logging.appenders.stderr
+          Logging.appenders.stderr layout: @custom_log_layout
         when String
-          Logging.appenders.file(data)
+          Logging.appenders.file data, layout: @custom_log_layout
         else
           raise "Don't know how to convert #{data.inspect} to an appender!"
         end
@@ -94,6 +94,9 @@ class Scarpe
       public
 
       def configure_logger(log_config)
+        # TODO: custom coloring? https://github.com/TwP/logging/blob/master/examples/colorization.rb
+        @custom_log_layout = Logging.layouts.pattern pattern: '[%r] %-5l %c: %m\n'
+
         if log_config.is_a?(String) && File.exist?(log_config)
           log_config = JSON.load_file(log_config)
         end

--- a/lib/scarpe/unit_test_helpers.rb
+++ b/lib/scarpe/unit_test_helpers.rb
@@ -93,6 +93,7 @@ module Scarpe::Test::LoggedTest
       "DisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
       "WV::RelayDisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
       "WV::WebviewDisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
+      "WV::ControlInterface" => ["debug", "logger/test_failure_events_#{file_id}.log"],
     }
   end
 

--- a/lib/scarpe/wv/control_interface.rb
+++ b/lib/scarpe/wv/control_interface.rb
@@ -18,11 +18,13 @@ class Scarpe
     DISPATCH_EVENTS = [:init, :shutdown, :redraw, :heartbeat]
 
     attr_writer :doc_root
+    attr_reader :do_shutdown
 
     # The control interface needs to see major system components to hook into their events
     def initialize
       log_init("WV::ControlInterface")
 
+      @do_shutdown = false
       @event_handlers = {}
       (SUBSCRIBE_EVENTS | DISPATCH_EVENTS).each { |e| @event_handlers[e] = [] }
     end
@@ -104,6 +106,8 @@ class Scarpe
         raise "Illegal dispatch of event #{event.inspect}! Valid values are: #{DISPATCH_EVENTS.inspect}"
       end
 
+      return if @do_shutdown
+
       if event == :redraw
         dumb_dispatch_event(:every_redraw, *args, **keywords)
 
@@ -126,6 +130,10 @@ class Scarpe
         dumb_dispatch_event(:next_heartbeat, *args, **keywords)
         @event_handlers[:next_heartbeat] -= handlers
         return
+      end
+
+      if event == :shutdown
+        @do_shutdown = true
       end
 
       dumb_dispatch_event(event, *args, **keywords)

--- a/lib/scarpe/wv/control_interface.rb
+++ b/lib/scarpe/wv/control_interface.rb
@@ -98,6 +98,8 @@ class Scarpe
 
     # Send out the specified event
     def dispatch_event(event, *args, **keywords)
+      @log.debug("CTL event #{event.inspect} #{args.inspect} #{keywords.inspect}")
+
       unless DISPATCH_EVENTS.include?(event)
         raise "Illegal dispatch of event #{event.inspect}! Valid values are: #{DISPATCH_EVENTS.inspect}"
       end

--- a/lib/scarpe/wv/control_interface_test.rb
+++ b/lib/scarpe/wv/control_interface_test.rb
@@ -224,8 +224,12 @@ class Scarpe
       end
     end
 
+    def then_with_js_value(js_code, wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT, &block)
+      @iface.with_js_value(js_code, wait_for: (wait_for + [self]), timeout:, &block)
+    end
+
     def then_with_js_dom_html(wait_for: [], timeout: DEFAULT_ASSERTION_TIMEOUT, &block)
-      @iface.with_js_dom_html(wait_for: (wait_for + [self]), timeout: timeout, &block)
+      @iface.with_js_dom_html(wait_for: (wait_for + [self]), timeout:, &block)
     end
   end
 end

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -277,3 +277,41 @@ class TestWebWranglerMocked < LoggedScarpeTest
     end
   end
 end
+
+class TestWebWranglerAsyncJS < LoggedScarpeTest
+  def round_trip_app(how_many)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-TEST_CODE, timeout: 5.0)
+      Scarpe.app do
+        para "Hello"
+      end
+    SCARPE_APP
+      on_event(:next_redraw) do
+        num_times = #{how_many}
+
+        p = wrangler.eval_js_async("document.tests = {}")
+        num_times.times do |i|
+          next_p = p.on_fulfilled do
+            wrangler.eval_js_async("document.tests[\#{i}] = true")
+          end
+          p = next_p
+        end
+
+        with_js_value("document.tests", wait_for: [p]) do |tests_hash|
+          expected_value = {}
+          num_times.times { |i| expected_value[i.to_s] = true }
+          assert_equal expected_value, tests_hash
+        end.then { return_when_assertions_done }
+      end
+    TEST_CODE
+  end
+
+  def test_many_round_trips
+    round_trip_app(30)
+  end
+
+  def test_many_app_starts
+    20.times do
+      round_trip_app(5)
+    end
+  end
+end


### PR DESCRIPTION
* Add better events logging
* Don't allow heartbeats and redraws to be delivered by ControlInterface after shutdown
* Add simple round-trip tests for async JS and tracking

Add some tests that just do simple JS round trips over and over, then check at the end that all the messages arrived. These have been fine on MacOS for some time, but we keep having trouble with similar things in GTK+ in CI.

Fixes #240

### Description

Added a TestPromise convenience helper for a JS round-trip thing, and then the tests themselves.

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
