### PR TITLE
list_box send_event to send_self_event

### DIFF
--- a/lib/scarpe/wv/list_box.rb
+++ b/lib/scarpe/wv/list_box.rb
@@ -9,7 +9,7 @@ class Scarpe
 
       # The JS handler sends a "change" event, which we forward to the Shoes widget tree
       bind("change") do |new_item|
-        send_event(new_item, event_name: "change")
+        send_self_event(new_item, event_name: "change")
       end
     end
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to Scarpe! 💖
-->

### Description

listbox send_event should be send_self_event

<!-- Please write a summary of the change, Please also include relevant motivation and context: -->



<!-- Add image of the feature u added here -->

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
<!--
for Linter

bundle exec rubocop

this would autocorrect offenses if they are autocorrectable.
bundle exec rubocop . --autocorrect-all

-->
