### PR TITLE
Allow using warning for warn

### DIFF
--- a/lib/scarpe/logger.rb
+++ b/lib/scarpe/logger.rb
@@ -139,6 +139,10 @@ class Scarpe
   end
 end
 
+class Logging::Logger
+  alias_method :warning, :warn
+end
+
 log_config = if ENV["SCARPE_LOG_CONFIG"]
   JSON.load_file(ENV["SCARPE_LOG_CONFIG"])
 else


### PR DESCRIPTION
This is for loggers. We use the Logging library, so the relevant class is Logging::Logger.

### Description

I managed to break "close the window to quit the app" by using @log.warning instead of @log.warn. While I could switch that back... that's a pain to remember, and I don't think this will be the last time this happens.

So I aliased Logging::Logger#warning to call warn, so it does the right thing. This fixes the "close the window to quit" workflow too.

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
