### PR TITLE
Initial 'build YARD on push' workflow

### DIFF
--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -1,0 +1,44 @@
+# Taken from: https://github.com/marketplace/actions/deploy-yard-to-pages
+
+name: Deploy API docs to GitHub Pages
+on:
+  push:
+    branches: ['main']
+    paths:
+      - '.github/workflows/pages.yml'
+      - '.yardopts'
+      - 'lib/**'
+      - '**.gemspec'
+      - 'Gemfile'
+      - '**.md'
+      - '**.txt'
+    # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy_yard:
+    # the deploy environment (not to be confused with env)
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    name: Build and deploy YARD
+    steps:
+      - uses: kachick/deploy-yard-to-pages@v1.3.0
+        id: deployment
+        # with:
+          # # default `doc` as default of `.yardopts`
+          # output-dir: 'docs'
+          # # default version is 3.2
+          # ruby-version: '3.2'
+


### PR DESCRIPTION
### Description

The intention is to start building docs, with YARD, on every code push. GH isn't running new actions on a draft PR, so I probably need to merge it to find out if it fully works :-(

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
