### PR TITLE
Longer default test timeout because of occasional long CI delays

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,7 +43,7 @@ class ScarpeWebviewTest < Minitest::Test
     test_app_location,
     test_code: "",
     app_test_code: "",
-    timeout: 3.0,
+    timeout: 10.0,
     allow_fail: false,
     exit_immediately: false,
     display_service: "wv_local"

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -226,7 +226,7 @@ end
 
 class TestWebWranglerAsyncJS < LoggedScarpeTest
   def round_trip_app(how_many)
-    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-TEST_CODE, timeout: 5.0)
+    run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-TEST_CODE)
       Scarpe.app do
         para "Hello"
       end


### PR DESCRIPTION
For logic leading to this, see #272.

Fixes #272.

### Description

Adjust default test timeout to 10 seconds, remove case that was overriding test timeout in a useless way.

### Checklist

- [X] Run tests locally
- [x] Run linter(check for linter errors)
