### PR TITLE
LIB_DIR and Scarpe constants

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Constants
-  LIB_DIR = File.join(Dir.home, "Desktop")
-end

--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -12,10 +12,9 @@ end
 require "securerandom"
 require "json"
 
-require_relative "constants"
-
 class Scarpe::Error < StandardError; end
 
+require_relative "scarpe/constants"
 require_relative "scarpe/version"
 require_relative "scarpe/promises"
 require_relative "scarpe/display_service"
@@ -27,7 +26,6 @@ d_s = ENV["SCARPE_DISPLAY_SERVICE"] || "wv_local"
 # This is require, not require_relative, to allow gems to supply a new display service
 require "scarpe/#{d_s}"
 
-#Constants Module
 include Constants
 
 class Scarpe

--- a/lib/scarpe/constants.rb
+++ b/lib/scarpe/constants.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+def find_lib_dir
+  homes = [
+    [ENV["LOCALAPPDATA"], "Shoes"],
+    [ENV["APPDATA"], "Shoes"],
+    [ENV["HOME"], ".shoes"],
+    [Dir.tmpdir, "shoes"],
+  ]
+  top, file = homes.detect { |home_top, _| home_top && File.exist?(home_top) }
+  File.join(top, file)
+end
+
+module Constants
+  LIB_DIR = find_lib_dir
+
+  # Math constants from Shoes3
+  RAD2PI = 0.01745329251994329577
+  TWO_PI = 6.28318530717958647693
+  HALF_PI = 1.57079632679489661923
+  PI = 3.14159265358979323846
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require "scarpe/unit_test_helpers"
 
 require "json"
 require "fileutils"
+require "tmpdir"
 
 require "minitest/autorun"
 
@@ -94,6 +95,7 @@ class ScarpeWebviewTest < Minitest::Test
         # For unit testing always supply --debug so we get the most logging
         system("SCARPE_TEST_CONTROL=#{control_file_path} SCARPE_TEST_RESULTS=#{result_path} " +
           "SCARPE_LOG_CONFIG=\"#{scarpe_log_config}\" SCARPE_APP_TEST=\"#{app_test_path}\" " +
+          "LOCALAPPDATA=\"#{Dir.tmpdir}\"" +
           "ruby #{SCARPE_EXE} --debug --dev #{test_app_location}")
 
         # Check if the process exited normally or crashed (segfault, failure, timeout)


### PR DESCRIPTION
### Description

Set LIB_DIR roughly the way Shoes3 did, and override it for tests.

Add the other Shoes3 constants I could find.

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
