### PR TITLE
Switch edit_box to correctly use the passed block as the change hook

### DIFF
--- a/examples/edit_box.rb
+++ b/examples/edit_box.rb
@@ -1,10 +1,8 @@
 Shoes.app do
   para "Manuscript:"
-  @manuscript = edit_box(width: "100%") do
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim."
+  lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim."
+  @manuscript = edit_box(lorem, width: "100%") do |box|
+    @char_count.replace("#{box.text.length} characters")
   end
   @char_count = para "#{@manuscript.text.length} characters"
-  @manuscript.change { |text|
-    @char_count.replace("#{text.length} characters")
-  }
 end

--- a/examples/ruby_racer.rb
+++ b/examples/ruby_racer.rb
@@ -8,23 +8,21 @@ Shoes.app(title: "Ruby Racer", debug: true) do
   flow do
     stack width: 0.45, margin: 5 do
       para "Racer 1", size: :caption
-      racer1 = edit_box(width: "100%", height: 100) do
-        <<~RUBY
-          for i in 1..10
-            a = "1"
-          end
-        RUBY
-      end
+      code1 = <<~RUBY
+        for i in 1..10
+          a = "1"
+        end
+      RUBY
+      racer1 = edit_box(code1, width: "100%", height: 100)
     end
     stack width: 0.45, margin: 5 do
       para "Racer 2", size: :caption
-      racer2 = edit_box(width: "100%", height: 100) do
-        <<~RUBY
-          10.times do
-            a = "1"
-          end
-        RUBY
-      end
+      code2 = <<~RUBY
+        10.times do
+          a = "1"
+        end
+      RUBY
+      racer2 = edit_box(code2, width: "100%", height: 100)
     end
   end
 

--- a/examples/shoes_school.rb
+++ b/examples/shoes_school.rb
@@ -1,4 +1,4 @@
-Shoes.app(title: "Shoes School", height: 700, width: 1000) do
+Shoes.app(title: "Shoes School", height: 800, width: 1000) do
   CHAPTERS = [
     [
       %(
@@ -37,9 +37,7 @@ Shoes.app(title: "Shoes School", height: 700, width: 1000) do
   end
   stack do
     flow do
-      IDE = edit_box(height: 300, width: "100%") do
-        CHAPTERS[current_chapter][0]
-      end
+      IDE = edit_box(CHAPTERS[current_chapter][0], height: 300, width: "100%")
     end
     flow do
       LECTURE = para CHAPTERS[current_chapter][1], size: 30

--- a/lib/scarpe/edit_box.rb
+++ b/lib/scarpe/edit_box.rb
@@ -4,14 +4,15 @@ class Scarpe
   class EditBox < Scarpe::Widget
     display_properties :text, :height, :width
 
-    def initialize(text = nil, height: nil, width: nil, &block)
-      @text = (text.nil? ? block&.call : text) || ""
+    def initialize(text = "", height: nil, width: nil, &block)
+      @text = text
+      @callback = block
 
       super
 
       bind_self_event("change") do |new_text|
         self.text = new_text
-        @callback&.call(new_text)
+        @callback&.call(self)
       end
 
       create_display_widget

--- a/lib/scarpe/text_widget.rb
+++ b/lib/scarpe/text_widget.rb
@@ -19,6 +19,7 @@ class Scarpe
       class_name = element.capitalize
 
       widget_class = Class.new(Scarpe::TextWidget) do
+        # Can we just change content to text to match the Shoes API?
         display_property :content
 
         def initialize(content)
@@ -27,6 +28,14 @@ class Scarpe
           super
 
           create_display_widget
+        end
+
+        def text
+          self.content
+        end
+
+        def text=(new_text)
+          self.content = new_text
         end
       end
       Scarpe.const_set class_name, widget_class

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -81,6 +81,12 @@ class Scarpe
       super() # linkable_id defaults to object_id
     end
 
+    def inspect
+      "#<#{self.class}:#{self.object_id} " +
+        "@linkable_id=#{@linkable_id.inspect} @parent=#{@parent.inspect} " +
+        "@children=#{@children.inspect} properties=#{display_property_values.inspect}>"
+    end
+
     def bind_self_event(event_name, &block)
       raise("Widget has no linkable_id! #{inspect}") unless linkable_id
 

--- a/lib/scarpe/wv/flow.rb
+++ b/lib/scarpe/wv/flow.rb
@@ -14,6 +14,9 @@ class Scarpe
       styles[:display] = "flex"
       styles["flex-direction"] = "row"
       styles["flex-wrap"] = "wrap"
+      styles["align-content"] = "flex-start"
+      styles["justify-content"] = "flex-start"
+      styles["align-items"] = "flex-start"
 
       styles
     end

--- a/lib/scarpe/wv/stack.rb
+++ b/lib/scarpe/wv/stack.rb
@@ -13,6 +13,9 @@ class Scarpe
 
       styles[:display] = "flex"
       styles["flex-direction"] = "column"
+      styles["align-content"] = "flex-start"
+      styles["justify-content"] = "flex-start"
+      styles["align-items"] = "flex-start"
       styles["overflow"] = "auto" if @scroll
 
       styles

--- a/test/test_edit_box.rb
+++ b/test/test_edit_box.rb
@@ -21,18 +21,23 @@ class TestEditBox < LoggedScarpeTest
     TEST_CODE
   end
 
-  def test_renders_textarea_content_block
+  def test_renders_textarea_no_change_cb_on_manual_replace
     run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
       Shoes.app do
-        edit_box { "Hello, World!" }
+        @p = para "Yo!"
+        edit_box { @p.replace "Double Yo!" }
       end
     SCARPE_APP
       on_heartbeat do
         box = edit_box
+        box.text = "Awwww yeah"
+        wait fully_updated
         html_id = box.display.html_id
         assert_html edit_box.display.to_html, :textarea, id: html_id, oninput: "scarpeHandler('#{box.display.shoes_linkable_id}-change', this.value)" do
-          "Hello, World!"
+          "Awwww yeah"
         end
+        # Shoes3 does *not* fire a change event when manually replacing text
+        assert_not_include para.display.to_html, "Double Yo!"
 
         test_finished
       end


### PR DESCRIPTION
This only requires changing examples we wrote for Scarpe -- legacy Shoes examples already do it that way.

Also, I had failed to add some important flexbox properties, so "free" space after a flow or stack was getting squished around evenly instead of "falling" to the right side or bottom.

### Description

Now the block passed to edit_box is properly treated as the "change" callback, like it should be.

### Checklist

- [x] Run tests locally
- [X] Run linter(check for linter errors)
