### PR TITLE
Shoes::DisplayService, not Scarpe::DisplayService

### DIFF
--- a/examples/fonts.rb
+++ b/examples/fonts.rb
@@ -1,6 +1,6 @@
-Scarpe.app do
+Shoes.app do
     para "Hello, world!", font: "Arial", size: 20
     para "Hello, world!", font: "Courier", size: 20
     para "Hello, world!", font: "MS Gothic", size: 20
 end
-  
+

--- a/examples/local_fonts.rb
+++ b/examples/local_fonts.rb
@@ -1,4 +1,4 @@
-Scarpe.app do
+Shoes.app do
   font "fonts/Pacifico.ttf"
   para "Hello yayyy"
 end

--- a/exe/scarpe
+++ b/exe/scarpe
@@ -94,8 +94,6 @@ end
 # We mustn't require Scarpe sooner than this so that the --dev setting is respected
 require "scarpe"
 
-Shoes = Scarpe unless defined?(Shoes)
-
 case verb
   when "-v"
     puts "Scarpe #{Scarpe::VERSION}"

--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -12,6 +12,7 @@ end
 require "securerandom"
 require "json"
 
+# Is there a Shoes::Error class? Should this be two different error classes?
 class Scarpe::Error < StandardError; end
 
 require_relative "scarpe/constants"
@@ -28,7 +29,7 @@ require "scarpe/#{d_s}"
 
 include Constants
 
-class Scarpe
+module Shoes
   class << self
     def app(...)
       app = Scarpe::App.new(...)

--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -54,7 +54,7 @@ class Scarpe
       # Try to de-dup as much as possible and not send repeat or multiple
       # destroy events
       @watch_for_destroy = bind_shoes_event(event_name: "destroy") do
-        DisplayService.unsub_from_events(@watch_for_destroy) if @watch_for_destroy
+        Shoes::DisplayService.unsub_from_events(@watch_for_destroy) if @watch_for_destroy
         @watch_for_destroy = nil
         self.destroy(send_event: false)
       end

--- a/lib/scarpe/cats_cradle.rb
+++ b/lib/scarpe/cats_cradle.rb
@@ -28,7 +28,7 @@ module Scarpe::Test
     def initialize(obj)
       @obj = obj
       # TODO: how to do this with Webview relay? Proxy object to send a message, maybe?
-      @display = ::Scarpe::DisplayService.display_service.query_display_widget_for(obj.linkable_id)
+      @display = ::Shoes::DisplayService.display_service.query_display_widget_for(obj.linkable_id)
     end
 
     def method_missing(method, ...)
@@ -110,7 +110,7 @@ module Scarpe::Test
 
       @cc_init_done = true
 
-      @control_interface = ::Scarpe::DisplayService.display_service.control_interface
+      @control_interface = ::Shoes::DisplayService.display_service.control_interface
       @wrangler = @control_interface.wrangler
 
       cc_instance = self # ControlInterface#on_event does an instance eval. We'll reset self with another.
@@ -235,7 +235,7 @@ module Scarpe::Test
       else
         return_results(true, "Test finished successfully")
       end
-      ::Scarpe::DisplayService.dispatch_event("destroy", nil)
+      ::Shoes::DisplayService.dispatch_event("destroy", nil)
     end
   end
 

--- a/lib/scarpe/display_service.rb
+++ b/lib/scarpe/display_service.rb
@@ -138,56 +138,58 @@ class Scarpe
         @service = @display_service_klass.new
       end
     end
+  end
+end
 
-    # This is for objects that can be referred to via events, using their
-    # IDs. There are also convenience functions for binding and sending
-    # events.
-    class Linkable
-      attr_reader :linkable_id
+module Shoes
+  # This is for objects that can be referred to via events, using their
+  # IDs. There are also convenience functions for binding and sending
+  # events.
+  class Linkable
+    attr_reader :linkable_id
 
-      def initialize(linkable_id: object_id)
-        @linkable_id = linkable_id
-      end
-
-      def send_self_event(*args, event_name:, **kwargs)
-        DisplayService.dispatch_event(event_name, self.linkable_id, *args, **kwargs)
-      end
-
-      def send_shoes_event(*args, event_name:, target: nil, **kwargs)
-        DisplayService.dispatch_event(event_name, target, *args, **kwargs)
-      end
-
-      def bind_shoes_event(event_name:, target: nil, &handler)
-        DisplayService.subscribe_to_event(event_name, target, &handler)
-      end
-
-      def unsub_shoes_event(unsub_id)
-        DisplayService.unsub_from_events(unsub_id)
-      end
+    def initialize(linkable_id: object_id)
+      @linkable_id = linkable_id
     end
 
-    # These methods are an interface to DisplayService objects.
-
-    def create_display_widget_for(widget_class_name, widget_id, properties)
-      raise "Override in DisplayService implementation!"
+    def send_self_event(*args, event_name:, **kwargs)
+      DisplayService.dispatch_event(event_name, self.linkable_id, *args, **kwargs)
     end
 
-    def set_widget_pairing(id, display_widget)
-      @display_widget_for ||= {}
-      @display_widget_for[id] = display_widget
+    def send_shoes_event(*args, event_name:, target: nil, **kwargs)
+      DisplayService.dispatch_event(event_name, target, *args, **kwargs)
     end
 
-    def query_display_widget_for(id, nil_ok: false)
-      display_widget = @display_widget_for[id]
-      unless display_widget || nil_ok
-        raise "Could not find display widget for linkable ID #{id.inspect}!"
-      end
-
-      display_widget
+    def bind_shoes_event(event_name:, target: nil, &handler)
+      DisplayService.subscribe_to_event(event_name, target, &handler)
     end
 
-    def destroy
-      raise "Override in DisplayService implementation!"
+    def unsub_shoes_event(unsub_id)
+      DisplayService.unsub_from_events(unsub_id)
     end
+  end
+
+  # These methods are an interface to DisplayService objects.
+
+  def create_display_widget_for(widget_class_name, widget_id, properties)
+    raise "Override in DisplayService implementation!"
+  end
+
+  def set_widget_pairing(id, display_widget)
+    @display_widget_for ||= {}
+    @display_widget_for[id] = display_widget
+  end
+
+  def query_display_widget_for(id, nil_ok: false)
+    display_widget = @display_widget_for[id]
+    unless display_widget || nil_ok
+      raise "Could not find display widget for linkable ID #{id.inspect}!"
+    end
+
+    display_widget
+  end
+
+  def destroy
+    raise "Override in DisplayService implementation!"
   end
 end

--- a/lib/scarpe/display_service.rb
+++ b/lib/scarpe/display_service.rb
@@ -38,7 +38,7 @@
 # you want both. But internally they're immediately dispatched as events
 # rather than keeping a literal array of items.
 #
-class Scarpe
+module Shoes
   class DisplayService
     class << self
       # This is in the eigenclass/metaclass, *not* instances of DisplayService
@@ -138,10 +138,32 @@ class Scarpe
         @service = @display_service_klass.new
       end
     end
-  end
-end
 
-module Shoes
+    # These methods are an interface to DisplayService objects.
+
+    def create_display_widget_for(widget_class_name, widget_id, properties)
+      raise "Override in DisplayService implementation!"
+    end
+
+    def set_widget_pairing(id, display_widget)
+      @display_widget_for ||= {}
+      @display_widget_for[id] = display_widget
+    end
+
+    def query_display_widget_for(id, nil_ok: false)
+      display_widget = @display_widget_for[id]
+      unless display_widget || nil_ok
+        raise "Could not find display widget for linkable ID #{id.inspect}!"
+      end
+
+      display_widget
+    end
+
+    def destroy
+      raise "Override in DisplayService implementation!"
+    end
+  end
+
   # This is for objects that can be referred to via events, using their
   # IDs. There are also convenience functions for binding and sending
   # events.
@@ -167,29 +189,5 @@ module Shoes
     def unsub_shoes_event(unsub_id)
       DisplayService.unsub_from_events(unsub_id)
     end
-  end
-
-  # These methods are an interface to DisplayService objects.
-
-  def create_display_widget_for(widget_class_name, widget_id, properties)
-    raise "Override in DisplayService implementation!"
-  end
-
-  def set_widget_pairing(id, display_widget)
-    @display_widget_for ||= {}
-    @display_widget_for[id] = display_widget
-  end
-
-  def query_display_widget_for(id, nil_ok: false)
-    display_widget = @display_widget_for[id]
-    unless display_widget || nil_ok
-      raise "Could not find display widget for linkable ID #{id.inspect}!"
-    end
-
-    display_widget
-  end
-
-  def destroy
-    raise "Override in DisplayService implementation!"
   end
 end

--- a/lib/scarpe/glibui.rb
+++ b/lib/scarpe/glibui.rb
@@ -26,4 +26,4 @@ require_relative "glibui/alert"
 require_relative "glibui/text_widget"
 require_relative "glibui/link"
 
-Scarpe::DisplayService.set_display_service_class(Scarpe::GlimmerLibUIDisplayService)
+Shoes::DisplayService.set_display_service_class(Scarpe::GlimmerLibUIDisplayService)

--- a/lib/scarpe/glibui/widget.rb
+++ b/lib/scarpe/glibui/widget.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Scarpe
-  class GlimmerLibUIWidget < DisplayService::Linkable
+  class GlimmerLibUIWidget < Shoes::Linkable
     class << self
       def display_class_for(scarpe_class_name)
         scarpe_class = Scarpe.const_get(scarpe_class_name)
-        unless scarpe_class.ancestors.include?(Scarpe::DisplayService::Linkable)
+        unless scarpe_class.ancestors.include?(Shoes::Linkable)
           raise "Scarpe GlimmerLibUI can only get display classes for Scarpe linkable widgets, not #{scarpe_class.inspect}!"
         end
 

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -106,7 +106,7 @@ class Scarpe
       klass_name = self.class.name.delete_prefix("Scarpe::").delete_prefix("Shoes::")
 
       # Should we save a reference to widget for later reference?
-      DisplayService.display_service.create_display_widget_for(klass_name, self.linkable_id, display_property_values)
+      ::Shoes::DisplayService.display_service.create_display_widget_for(klass_name, self.linkable_id, display_property_values)
     end
 
     attr_reader :parent

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -7,7 +7,7 @@
 # some kind. A Widget with no element method renders as its children's markup, joined.
 
 class Scarpe
-  class Widget < DisplayService::Linkable
+  class Widget < Shoes::Linkable
     include Scarpe::Log
     include Scarpe::Colors
 

--- a/lib/scarpe/wv/webview_local_display.rb
+++ b/lib/scarpe/wv/webview_local_display.rb
@@ -6,7 +6,7 @@ class Scarpe
   # process, too many or too large evals can crash the process, etc.
   # Normally the intention is to use a RelayDisplayService to a second
   # process containing one of these.
-  class WebviewDisplayService < Scarpe::DisplayService
+  class WebviewDisplayService < Shoes::DisplayService
     include Scarpe::Log
 
     class << self

--- a/lib/scarpe/wv/webview_relay_display.rb
+++ b/lib/scarpe/wv/webview_relay_display.rb
@@ -120,7 +120,7 @@ class Scarpe
 
   # This "display service" actually creates a child process and sends events
   # back and forth, but creates no widgets of its own.
-  class WVRelayDisplayService < Scarpe::DisplayService
+  class WVRelayDisplayService < Shoes::DisplayService
     include Scarpe::Log
     include WVRelayUtil # Needs Scarpe::Log
 

--- a/lib/scarpe/wv/widget.rb
+++ b/lib/scarpe/wv/widget.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class Scarpe
-  class WebviewWidget < DisplayService::Linkable
+  class WebviewWidget < Shoes::Linkable
     include Scarpe::Log
 
     class << self
       def display_class_for(scarpe_class_name)
         scarpe_class = Scarpe.const_get(scarpe_class_name)
-        unless scarpe_class.ancestors.include?(Scarpe::DisplayService::Linkable)
+        unless scarpe_class.ancestors.include?(Shoes::Linkable)
           raise "Scarpe Webview can only get display classes for Scarpe " +
             "linkable widgets, not #{scarpe_class_name.inspect}!"
         end

--- a/lib/scarpe/wv/wv_display_worker.rb
+++ b/lib/scarpe/wv/wv_display_worker.rb
@@ -17,7 +17,7 @@ if ARGV.length != 1
   exit(-1)
 end
 
-class WebviewContainedService < Scarpe::DisplayService::Linkable
+class WebviewContainedService < Shoes::Linkable
   include Scarpe::Log
   include Scarpe::WVRelayUtil # Needs Scarpe::Log
 

--- a/lib/scarpe/wv_local.rb
+++ b/lib/scarpe/wv_local.rb
@@ -3,4 +3,4 @@
 require_relative "wv"
 require_relative "wv/webview_local_display"
 
-Scarpe::DisplayService.set_display_service_class(Scarpe::WebviewDisplayService)
+Shoes::DisplayService.set_display_service_class(Scarpe::WebviewDisplayService)

--- a/lib/scarpe/wv_relay.rb
+++ b/lib/scarpe/wv_relay.rb
@@ -3,4 +3,4 @@
 require_relative "wv"
 require_relative "wv/webview_relay_display"
 
-Scarpe::DisplayService.set_display_service_class(Scarpe::WVRelayDisplayService)
+Shoes::DisplayService.set_display_service_class(Scarpe::WVRelayDisplayService)

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -9,11 +9,11 @@ class TestWebviewImage < ScarpeWebviewTest
       "shoes_linkable_id" => 1,
       "url" => @url,
     }
-    Scarpe::DisplayService.full_reset!
+    Shoes::DisplayService.full_reset!
   end
 
   def teardown
-    Scarpe::DisplayService.full_reset!
+    Shoes::DisplayService.full_reset!
   end
 
   def test_renders_image

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -11,11 +11,11 @@ class TestWebviewPara < ScarpeWebviewTest
       "size" => :para,
       "html_attributes" => {},
     }
-    Scarpe::DisplayService.full_reset!
+    Shoes::DisplayService.full_reset!
   end
 
   def teardown
-    Scarpe::DisplayService.full_reset!
+    Shoes::DisplayService.full_reset!
   end
 
   def test_renders_paragraph

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -27,7 +27,7 @@ class TestWebWranglerInScarpeApp < LoggedScarpeTest
     SCARPE_APP
       on_event(:next_redraw) do
         return_results(true, "Destroy and exit")
-        DisplayService.dispatch_event("destroy", nil)
+        Shoes::DisplayService.dispatch_event("destroy", nil)
       end
     TEST_CODE
   end

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -9,7 +9,7 @@ class TestWebWranglerInScarpeApp < LoggedScarpeTest
   # Need to make sure that even with no widgets we still get at least one redraw
   def test_empty_app
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
-      Scarpe.app do
+      Shoes.app do
       end
     SCARPE_APP
       on_event(:next_redraw) do
@@ -227,7 +227,7 @@ end
 class TestWebWranglerAsyncJS < LoggedScarpeTest
   def round_trip_app(how_many)
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-TEST_CODE)
-      Scarpe.app do
+      Shoes.app do
         para "Hello"
       end
     SCARPE_APP


### PR DESCRIPTION
### Description

Change the last few Scarpe.app calls to Shoes.app. Disallow Scarpe.app in favour of Shoes.app.

Change Scarpe::Linkable to Shoes::Linkable, and Scarpe::DisplayService to Shoes::DisplayService - but leave all the actual display services under Scarpe, intentionally.

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
