### PR TITLE
Start customising YARD output with a new "Doc Pages" category.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Gemfile.lock
 scarpe_results.txt
 **/.DS_Store
 logger/*.log
+/docs/yard/template/default/doc
+/docs/yard/template/default/.yardoc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'bin/**/*'
     - 'exe/**/*'
     - 'examples/**/*'
+    - 'docs/**/*'
 
 Layout/LineLength:
   Max: 150

--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,10 @@
 --markup-provider=redcarpet
 --markup=markdown
+--protected
+--no-private
+--template-path docs/yard/template
+-
+lib/**/*.rb
+docs/yard/*.md
+docs/static/manual.md
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Example usage:
 
 The SCARPE_TEST_CONTROL environment variable can contain a path to a test-control-interface script for the Webview display service. If you look at test_helper, it gives some examples of how to use it.
 
+If you run ./exe/scarpe env, you can see all current environment settings.
+
 ## More info
 
 * [Nobody Knows Shoes manual](https://github.com/whymirror/why-archive/raw/master/shoes/nobody-knows-shoes.pdf)

--- a/docs/yard/catscradle.md
+++ b/docs/yard/catscradle.md
@@ -1,0 +1,44 @@
+# CatsCradle and Fiber-Based Testing
+
+We've tried a number of things for testing. We mock extensively in many places. We use promises to handle "assert thing X after the next redraw"-type testing.
+
+Most recently, we have a Fiber-based approach to testing which is a little weird, but (so far) looks pretty good. Here's a representative test of that kind:
+
+```
+  def test_html_dom_multiple_update
+    run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
+      Shoes.app do
+        para "Hello World"
+      end
+    SCARPE_APP
+      on_heartbeat do
+        p = para()
+        assert_include dom_html, "Hello World"
+        p.replace("Goodbye World")
+        wait fully_updated
+        assert_include dom_html, "Goodbye World"
+        p.replace("Hello Again")
+        wait fully_updated
+        assert_include dom_html, "Hello Again"
+
+        test_finished
+      end
+    TEST_CODE
+  end
+```
+
+That's fine. There's a very simple Scarpe app with a single para. The test finds it, then makes sure the page HTML includes the right text. Then it changes it, waits for the redraw and makes sure it contains the new right text. Then, basically, does those same things again. So what's interesting here?
+
+Primarily that it waits. You could reasonably think, "waiting is easy - you can use promises or sleeps for that." And normally you'd be right. But in this case, this uses the Webview local display service. It will crash if you don't return control to its main loop within a fraction of a second. And until it gets back to its main loop it can't receive calls from Javascript. Those "dom_html" calls require looping to Webview and back, as (of course) does "wait fully_updated".
+
+But this method appears to run through, line by line, until it's done. How?
+
+Fibers. Specifically, Ruby 3.0 added some nice Fiber capabilities that we can use. You can go look [at the docs](https://ruby-doc.org/core-3.0.0/Fiber.html#method-i-transfer) if you want.
+
+If you check catscradle.rb, you can see us doing a fun little dance where a block like the on_heartbeat above creates a Fiber, and there's a manager Fiber to coordinate them. On every heartbeat and redraw we run the manager Fiber, which in turn runs every other Fiber that's ready, which it tracks via Promises.
+
+A ready Fiber will run until it does something blocking, like a dom_html or wait call. Then it returns a Promise object that will be fulfilled when it's ready to run again, like a Promise for being fully redrawn, or a promise for when a snippet of Javascript finishes.
+
+Once the manager has run every ready Fiber once, it yields control and waits to be called again.
+
+Right now (June 2023) we keep control simple by only being called on heartbeats or redraws, so sometimes a promise *not* involving promises or redraws can wait awhile extra (up to 1/10th of a second or so) before it runs again. It would be possible to run the manager in response to other promises completing, and that would probably be more efficient. I'm just worried about that complicating the flow of control and leading to weird order-dependent bugs. So right now we do the simple thing, which can be slower.

--- a/docs/yard/template/default/fulldoc/html/setup.rb
+++ b/docs/yard/template/default/fulldoc/html/setup.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+def generate_docpages_list
+  @file_list = true
+
+  # Customise these more?
+  @items = options.files.select { |m| m.filename.end_with?(".md") }
+
+  @list_title = "Doc Pages List"
+  @list_type = "file"
+  generate_list_contents
+  @file_list = nil
+end

--- a/docs/yard/template/default/layout/html/setup.rb
+++ b/docs/yard/template/default/layout/html/setup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+def menu_lists
+  [
+    {:type => 'docpages', :title => 'Doc Pages', :search_title => 'Doc Pages'},
+    {:type => 'class', :title => 'Classes', :search_title => 'Class List'},
+    {:type => 'method', :title => 'Methods', :search_title => 'Method List'},
+    {:type => 'file', :title => 'Files', :search_title => 'File List'},
+  ]
+end


### PR DESCRIPTION
### Description

We'll want customised YARD output. I've started with a new category of pages next to classes, methods and files.

I've changed the CatsCradle wiki page to an in-source-tree docs page, both as an example and because it belongs there.

This will work with the new auto-build code (#279), or locally. But it there shouldn't be any conflicts or requirements between them.

### Image(if needed, helps for a faster review)

<img width="1408" alt="Screenshot 2023-07-09 at 20 54 20" src="https://github.com/scarpe-team/scarpe/assets/82408/a5fe48ef-d1f7-44ea-bd92-6376a3d983be">

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
