### PR TITLE
Add a lacci gemspec, update scarpe-team/scarpe repo links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ scarpe_results.txt
 logger/*.log
 /docs/yard/template/default/doc
 /docs/yard/template/default/.yardoc
+lacci-*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in scarpe.gemspec
-gemspec
+gemspec name: "scarpe"
 
 gem "bloops", "~> 0.5" #path: "../bloopsaphone" #git: "https://github.com/scarpe-team/bloopsaphone"
 gem "rake", "~> 13.0"

--- a/lacci.gemspec
+++ b/lacci.gemspec
@@ -3,12 +3,12 @@
 require_relative "lib/scarpe/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "scarpe"
+  spec.name = "lacci"
   spec.version = Scarpe::VERSION
   spec.authors = ["Marco Concetto Rudilosso", "Noah Gibbs"]
   spec.email = ["marcoc.r@outlook.com", "the.codefolio.guy@gmail.com"]
 
-  spec.summary = "Scarpe - shoes but running on webview"
+  spec.summary = "Lacci - a portable Shoes DSL with switchable display backends, part of Scarpe"
   spec.homepage = "https://github.com/scarpe-team/scarpe"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
@@ -30,14 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastimage"
-  spec.add_dependency "glimmer-dsl-libui"
-  spec.add_dependency "nokogiri"
-  spec.add_dependency "sqlite3"
-
-  spec.add_dependency "bloops", "~>0.5"
-  spec.add_dependency "logging", "~>2.3.1"
-  spec.add_dependency "webview_ruby", "~>0.1.1"
+  #spec.add_dependency ""
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
### Description

We've decided to call the portable Shoes DSL part "lacci" -- "laces" in Italian. Added a gemspec for it.

Also added a .gitignore for built lacci gems, and updated links to the scarpe repo in scarpe.gemspec.

### Checklist

- [ ] Run tests locally
- [x] Run linter(check for linter errors)
