### PR TITLE
Use the SCARPE_DEBUG env var to set debug behaviour

### DIFF
--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -10,14 +10,13 @@ module Shoes
 
     attr_reader :document_root
 
-    display_properties :title, :width, :height, :resizable, :debug
+    display_properties :title, :width, :height, :resizable
 
     def initialize(
       title: "Shoes!",
       width: 480,
       height: 420,
       resizable: true,
-      debug: ENV["SCARPE_DEBUG"] ? true : false,
       &app_code_body
     )
       if Shoes::App.instance

--- a/lacci/lib/shoes/display_service.rb
+++ b/lacci/lib/shoes/display_service.rb
@@ -32,8 +32,6 @@ module Shoes
       # This is in the eigenclass/metaclass, *not* instances of DisplayService
       include Shoes::Log
 
-      attr_accessor :json_debug_serialize
-
       # An event_target may be nil, to indicate there is no target.
       def dispatch_event(event_name, event_target, *args, **kwargs)
         @@display_event_handlers ||= {}
@@ -46,7 +44,8 @@ module Shoes
 
         @log.debug("Dispatch event: #{event_name.inspect} T: #{event_target.inspect} A: #{args.inspect} KW: #{kwargs.inspect}")
 
-        if DisplayService.json_debug_serialize
+        # When true, this makes sure all events and properties are 100% strings, no symbols.
+        if ENV["SCARPE_DEBUG"]
           args = JSON.parse JSON.dump(args)
           new_kw = {}
           kwargs.each do |k, v|

--- a/lib/scarpe/wv/app.rb
+++ b/lib/scarpe/wv/app.rb
@@ -3,7 +3,6 @@
 class Scarpe
   # Scarpe::WebviewApp must only be used from the main thread, due to GTK+ limitations.
   class WebviewApp < WebviewWidget
-    attr_reader :debug
     attr_reader :control_interface
 
     attr_writer :shoes_linkable_id
@@ -29,8 +28,7 @@ class Scarpe
       @view = Scarpe::WebWrangler.new title: @title,
         width: @width,
         height: @height,
-        resizable: @resizable,
-        debug: @debug
+        resizable: @resizable
 
       @callbacks = {}
 

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -83,16 +83,15 @@ class Scarpe
     # @param width [Integer] window width in pixels
     # @param height [Integer] window height in pixels
     # @param resizable [Boolean] whether the window should be resizable by the user
-    # @param debug [Boolean] whether to log all Webview API calls
     # @param heartbeat [Float] time between heartbeats in seconds
-    def initialize(title:, width:, height:, resizable: false, debug: false, heartbeat: 0.1)
+    def initialize(title:, width:, height:, resizable: false, heartbeat: 0.1)
       log_init("WV::WebWrangler")
 
       @log.debug("Creating WebWrangler...")
 
       # For now, always allow inspect element, so pass debug: true
       @webview = WebviewRuby::Webview.new debug: true
-      @webview = Shoes::LoggedWrapper.new(@webview, "WebviewAPI") if debug
+      @webview = Shoes::LoggedWrapper.new(@webview, "WebviewAPI") if ENV["SCARPE_DEBUG"]
       @init_refs = {} # Inits don't go away so keep a reference to them to prevent GC
 
       @title = title


### PR DESCRIPTION
Also when debugging do JSON auto-serialise.

### Description

In several places we allowed manual passing of a debug param. This used to be necessary to activate logging, but now we have better log config facilities. And it's sort of like SCARPE_DEBUG, but we have SCARPE_DEBUG. That fixes issue #257.

So I turned on most debug behaviour if and only if SCARPE_DEBUG is true. I also turned on JSON serialisation of DisplayService events whenever SCARPE_DEBUG is true, which includes during all unit tests. That fixes issue #258 -- it turns out the WebWrangler-side events are already snippy about symbols only. You could argue that having Shoes events be strings-only and WebWrangler be symbol-only is a problem, but as long as everything is locked down to specifically one or the other, I think it's fine (feel free to file a bug or PR if you disagree!)

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
