### PR TITLE
Fix transient Linter failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10 
     steps:
+      - name: Install dependencies
+        run: brew install pkg-config portaudio
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Ruby and install gems


### PR DESCRIPTION
### Description

Sometimes Github actions runs both tasks on the same node and some times it does not.

If it does, all is well. If it does not, then the Linter task tries to gem install bloops but it hasn't run the dependencies step, which means portaudio isn't installed

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
