### PR TITLE
Flow should run to the end of its current container

### DIFF
--- a/lacci/lib/shoes/widgets/flow.rb
+++ b/lacci/lib/shoes/widgets/flow.rb
@@ -4,7 +4,7 @@ module Shoes
   class Flow < Shoes::Slot
     display_properties :width, :height, :margin, :padding
 
-    def initialize(width: nil, height: nil, margin: nil, padding: nil, **options, &block)
+    def initialize(width: "100%", height: nil, margin: nil, padding: nil, **options, &block)
       @options = options
 
       super


### PR DESCRIPTION
right now two flows stack side by side. this shouldn't happen, we want them to run to the end of their container. I'm using this to make soundalizer work but figured it should be its own PR for everyone
