### PR TITLE
Update README to run Scarpe without the exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ First, clone the [main GitHub repository](https://github.com/scarpe-team/scarpe)
 
 `bundle install` dependencies like webview from the cloned directory in your Ruby of choice.
 
-You can run without Scarpe being installed by including its directory. For instance, from the "examples" directory you can run `ruby -I../lib hello_world.rb`. You can also install Scarpe locally (`gem build scarpe.gemspec && gem install scarpe-0.1.0.gem`) or using a Gemfile with the "path" option for local Scarpe.
+You can run without Scarpe being installed by including its directory. For instance, from the "examples" directory you can run `ruby -I../lib -I../lacci/lib -rscarpe hello_world.rb`. You can also install Scarpe locally (`gem build scarpe.gemspec && gem install scarpe-0.1.0.gem`) or using a Gemfile with the "path" option for local Scarpe.
 
 Most commonly we are all using this command: `./exe/scarpe examples/button.rb --dev`
 


### PR DESCRIPTION

### Description

Since the `lacci` extraction the old instructions for how to run Scarpe without using the exe fail with the following error

```
❯ ruby -Ilib examples/backdround_with_image.rb
examples/backdround_with_image.rb:1:in `<main>': uninitialized constant Shoes (NameError)

Shoes.app do
^^^^^
```

To fix this we need to add another include path for `lacci` and manually require scarpe.

```
❯ ruby -Ilib -Ilacci/lib -rscarpe examples/backdround_with_image.rb
```

This PR updates the README to reflect that
