### PR TITLE
Clear append destroy

### DIFF
--- a/examples/clear_and_append.rb
+++ b/examples/clear_and_append.rb
@@ -1,0 +1,24 @@
+Shoes.app do
+  stack do
+    button("More Stuff!") do
+      @slot.append do
+        ins "I'm enthused."
+        title "Enthused!"
+        banner "ENTHUSED!"
+      end
+    end
+
+    button("No Stuff!") do
+      @slot.clear
+    end
+
+    button("Different Stuff!") do
+      @slot.clear do
+        para "I'm so different!"
+        title "I'm like a totally different but emo person! Or possibly chicken."
+      end
+    end
+
+    @slot = stack(width: "100%") { para 'Good Morning' }
+  end
+end

--- a/examples/link.rb
+++ b/examples/link.rb
@@ -2,7 +2,7 @@ Shoes.app do
   def collapsed
     @para = para(
       "'Scarpe' means shoes in Italian. 'Scarpe' also means Shoes in...",
-      link("(show more)") { @para.destroy_self; @para = expanded }
+      link("(show more)") { @para.destroy; @para = expanded }
     )
   end
 
@@ -12,7 +12,7 @@ Shoes.app do
       "Scarpe isn't feature complete with any version of Shoes (yet?). We're initially targeting Shoes Classic. ",
       link("Learn more", click: "http://github.com/schwad/scarpe"),
       " ",
-      link("(show less)") { @para.destroy_self; @para = collapsed }
+      link("(show less)") { @para.destroy; @para = collapsed }
     )
   end
 

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -19,14 +19,14 @@ module Shoes
       resizable: true,
       &app_code_body
     )
+      log_init("Shoes::App")
+
       if Shoes::App.instance
         @log.error("Trying to create a second Shoes::App in the same process! Fail!")
         raise "Cannot create multiple Shoes::App objects!"
       else
         Shoes::App.instance = self
       end
-
-      log_init("Shoes::App")
 
       @do_shutdown = false
 
@@ -144,7 +144,7 @@ module Shoes
       specs.each do |spec|
         if spec.is_a?(Class)
           widgets.select! { |w| spec === w }
-        elsif spec.is_a?(Symbol)
+        elsif spec.is_a?(Symbol) || spec.is_a?(String)
           s = spec.to_s
           case s[0]
           when "$"
@@ -156,7 +156,7 @@ module Shoes
               raise "Error getting global variable: #{spec.inspect}"
             end
           when "@"
-            if app.instance_variables.include?(spec)
+            if Shoes::App.instance.instance_variables.include?(spec.to_sym)
               widgets &= [self.instance_variable_get(spec)]
             else
               raise "Can't find top-level instance variable: #{spec.inspect}!"

--- a/lacci/lib/shoes/widget.rb
+++ b/lacci/lib/shoes/widget.rb
@@ -149,7 +149,23 @@ module Shoes
       send_shoes_event(event_name: "destroy", target: linkable_id)
     end
 
-    alias_method :destroy_self, :destroy
+    alias_method :remove, :destroy
+
+    def clear(&block)
+      @children.dup.each do |child|
+        child.destroy
+      end
+      if block_given?
+        append(&block)
+      end
+    end
+
+    def append(&block)
+      raise("append requires a block!") unless block_given?
+      raise("Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
+
+      Shoes::App.instance.with_slot(self, &block)
+    end
 
     # We use method_missing for widget-creating methods like "button",
     # and also to auto-create display-property getters and setters.

--- a/lacci/lib/shoes/widget.rb
+++ b/lacci/lib/shoes/widget.rb
@@ -152,12 +152,8 @@ module Shoes
     alias_method :remove, :destroy
 
     def clear(&block)
-      @children.dup.each do |child|
-        child.destroy
-      end
-      if block_given?
-        append(&block)
-      end
+      @children.dup.each(&:destroy)
+      append(&block) if block_given?
     end
 
     def append(&block)

--- a/test/test_stack.rb
+++ b/test/test_stack.rb
@@ -65,3 +65,40 @@ class TestWebviewStack < Minitest::Test
   #  assert(stack.to_html.include?("background:linear-gradient(45deg, #AAA, #DDD);"))
   #end
 end
+
+class TestStackMethods < LoggedScarpeTest
+  def test_stack_clear_append
+    run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
+      Shoes.app do
+        @slot = stack do
+          para "Hello World"
+        end
+        @b_clear = button("Clear") { @slot.clear }
+        @b_add = button("Add") { @slot.append { para "Woot!" } }
+      end
+    SCARPE_APP
+      on_heartbeat do
+        main = stack("@slot")
+
+        assert_equal 1, main.children.size
+
+        b_clear = button("@b_clear")
+        b_add = button("@b_add")
+        b_clear_js = b_clear.display.handler_js_code("click")
+        b_add_js = b_add.display.handler_js_code("click")
+
+        query_js_value(b_add_js)
+        query_js_value(b_add_js)
+        query_js_value(b_add_js)
+        wait fully_updated
+        assert_equal 4, main.children.size
+
+        query_js_value(b_clear_js) # Run the click-event code
+        wait fully_updated
+        assert_equal 0, main.children.size
+
+        test_finished
+      end
+    TEST_CODE
+  end
+end


### PR DESCRIPTION
### Description

Add append and clear operations to slots (e.g. stack, flow.) Add a test for it. Remove an old destroy_self alias we didn't use in favour of destroy (which we use a lot in Scarpe) and remove (the actual Shoes correct name.)

Technically we're not quite Shoes-compatible on append because we instance-eval for append, which removes the need for the Slot#app method. But that's basically always what we want. We can always break it later if we need to.

### Image(if needed, helps for a faster review)

<img width="497" alt="Screenshot 2023-07-27 at 15 32 11" src="https://github.com/scarpe-team/scarpe/assets/82408/40e409a0-124c-42cc-8cb8-51c0fba806ce">

### Checklist

- [x] Run tests locally
- [X] Run linter(check for linter errors)
