### PR TITLE
Regularise how Webview handles styling, and add show/hide to Lacci

### DIFF
--- a/examples/show_hide.rb
+++ b/examples/show_hide.rb
@@ -1,0 +1,6 @@
+Shoes.app do
+  @b1 = button("First")
+  @b2 = button("Hide First") { @b1.hide }
+  @b3 = button("Show everybody") { @b1.show; @b2.show; @b3.show; @b4.show }
+  @b4 = button("Toggle Hide-First") { @b2.toggle }
+end

--- a/lacci/lib/shoes/widget.rb
+++ b/lacci/lib/shoes/widget.rb
@@ -72,6 +72,9 @@ module Shoes
       end
     end
 
+    # Shoes uses a "hidden" style property for hide/show
+    display_property :hidden
+
     def initialize(*args, **kwargs)
       log_init("Widget")
 
@@ -138,6 +141,7 @@ module Shoes
     end
 
     # Do not call directly, use set_parent
+    # Can this be private?
     def add_child(child)
       @children ||= []
       @children << child
@@ -151,16 +155,47 @@ module Shoes
 
     alias_method :remove, :destroy
 
+    # Remove all children from this widget. If a block
+    # is given, call the block to replace the children with
+    # new contents from that block.
+    #
+    # Should only be called on Slots, which can
+    # have children.
+    #
+    # @yield The block to call to replace the contents of the widget (optional)
+    # @return [void]
     def clear(&block)
       @children.dup.each(&:destroy)
       append(&block) if block_given?
+      nil
     end
 
+    # Call the block to append new children to a Slot.
+    #
+    # Should only be called on a Slot, since only Slots can have children.
+    #
+    # @yield the block to call to replace children; will be called on the Shoes::App, appending to the called Slot as the current slot
+    # @return [void]
     def append(&block)
       raise("append requires a block!") unless block_given?
       raise("Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
 
       Shoes::App.instance.with_slot(self, &block)
+    end
+
+    # Hide the widget.
+    def hide
+      self.hidden = true
+    end
+
+    # Show the widget.
+    def show
+      self.hidden = false
+    end
+
+    # Hide the widget if it is currently shown. Show it if it is currently hidden.
+    def toggle
+      self.hidden = !self.hidden
     end
 
     # We use method_missing for widget-creating methods like "button",

--- a/lacci/lib/shoes/widgets/alert.rb
+++ b/lacci/lib/shoes/widgets/alert.rb
@@ -10,7 +10,7 @@ module Shoes
       super
 
       bind_self_event("click") do
-        destroy_self
+        remove
       end
 
       create_display_widget

--- a/lacci/lib/shoes/widgets/para.rb
+++ b/lacci/lib/shoes/widgets/para.rb
@@ -34,22 +34,6 @@ module Shoes
       # This should signal the display widget to change
       self.text_items = text_children_to_items(@text_children)
     end
-
-    def hide
-      # idempotent
-      return unless @hidden_text_items.empty?
-
-      @hidden_text_items = self.text_items
-      self.text_items = []
-    end
-
-    def show
-      # idempotent
-      return unless self.text_items.empty?
-
-      self.text_items = @hidden_text_items
-      @hidden_text_items = []
-    end
   end
 end
 

--- a/lib/scarpe/cats_cradle.rb
+++ b/lib/scarpe/cats_cradle.rb
@@ -24,6 +24,7 @@ module Scarpe::Test
   # call some of *those* methods.
   class CCProxy
     attr_reader :display
+    attr_reader :obj
 
     def initialize(obj)
       @obj = obj
@@ -163,6 +164,10 @@ module Scarpe::Test
 
         CCProxy.new(widgets[0])
       end
+    end
+
+    def proxy_for(shoes_widget)
+      CCProxy.new(shoes_widget)
     end
 
     def wait(promise)

--- a/lib/scarpe/wv/alert.rb
+++ b/lib/scarpe/wv/alert.rb
@@ -23,8 +23,9 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
+    # If the whole widget is hidden, the parent style adds display:none
     def overlay_style
       {
         position: "fixed",
@@ -38,7 +39,7 @@ class Scarpe
         display: "flex",
         "align-items": "center",
         "justify-content": "center",
-      }
+      }.merge(style)
     end
 
     def modal_style

--- a/lib/scarpe/wv/arc.rb
+++ b/lib/scarpe/wv/arc.rb
@@ -17,16 +17,18 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      {
+      super.merge({
         left: "#{@left}px",
         top: "#{@top}px",
         width: "#{@width}px",
         height: "#{@height}px",
-      }
+      })
     end
+
+    private
 
     def arc_path
       center_x = @width / 2

--- a/lib/scarpe/wv/button.rb
+++ b/lib/scarpe/wv/button.rb
@@ -20,24 +20,26 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      styles = {}
-      styles["background-color"] = @color
-      styles["padding-top"] = @padding_top
-      styles["padding-bottom"] = @padding_bottom
+      styles = super
+
+      styles[:"background-color"] = @color
+      styles[:"padding-top"] = @padding_top
+      styles[:"padding-bottom"] = @padding_bottom
       styles[:color] = @text_color
       styles[:width] = Dimensions.length(@width) if @width
       styles[:height] = Dimensions.length(@height) if @height
-      styles["font-size"] = @font_size
+      styles[:"font-size"] = @font_size
 
       styles[:top] = Dimensions.length(@top) if @top
       styles[:left] = Dimensions.length(@left) if @left
       styles[:position] = "absolute" if @top || @left
-      styles["font-size"] = Dimensions.length(font_size) if @size
-      styles["font-family"] = @font if @font
-      styles["color"] = rgb_to_hex(@stroke) if @stroke
+      styles[:"font-size"] = Dimensions.length(font_size) if @size
+      styles[:"font-family"] = @font if @font
+      styles[:color] = rgb_to_hex(@stroke) if @stroke
+
       styles
     end
 

--- a/lib/scarpe/wv/check.rb
+++ b/lib/scarpe/wv/check.rb
@@ -22,7 +22,7 @@ class Scarpe
 
     def element
       HTML.render do |h|
-        h.input(type: :checkbox, id: html_id, onclick: handler_js_code("click"), value: "hmm #{text}", checked: @checked)
+        h.input(type: :checkbox, id: html_id, onclick: handler_js_code("click"), value: "hmm #{text}", checked: @checked, style:)
       end
     end
   end

--- a/lib/scarpe/wv/edit_box.rb
+++ b/lib/scarpe/wv/edit_box.rb
@@ -30,15 +30,13 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      styles = {}
-
-      styles[:height] = Dimensions.length(height)
-      styles[:width] = Dimensions.length(width)
-
-      styles.compact
+      super.merge({
+        height: Dimensions.length(height),
+        width: Dimensions.length(width),
+      }.compact)
     end
   end
 end

--- a/lib/scarpe/wv/edit_line.rb
+++ b/lib/scarpe/wv/edit_line.rb
@@ -30,10 +30,10 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      styles = {}
+      styles = super
 
       styles[:width] = Dimensions.length(@width) if @width
 

--- a/lib/scarpe/wv/flow.rb
+++ b/lib/scarpe/wv/flow.rb
@@ -9,16 +9,14 @@ class Scarpe
     protected
 
     def style
-      styles = super
-
-      styles[:display] = "flex"
-      styles["flex-direction"] = "row"
-      styles["flex-wrap"] = "wrap"
-      styles["align-content"] = "flex-start"
-      styles["justify-content"] = "flex-start"
-      styles["align-items"] = "flex-start"
-
-      styles
+      {
+        display: "flex",
+        "flex-direction": "row",
+        "flex-wrap": "wrap",
+        "align-content": "flex-start",
+        "justify-content": "flex-start",
+        "align-items": "flex-start",
+      }.merge(super)
     end
   end
 end

--- a/lib/scarpe/wv/image.rb
+++ b/lib/scarpe/wv/image.rb
@@ -23,10 +23,10 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      styles = {}
+      styles = super
 
       styles[:width] = Dimensions.length(@width) if @width
       styles[:height] = Dimensions.length(@height) if @height

--- a/lib/scarpe/wv/line.rb
+++ b/lib/scarpe/wv/line.rb
@@ -16,13 +16,13 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      {
+      super.merge({
         left: "#{@left}px",
         top: "#{@top}px",
-      }
+      })
     end
 
     def line_style

--- a/lib/scarpe/wv/link.rb
+++ b/lib/scarpe/wv/link.rb
@@ -23,6 +23,7 @@ class Scarpe
         id: html_id,
         href: @click,
         onclick: (handler_js_code("click") if @has_block),
+        style: style,
       }.compact
     end
   end

--- a/lib/scarpe/wv/list_box.rb
+++ b/lib/scarpe/wv/list_box.rb
@@ -36,15 +36,15 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      styles = {}
+      styles = super
 
       styles[:height] = Dimensions.length(height) if height
       styles[:width] = Dimensions.length(width) if width
 
-      styles.compact
+      styles
     end
   end
 end

--- a/lib/scarpe/wv/para.rb
+++ b/lib/scarpe/wv/para.rb
@@ -57,6 +57,22 @@ class Scarpe
       element { child_markup }
     end
 
+    protected
+
+    def style
+      super.merge({
+        color: rgb_to_hex(@stroke),
+        "font-size": font_size,
+        "font-family": @font,
+      }.compact)
+    end
+
+    def font_size
+      font_size = @size.is_a?(Symbol) ? SIZES[@size] : @size
+
+      Dimensions.length(font_size)
+    end
+
     private
 
     def child_markup
@@ -71,20 +87,6 @@ class Scarpe
 
     def options
       @html_attributes.merge(id: html_id, style: style)
-    end
-
-    def style
-      {
-        "color" => rgb_to_hex(@stroke),
-        "font-size" => font_size,
-        "font-family" => @font,
-      }.compact
-    end
-
-    def font_size
-      font_size = @size.is_a?(Symbol) ? SIZES[@size] : @size
-
-      Dimensions.length(font_size)
     end
   end
 end

--- a/lib/scarpe/wv/radio.rb
+++ b/lib/scarpe/wv/radio.rb
@@ -21,7 +21,7 @@ class Scarpe
 
     def element
       HTML.render do |h|
-        h.input(type: :radio, id: html_id, onclick: handler_js_code("click"), name: group_name, value: "hmm #{text}", checked: @checked)
+        h.input(type: :radio, id: html_id, onclick: handler_js_code("click"), name: group_name, value: "hmm #{text}", checked: @checked, style: style)
       end
     end
 

--- a/lib/scarpe/wv/shape.rb
+++ b/lib/scarpe/wv/shape.rb
@@ -58,11 +58,13 @@ class Scarpe
       current_path
     end
 
+    protected
+
     def style
-      {
+      super.merge({
         width: "400",
         height: "900",
-      }
+      })
     end
   end
 end

--- a/lib/scarpe/wv/slot.rb
+++ b/lib/scarpe/wv/slot.rb
@@ -67,10 +67,10 @@ class Scarpe
     def style
       styles = super
 
-      styles["margin-top"] = @margin_top if @margin_top
-      styles["margin-bottom"] = @margin_bottom if @margin_bottom
-      styles["margin-left"] = @margin_left if @margin_left
-      styles["margin-right"] = @margin_right if @margin_right
+      styles[:"margin-top"] = @margin_top if @margin_top
+      styles[:"margin-bottom"] = @margin_bottom if @margin_bottom
+      styles[:"margin-left"] = @margin_left if @margin_left
+      styles[:"margin-right"] = @margin_right if @margin_right
 
       styles[:width] = Dimensions.length(@width) if @width
       styles[:height] = Dimensions.length(@height) if @height

--- a/lib/scarpe/wv/span.rb
+++ b/lib/scarpe/wv/span.rb
@@ -43,18 +43,20 @@ class Scarpe
       element { @text }
     end
 
+    protected
+
+    def style
+      {
+        color: @stroke,
+        "font-size": font_size,
+        "font-family": @font,
+      }.compact
+    end
+
     private
 
     def options
       @html_attributes.merge(id: html_id, style: style)
-    end
-
-    def style
-      {
-        "color" => @stroke,
-        "font-size" => font_size,
-        "font-family" => @font,
-      }.compact
     end
 
     def font_size

--- a/lib/scarpe/wv/stack.rb
+++ b/lib/scarpe/wv/stack.rb
@@ -9,16 +9,14 @@ class Scarpe
     protected
 
     def style
-      styles = super
-
-      styles[:display] = "flex"
-      styles["flex-direction"] = "column"
-      styles["align-content"] = "flex-start"
-      styles["justify-content"] = "flex-start"
-      styles["align-items"] = "flex-start"
-      styles["overflow"] = "auto" if @scroll
-
-      styles
+      {
+        display: "flex",
+        "flex-direction": "column",
+        "align-content": "flex-start",
+        "justify-content": "flex-start",
+        "align-items": "flex-start",
+        overflow: @scroll ? "auto" : nil,
+      }.compact.merge(super)
     end
   end
 end

--- a/lib/scarpe/wv/star.rb
+++ b/lib/scarpe/wv/star.rb
@@ -21,14 +21,16 @@ class Scarpe
       end
     end
 
-    private
+    protected
 
     def style
-      {
+      super.merge({
         width: Dimensions.length(@width),
         height: Dimensions.length(@height),
-      }
+      })
     end
+
+    private
 
     def star_points
       get_star_points.join(",")

--- a/lib/scarpe/wv/video.rb
+++ b/lib/scarpe/wv/video.rb
@@ -30,13 +30,5 @@ class Scarpe
     def supported_formats
       SUPPORTED_FORMATS.select { |_format, extensions| extensions.include?(File.extname(@url)) }.keys
     end
-
-    def style
-      styles = {}
-
-      # ADD YOUR STYLES HERE
-
-      styles.compact
-    end
   end
 end

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -834,6 +834,15 @@ class Scarpe
         @webwrangler.dom_change("document.getElementById(\"" + html_id + "\").setAttribute(" + attribute.inspect + "," + value.inspect + "); true")
       end
 
+      # Update an attribute of the JS DOM element's style. The given Ruby value will be inspected and assigned.
+      #
+      # @param style_attr [String] the style attribute name
+      # @param value [String] the new style attribute value
+      # @return [Scarpe::Promise] a promise that will be fulfilled when the change is complete
+      def set_style(style_attr, value)
+        @webwrangler.dom_change("document.getElementById(\"" + html_id + "\").style.#{style_attr} = " + value.inspect + "; true")
+      end
+
       # Remove the specified DOM element
       #
       # @return [Scarpe::Promise] a promise that wil be fulfilled when the element is removed

--- a/lib/scarpe/wv/widget.rb
+++ b/lib/scarpe/wv/widget.rb
@@ -83,6 +83,19 @@ class Scarpe
     #
     # @param changes [Hash] a Hash of new values for properties that have changed
     def properties_changed(changes)
+      # If a widget does something really nonstandard with its html_id or element, it will
+      # need to override to prevent this from happening. That's easy enough, though.
+      if changes.key?("hidden")
+        hidden = changes.delete("hidden")
+        if hidden
+          html_element.set_style("display", "none")
+        else
+          new_style = style # Get current display CSS property, which may vary by subclass
+          disp = new_style[:display]
+          html_element.set_style("display", disp || "block")
+        end
+      end
+
       needs_update! unless changes.empty?
     end
 
@@ -143,6 +156,15 @@ class Scarpe
       b_int = (b_float * 255.0).to_i.clamp(0, 255)
 
       "#%0.2X%0.2X%0.2X" % [r_int, g_int, b_int]
+    end
+
+    # CSS styles
+    def style
+      styles = {}
+      if @hidden
+        styles[:display] = "none"
+      end
+      styles
     end
 
     public

--- a/test/test_widgets.rb
+++ b/test/test_widgets.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Widgets Testing
+class TestWidgets < LoggedScarpeTest
+  def test_hide_show
+    run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
+      Shoes.app do
+        @widgets = []
+        @widgets << alert("YOLO!")
+        @widgets << arc(400, 0, 120, 100, 175, 175)
+        @widgets << button("Press Me")
+        @widgets << check
+        @widgets << edit_line("foo")
+        @widgets << edit_box("bar")
+        @widgets << flow {} # Slightly weird thing here: empty flow
+        @widgets << image("https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png")
+        @widgets << line(0, 0, 100, 100)
+        @widgets << list_box(items: ['A', 'B'])
+        @widgets << para("Hello")
+        @widgets << radio("ooga")
+        @widgets << shape { line(0, 0, 10, 10) }
+        @widgets << stack {}
+        @widgets << star(230, 100, 6, 50, 25)
+        @widgets << video("http://techslides.com/demos/sample-videos/small.mp4")
+      end
+    SCARPE_APP
+      on_heartbeat do
+        # Get proxy objects for the Shoes widgets so we can get their display objects, etc.
+        w = Shoes::App.instance.instance_variable_get("@widgets").map { |sw| proxy_for(sw) }
+
+        w.each { |i| i.hide }
+        w.each { |i| assert_include i.display.to_html, "display:none" }
+        w.each { |i| i.toggle() }
+        w.each { |i| assert_not_include i.display.to_html, "display:none" }
+
+        # Nothing hidden, make sure no display:none
+        wait fully_updated
+        assert_not_include dom_html, "display:none"
+
+        # Exactly one thing hidden
+        para.hide
+        wait fully_updated
+        # Okay, so what's weird about this is that if we use the DOM style setter to set display, it gets a space...
+        assert_include dom_html, "display: none"
+
+        test_finished
+      end
+    TEST_CODE
+  end
+end


### PR DESCRIPTION
### Description

Add parent styles to Scarpe Webview as a thing, and have the various widgets pick up on that. In order to make styles mergeable, convert all style hash keys to symbol, not a mix of symbol and string.

As a side effect, that means we can set a "hidden" property on the widget in the parent and pick it up in the children.

For added fun, there's a test that makes one of all the top-level widgets, puts it into an array called @ widgets and then does a bunch of stuff to mess with it.

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
