### PR TITLE
Change warning to warn for all log stuff

### DIFF
--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -67,7 +67,7 @@ module Shoes
       end
 
       Signal.trap("INT") do
-        @log.warning("App interrupted by signal, stopping...")
+        @log.warn("App interrupted by signal, stopping...")
         puts "\nStopping Shoes app..."
         destroy
       end

--- a/lacci/lib/shoes/log.rb
+++ b/lacci/lib/shoes/log.rb
@@ -9,7 +9,7 @@
 # an implementation to be plugged in.
 
 module Shoes
-  LOG_LEVELS = [:debug, :info, :warning, :error, :fatal].freeze
+  LOG_LEVELS = [:debug, :info, :warn, :error, :fatal].freeze
 
   # Include this module to get a @log instance variable to log as your
   # configured component.

--- a/lib/scarpe/logger.rb
+++ b/lib/scarpe/logger.rb
@@ -21,7 +21,7 @@ class Scarpe
         :debug
       when "info"
         :info
-      when "warn", "warning"
+      when "warn"
         :warn
       when "err", "error"
         :error
@@ -103,10 +103,6 @@ class Scarpe
       end
     end
   end
-end
-
-class Logging::Logger
-  alias_method :warning, :warn
 end
 
 log_config = if ENV["SCARPE_LOG_CONFIG"]

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -216,7 +216,7 @@ class Scarpe
     def js_eventually(code)
       raise "WebWrangler isn't running, eval doesn't work!" unless @is_running
 
-      @log.warning "Deprecated: please do NOT use js_eventually, it's basically never what you want!" unless ENV["CI"]
+      @log.warn "Deprecated: please do NOT use js_eventually, it's basically never what you want!" unless ENV["CI"]
 
       @webview.eval(code)
     end


### PR DESCRIPTION
fixes issue #313

### Description

Should be "warn" rather than "warning" for everything log-related. The TwP/logging gem uses "warning" as an internal private method, which causes conflicts.

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
