### PR TITLE
Implement Slot#app, move append/clear and child methods to slots only

### DIFF
--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -131,7 +131,7 @@ module Shoes
       to_add = @document_root.children
       until to_add.empty?
         out.concat(to_add)
-        to_add = to_add.flat_map(&:children).compact
+        to_add = to_add.flat_map { |w| w.respond_to?(:children) ? w.children : [] }.compact
       end
 
       out

--- a/lacci/lib/shoes/widget.rb
+++ b/lacci/lib/shoes/widget.rb
@@ -93,6 +93,8 @@ module Shoes
         "@children=#{@children.inspect} properties=#{display_property_values.inspect}>"
     end
 
+    private
+
     def bind_self_event(event_name, &block)
       raise("Widget has no linkable_id! #{inspect}") unless linkable_id
 
@@ -102,6 +104,8 @@ module Shoes
     def bind_no_target_event(event_name, &block)
       bind_shoes_event(event_name:, &block)
     end
+
+    public
 
     def display_property_values
       all_property_names = self.class.display_property_names
@@ -114,6 +118,8 @@ module Shoes
       properties
     end
 
+    private
+
     def create_display_widget
       klass_name = self.class.name.delete_prefix("Scarpe::").delete_prefix("Shoes::")
 
@@ -121,8 +127,9 @@ module Shoes
       ::Shoes::DisplayService.display_service.create_display_widget_for(klass_name, self.linkable_id, display_property_values)
     end
 
+    public
+
     attr_reader :parent
-    attr_reader :children
 
     def set_parent(new_parent)
       @parent&.remove_child(self)
@@ -131,57 +138,12 @@ module Shoes
       send_shoes_event(new_parent.linkable_id, event_name: "parent", target: linkable_id)
     end
 
-    # Do not call directly, use set_parent
-    def remove_child(child)
-      @children ||= []
-      unless @children.include?(child)
-        @log.warn("remove_child: no such child(#{child.inspect}) for parent(#{parent.inspect})!")
-      end
-      @children.delete(child)
-    end
-
-    # Do not call directly, use set_parent
-    # Can this be private?
-    def add_child(child)
-      @children ||= []
-      @children << child
-    end
-
     # Removes the element from the Shoes::Widget tree
     def destroy
       @parent&.remove_child(self)
       send_shoes_event(event_name: "destroy", target: linkable_id)
     end
-
     alias_method :remove, :destroy
-
-    # Remove all children from this widget. If a block
-    # is given, call the block to replace the children with
-    # new contents from that block.
-    #
-    # Should only be called on Slots, which can
-    # have children.
-    #
-    # @yield The block to call to replace the contents of the widget (optional)
-    # @return [void]
-    def clear(&block)
-      @children.dup.each(&:destroy)
-      append(&block) if block_given?
-      nil
-    end
-
-    # Call the block to append new children to a Slot.
-    #
-    # Should only be called on a Slot, since only Slots can have children.
-    #
-    # @yield the block to call to replace children; will be called on the Shoes::App, appending to the called Slot as the current slot
-    # @return [void]
-    def append(&block)
-      raise("append requires a block!") unless block_given?
-      raise("Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
-
-      Shoes::App.instance.with_slot(self, &block)
-    end
 
     # Hide the widget.
     def hide

--- a/lacci/lib/shoes/widgets/flow.rb
+++ b/lacci/lib/shoes/widgets/flow.rb
@@ -2,6 +2,10 @@
 
 module Shoes
   class Flow < Shoes::Slot
+    include Shoes::Background
+    include Shoes::Border
+    include Shoes::Spacing
+
     display_properties :width, :height, :margin, :padding
 
     def initialize(width: "100%", height: nil, margin: nil, padding: nil, **options, &block)

--- a/lacci/lib/shoes/widgets/shape.rb
+++ b/lacci/lib/shoes/widgets/shape.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 module Shoes
-  # Weirdly, in Shoes3 Shape is *not* a Slot subclass, it's a normal Type even though it has a block.
-  # We need to push the Shape as a slot so that we can correctly direct move_to, line_to, etc. to it.
-  class Shape < Shoes::Widget
+  # A Shape acts as a sort of union type for drawn shapes. In Shoes you can use it to merge multiple
+  # ovals, arcs, stars, etc. into a single drawn shape.
+  #
+  # In Shoes3, a Shape isn't really a Slot. It's a kind of DSL with drawing commands that happen
+  # to have the same name as the Art widgets like star, arc, etc. Here we're treating it as
+  # a slot containing those widgets, which is wrong but not *too* wrong.
+  #
+  # @incompatibility A Shoes3 Shape is *not* a slot; Scarpe does *not* do union shapes
+  class Shape < Shoes::Slot
     display_properties :left, :top, :shape_commands, :draw_context
 
     def initialize(left: nil, top: nil, &block)

--- a/lacci/lib/shoes/widgets/slot.rb
+++ b/lacci/lib/shoes/widgets/slot.rb
@@ -1,7 +1,75 @@
 # frozen_string_literal: true
 
 class Shoes::Slot < Shoes::Widget
-  include Shoes::Background
-  include Shoes::Border
-  include Shoes::Spacing
+  # @incompatibility Shoes uses #content, not #children, for this
+  attr_reader :children
+
+  # Do not call directly, use set_parent
+  def remove_child(child)
+    @children ||= []
+    unless @children.include?(child)
+      @log.warn("remove_child: no such child(#{child.inspect}) for parent(#{parent.inspect})!")
+    end
+    @children.delete(child)
+  end
+
+  # Do not call directly, use set_parent
+  def add_child(child)
+    @children ||= []
+    @children << child
+  end
+
+  # Get a list of child widgets
+  def contents
+    @children ||= []
+    @children.dup
+  end
+
+  # Calling stack.app or flow.app will execute the block
+  # with the Shoes::App as self, and with that stack or
+  # flow as the current slot.
+  #
+  # @incompatibility Shoes Classic will only change self
+  #   via this method, while Scarpe will also change self
+  #   with the other Slot Manipulation methods: #clear,
+  #   #append, #prepend, #before and #after.
+  #
+  # @return [Shoes::App] the Shoes app
+  # @yield the block to call with the Shoes App as self
+  def app(&block)
+    Shoes::App.instance.with_slot(self, &block) if block_given?
+    Shoes::App.instance
+  end
+
+  # Remove all children from this widget. If a block
+  # is given, call the block to replace the children with
+  # new contents from that block.
+  #
+  # Should only be called on Slots, which can
+  # have children.
+  #
+  # @incompatibility Shoes Classic calls the clear block with current self, while Scarpe uses the Shoes::App as self
+  #
+  # @yield The block to call to replace the contents of the widget (optional)
+  # @return [void]
+  def clear(&block)
+    @children.dup.each(&:destroy)
+    append(&block) if block_given?
+    nil
+  end
+
+  # Call the block to append new children to a Slot.
+  #
+  # Should only be called on a Slot, since only Slots can have children.
+  #
+  # @incompatibility Shoes Classic calls the append block with current self, while Scarpe uses the Shoes::App as self
+  #
+  # @yield the block to call to replace children; will be called on the Shoes::App, appending to the called Slot as the current slot
+  # @return [void]
+  def append(&block)
+    raise("append requires a block!") unless block_given?
+    raise("Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
+
+    Shoes::App.instance.with_slot(self, &block)
+  end
 end

--- a/lacci/lib/shoes/widgets/stack.rb
+++ b/lacci/lib/shoes/widgets/stack.rb
@@ -2,6 +2,10 @@
 
 module Shoes
   class Stack < Shoes::Slot
+    include Shoes::Background
+    include Shoes::Border
+    include Shoes::Spacing
+
     # TODO: sort out various margin and padding properties, including putting stuff into spacing
     display_properties :width, :height, :scroll
 

--- a/test/test_widgets.rb
+++ b/test/test_widgets.rb
@@ -49,4 +49,31 @@ class TestWidgets < LoggedScarpeTest
       end
     TEST_CODE
   end
+
+  def test_app_method
+    run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
+      class NotAWidget
+        def self.magic(stack)
+          stack.app do
+            @s2.para "Hello!"
+          end
+        end
+      end
+
+      Shoes.app do
+        @s = stack do
+          button("Press Me") { NotAWidget.magic(@s) }
+        end
+        @s2 = stack {}
+      end
+    SCARPE_APP
+      on_heartbeat do
+        assert_equal [], stack("@s2").contents
+        js = button.display.handler_js_code('click')
+        query_js_value(js)
+
+        test_finished
+      end
+    TEST_CODE
+  end
 end


### PR DESCRIPTION
### Description

As part of this, I've made Shape a Slot. That's not long-term accurate, but it's one more slow step in the right direction.

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
