### PR TITLE
Bloops gem should be required by the display service, not core Scarpe

### DIFF
--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -18,8 +18,6 @@ class Scarpe::Error < StandardError; end
 require_relative "scarpe/version"
 require_relative "scarpe/promises"
 
-require "bloops"
-
 d_s = ENV["SCARPE_DISPLAY_SERVICE"] || "wv_local"
 # This is require, not require_relative, to allow gems to supply a new display service
 require "scarpe/#{d_s}"

--- a/lib/scarpe/wv_local.rb
+++ b/lib/scarpe/wv_local.rb
@@ -3,4 +3,6 @@
 require_relative "wv"
 require_relative "wv/webview_local_display"
 
+require "bloops"
+
 Shoes::DisplayService.set_display_service_class(Scarpe::WebviewDisplayService)

--- a/lib/scarpe/wv_relay.rb
+++ b/lib/scarpe/wv_relay.rb
@@ -3,4 +3,6 @@
 require_relative "wv"
 require_relative "wv/webview_relay_display"
 
+require "bloops"
+
 Shoes::DisplayService.set_display_service_class(Scarpe::WVRelayDisplayService)


### PR DESCRIPTION
### Description

That way it can be overridden (or just not implemented) by display services like Wasm that can't easily use the normal Ruby bloopsaphone gem.

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
