### PR TITLE
For now, stub out LIB_DIR since it isn't used yet - will need to revisit

### DIFF
--- a/lacci/lib/shoes/constants.rb
+++ b/lacci/lib/shoes/constants.rb
@@ -15,7 +15,7 @@ module Shoes
       File.join(top, file)
     end
 
-    LIB_DIR = find_lib_dir
+    LIB_DIR = nil # find_lib_dir # Need to stub this in a way that works with Wasm - not currently used by working legacy apps
 
     # Math constants from Shoes3
     RAD2PI = 0.01745329251994329577


### PR DESCRIPTION
### Description

Since nobody's using it yet, we can just stub it out for now. Wasm doesn't support this, and we'll need to implement it differently to make Lacci portable to both Wasm and more standard environments.

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
