### PR TITLE
Stub out LIB_DIR in a fairly Wasm-specific way, maybe to revisit later.

### DIFF
--- a/lacci/lib/shoes/constants.rb
+++ b/lacci/lib/shoes/constants.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
-require "tmpdir"
-
 module Shoes
   module Constants
     def self.find_lib_dir
+      begin
+        require "tmpdir"
+      rescue LoadError
+        return nil
+      end
       homes = [
         [ENV["LOCALAPPDATA"], "Shoes"],
         [ENV["APPDATA"], "Shoes"],


### PR DESCRIPTION
### Description

LIB_DIR will be nil if there doesn't seem to be a file system, and we don't require "tmpdir" unless we use it.

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
