### PR TITLE
Don't require things until needed for image or download

### DIFF
--- a/lacci/lib/shoes/download.rb
+++ b/lacci/lib/shoes/download.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "net/http"
-require "openssl"
-require "nokogiri"
-
 module Shoes
   class Widget
     class ResponseWrapper
@@ -23,6 +19,10 @@ module Shoes
     end
 
     def download(url, method: "GET", save: nil, styles: {}, &block)
+      require "net/http"
+      require "openssl"
+      require "nokogiri"
+
       @block = block
 
       Thread.new do

--- a/lacci/lib/shoes/widgets/image.rb
+++ b/lacci/lib/shoes/widgets/image.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "fastimage"
 require "open-uri"
 
 module Shoes
@@ -27,6 +26,7 @@ end
 module Shoes
   class Widget
     def size
+      require "fastimage"
       width, height = FastImage.size(@url)
 
       [width, height]


### PR DESCRIPTION
### Description

This isn't a full rework, just making sure that a Wasm Scarpe app that doesn't use images or downloads doesn't get broken by trying to require things it can't.

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
