### PR TITLE
Docs-build workflow that doesn't use new GitHub Actions deployment

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get -y install portaudio19-dev libgtk-3-dev libwebkit2gtk-4.0-dev
+        run: sudo apt-get update && sudo apt-get -y install portaudio19-dev libgtk-3-dev libwebkit2gtk-4.0-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:
@@ -43,21 +43,20 @@ jobs:
         run: rm -rf .yardoc doc && bundle exec yardoc -o doc
         env:
           FAKE_ENV: example
-      - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: ./doc
-
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+      - name: Push yardoc files to pages branch
+        run: |
+          set -e
+          set -x
+          git switch --orphan new_pages
+          find . -mindepth 1 -maxdepth 1 ! \( -name "doc" -o -name ".git" \) -exec rm -rf {} ';'
+          mv doc/* .
+          touch .nojekyll
+          rmdir doc
+          git add .
+          git config user.email "builder@example.com"
+          git config user.name "Docs Builder"
+          git commit -m "New docs build"
+          git checkout -b pages || git checkout pages
+          git reset --hard new_pages
+          git push -f origin pages
 


### PR DESCRIPTION
### Description

If we use the new beta-only GHActions deployment for building docs then if the build ever fails, there's no docs -- they just 404 and don't keep the previous successfully-built docs around.

You know what works fine after a bunch of ugly workarounds? Just building the docs and pushing them to a pages branch.

Given that GitHub seems to have screwed up the docs right now anyway, I've just switched the project settings over to use this. I debugged it on noahgibbs/scarpe.

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
