### PR TITLE
Extract Webview-specific log config from the test-helper log config

### DIFF
--- a/test/test_catscradle.rb
+++ b/test/test_catscradle.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 # Tests for the CatsCradle testing language
 class TestCatsCradle < LoggedScarpeTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
   def test_para_finder
     run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
       Shoes.app do

--- a/test/test_control_interface.rb
+++ b/test/test_control_interface.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class TestControlInterface < LoggedScarpeTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
   def test_trivial_async_assert
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do

--- a/test/test_edit_box.rb
+++ b/test/test_edit_box.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class TestEditBox < LoggedScarpeTest
+  self.logger_dir = File.expand_path "#{__dir__}/../logger"
+
   def test_renders_textarea
     run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
       Shoes.app do

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class TestExamplesWithWebview < LoggedScarpeTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
   match_str = ENV["EXAMPLES_MATCHING"] || ""
 
   examples_to_test = Dir["examples/**/*.rb"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -175,4 +175,20 @@ end
 
 class LoggedScarpeTest < ScarpeWebviewTest
   include Scarpe::Test::LoggedTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
+  def setup
+    self.extra_log_config = {
+      # file_id is the test name, and comes from LoggedTest
+      "WV" => ["debug", "logger/test_failure_wv_misc_#{file_id}.log"],
+      "WV::API" => ["debug", "logger/test_failure_wv_api_#{file_id}.log"],
+
+      "WV::CatsCradle" => ["debug", "logger/test_failure_catscradle_#{file_id}.log"],
+
+      "WV::RelayDisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
+      "WV::WebviewDisplayService" => ["debug", "logger/test_failure_events_#{file_id}.log"],
+      "WV::ControlInterface" => ["debug", "logger/test_failure_events_#{file_id}.log"],
+    }
+    super
+  end
 end

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -5,6 +5,8 @@ require "test_helper"
 # These are a variety of simple apps, and we're just making sure they don't immediately fail.
 
 class TestWebviewScarpe < LoggedScarpeTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
   def test_that_it_has_a_version_number
     refute_nil ::Scarpe::VERSION
   end

--- a/test/test_slots.rb
+++ b/test/test_slots.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class TestSlots < LoggedScarpeTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
   def test_stack_child
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')
       Shoes.app do

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -6,6 +6,8 @@ require "test_helper"
 # This may go away over time as CatsCradle gets more capable.
 
 class TestWebWranglerInScarpeApp < LoggedScarpeTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
   # Need to make sure that even with no widgets we still get at least one redraw
   def test_empty_app
     run_test_scarpe_code(<<-'SCARPE_APP', test_code: <<-'TEST_CODE')

--- a/test/test_widgets.rb
+++ b/test/test_widgets.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 # Widgets Testing
 class TestWidgets < LoggedScarpeTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
   def test_hide_show
     run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
       Shoes.app do


### PR DESCRIPTION
### Description

Also, fix an error in LOGGER_DIR and prevent it from recurring.

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
