### PR TITLE
Add segmented Scarpe app files, reuse more of exe/scarpe

### DIFF
--- a/exe/scarpe
+++ b/exe/scarpe
@@ -76,7 +76,7 @@ when "-v"
   puts "Lacci #{Lacci::VERSION}"
 when "run"
   # Run the Scarpe app file
-  load ARGV[0]
+  Shoes.run_app ARGV[0]
 when "env"
   print_env
 else

--- a/exe/scarpe
+++ b/exe/scarpe
@@ -1,66 +1,44 @@
 #!/usr/bin/env ruby
 
-# We need to not use syntactic features of very recent Rubies in this file, so that it parses
-# correctly in earlier Rubies and can successfully give the version-check error.
-if RUBY_VERSION[0..2] < "3.2"
-  $stderr.puts("Scarpe requires Ruby 3.2 or higher!")
-  exit(-1)
-end
-
-def print_usage
-  puts <<USAGE
-Usage: scarpe [OPTIONS] <scarpe app file>           # Same as "scarpe run"
-       scarpe [OPTIONS] run <scarpe app file>
-       scarpe [OPTIONS] env                         # print Scarpe environment settings
-       scarpe -v                                    # print the Scarpe gem version and exit
-  Options:
-      --dev                          Use development local scarpe, not an installed gem
-      --debug                        Turn on application debug mode
-USAGE
-end
-
-def env_or_default(env_var, default_val)
-  "#{env_var}: #{ENV[env_var] || default_val}"
-end
-
-def env_or_none(env_var)
-  env_or_default(env_var, "(none)")
-end
-
-def print_env
-  puts <<~SCARPE_ENV
-    Scarpe environment:
-      #{env_or_default("SCARPE_DISPLAY_SERVICE", "(default)wv_local")}
-      #{env_or_default("SCARPE_LOG_CONFIG", "(default)#{Shoes::Log::DEFAULT_LOG_CONFIG.inspect}")}
-      #{env_or_none("SCARPE_APP_TEST")}
-    Scarpe::WV environment:
-      #{env_or_none("SCARPE_TEST_CONTROL")}
-      #{env_or_none("SCARPE_TEST_RESULTS")}
-      #{env_or_none("SCARPE_DEBUG")}
-    Ruby and shell environment:
-      RUBY_DESCRIPTION: #{RUBY_DESCRIPTION.inspect}
-      RUBY_PLATFORM: #{RUBY_PLATFORM.inspect}
-      RUBY_ENGINE: #{RUBY_ENGINE.inspect}
-      #{env_or_none("SHELL")}
-      #{env_or_none("PATH")}
-      #{env_or_none("LD_LIBRARY_PATH")}
-      #{env_or_none("DYLD_LIBRARY_PATH")}
-      #{env_or_none("GEM_ROOT")}
-      #{env_or_none("GEM_HOME")}
-      #{env_or_none("GEM_PATH")}
-  SCARPE_ENV
-end
+# First we need to load Scarpe and Lacci, which means figuring out where from.
 
 # --dev option applies to all actions
 use_dev = ARGV.delete("--dev") ? true : false
 use_debug = ARGV.delete("--debug") ? true : false
 
+# Default to local webview display if not otherwise given
+ENV['SCARPE_DISPLAY'] ||= 'wv_local'
+
+if use_debug
+  ENV['SCARPE_DEBUG'] = 'true'
+end
+if use_dev
+  dev_path = File.expand_path("../lib", __dir__)
+  $LOAD_PATH.prepend dev_path
+end
+
 if use_dev
   require 'bundler/setup'
   Bundler.require(:default)
 end
-
 require "scarpe"
+require "lacci/scarpe_cli"
+
+include Scarpe::CLI
+
+# We need to not use syntactic features of very recent Rubies in this file, so that it parses
+# correctly in earlier Rubies and can successfully give the version-check error.
+version_check
+
+def print_usage
+  puts DEFAULT_USAGE
+end
+
+add_env_categories("Scarpe::WV" => [
+  env_or_default("SCARPE_TEST_CONTROL", "(none)"),
+  env_or_default("SCARPE_TEST_RESULTS", "(none)"),
+  env_or_default("SCARPE_TEST_DEBUG", "(none)"),
+])
 
 verb = "run"
 verb_target = nil
@@ -91,24 +69,16 @@ else
   verb_target = ARGV[0]
 end
 
-if use_debug
-  ENV['SCARPE_DEBUG'] = 'true'
-end
-if use_dev
-  dev_path = File.expand_path("../lib", __dir__)
-  $LOAD_PATH.prepend dev_path
-end
-# We mustn't require Scarpe sooner than this so that the --dev setting is respected
-require "scarpe"
-
 case verb
-  when "-v"
-    puts "Scarpe #{Scarpe::VERSION}"
-  when "run"
-    # Run the Scarpe app file
-    load ARGV[0]
-  when "env"
-    print_env
-  else
-    raise "Internal error! Unknown ./exe/scarpe verb!"
+when "-v"
+  puts "Scarpe #{Scarpe::VERSION}"
+  puts "Scarpe-Components #{Scarpe::Components::VERSION}"
+  puts "Lacci #{Lacci::VERSION}"
+when "run"
+  # Run the Scarpe app file
+  load ARGV[0]
+when "env"
+  print_env
+else
+  raise "Internal error! Unknown ./exe/scarpe verb!"
 end

--- a/lacci/lib/lacci/scarpe_cli.rb
+++ b/lacci/lib/lacci/scarpe_cli.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Scarpe
+  module CLI
+    DEFAULT_USAGE = <<~'USAGE'
+      Usage: scarpe_core [OPTIONS] <scarpe app file>           # Same as "scarpe run"
+             scarpe_core [OPTIONS] run <scarpe app file>
+             scarpe_core [OPTIONS] env                         # print Scarpe environment settings
+             scarpe_core -v                                    # print the Scarpe gem version and exit
+        Options:
+            --dev                          Use development local scarpe, not an installed gem
+            --debug                        Turn on application debug mode
+    USAGE
+
+    def version_check
+      if RUBY_VERSION[0..2] < "3.2"
+        raise "Scarpe and Lacci require Ruby 3.2 or higher!"
+      end
+    end
+
+    def env_or_default(env_var, default_val)
+      [env_var, ENV[env_var] ? ENV[env_var].inspect : default_val]
+    end
+
+    def default_env_categories
+      {
+        "Lacci" => [
+          env_or_default("SCARPE_DISPLAY_SERVICE", "(none)"),
+          env_or_default("SCARPE_LOG_CONFIG", "(default)#{Shoes::Log::DEFAULT_LOG_CONFIG.inspect}"),
+          env_or_default("SCARPE_APP_TEST", "(none)"),
+        ],
+        "Ruby and Shell" => [
+          ["RUBY_DESCRIPTION", RUBY_DESCRIPTION],
+          ["RUBY_PLATFORM", RUBY_PLATFORM],
+          ["RUBY_ENGINE", RUBY_ENGINE],
+          env_or_default("SHELL", "(none)"),
+          env_or_default("PATH", "(none)"),
+          env_or_default("LD_LIBRARY_PATH", "(none)"),
+          env_or_default("DYLD_LIBRARY_PATH", "(none)"),
+          env_or_default("GEM_ROOT", "(none)"),
+          env_or_default("GEM_HOME", "(none)"),
+          env_or_default("GEM_PATH", "(none)"),
+        ],
+      }
+    end
+
+    def env_categories
+      @env_categories ||= default_env_categories
+      @env_categories
+    end
+
+    def add_env_categories(categories)
+      unless categories.is_a?(Hash)
+        raise("Please supply a hash with categories names as keys and an array of two-elt arrays as values!")
+      end
+
+      # Try to get categories into the *start* of the hash, insertion-order-wise
+      @env_categories = categories.merge(env_categories)
+    end
+
+    def print_env
+      env_categories.each do |category, entries|
+        puts "#{category} environment:"
+        entries.each do |name, val|
+          puts "  #{name}: #{val}"
+        end
+      end
+    end
+  end
+end

--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -96,8 +96,8 @@ module Shoes
       nil
     end
 
-    def file_loaders
-      @file_loaders ||= [
+    def default_file_loaders
+      [
         # By default we will always try to load any file, regardless of extension, as a Shoes Ruby file.
         proc do |path|
           load path
@@ -106,8 +106,20 @@ module Shoes
       ]
     end
 
+    def file_loaders
+      @file_loaders ||= default_file_loaders
+    end
+
     def add_file_loader(loader)
       file_loaders.prepend(loader)
+    end
+
+    def reset_file_loaders
+      @file_loaders = default_file_loaders
+    end
+
+    def set_file_loaders(loaders)
+      @file_loaders = loaders
     end
   end
 end

--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -73,5 +73,41 @@ module Shoes
       app.run
       nil
     end
+
+    # Load a Shoes app from a file. By default, this will load old-style Shoes apps
+    # from a .rb file with all the appropriate libraries loaded. By setting one or
+    # more loaders, a Lacci-based display library can accept new file formats as
+    # well, not just raw Shoes .rb files.
+    #
+    # @param path [String] The current-dir-relative path to the file
+    # @return [void]
+    # @see Shoes.add_file_loader
+    def run_app(relative_path)
+      path = File.expand_path relative_path
+      loaded = false
+      file_loaders.each do |loader|
+        if loader.call(path)
+          loaded = true
+          break
+        end
+      end
+      raise "Could not find a file loader for #{path.inspect}!" unless loaded
+
+      nil
+    end
+
+    def file_loaders
+      @file_loaders ||= [
+        # By default we will always try to load any file, regardless of extension, as a Shoes Ruby file.
+        proc do |path|
+          load path
+          true
+        end,
+      ]
+    end
+
+    def add_file_loader(loader)
+      file_loaders.prepend(loader)
+    end
   end
 end

--- a/lib/scarpe/wv.rb
+++ b/lib/scarpe/wv.rb
@@ -22,7 +22,8 @@ Shoes::Log.instance = Scarpe::Components::ModularLogImpl.new
 Shoes::Log.configure_logger(log_config)
 
 require "scarpe/components/segmented_file_loader"
-Shoes.add_file_loader Scarpe::Components::SEGMENTED_FILE_LOADER
+loader = Scarpe::Components::SegmentedFileLoader.new
+Shoes.add_file_loader loader
 
 require_relative "wv/web_wrangler"
 require_relative "wv/control_interface"

--- a/lib/scarpe/wv.rb
+++ b/lib/scarpe/wv.rb
@@ -21,6 +21,9 @@ end
 Shoes::Log.instance = Scarpe::Components::ModularLogImpl.new
 Shoes::Log.configure_logger(log_config)
 
+require "scarpe/components/segmented_file_loader"
+Shoes.add_file_loader Scarpe::Components::SEGMENTED_FILE_LOADER
+
 require_relative "wv/web_wrangler"
 require_relative "wv/control_interface"
 

--- a/scarpe-components/lib/scarpe/components/file_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/file_helpers.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+# These can be used for unit tests, but also more generally.
+
+module Scarpe::Components::FileHelpers
+  # Create a temporary file with the given prefix and contents.
+  # Execute the block of code with it in place. Make sure
+  # it gets cleaned up afterward.
+  #
+  # @param prefix [String] the prefix passed to Tempfile to identify this file on disk
+  # @param contents [String] the file contents that should be written to Tempfile
+  # @param dir [String] the directory to create the tempfile in
+  # @yield The code to execute with the tempfile present
+  # @yieldparam the path of the new tempfile
+  def with_tempfile(prefix, contents, dir: Dir.tmpdir)
+    t = Tempfile.new(prefix, dir)
+    t.write(contents)
+    t.flush # Make sure the contents are written out
+
+    yield(t.path)
+  ensure
+    t.close
+    t.unlink
+  end
+
+  # Create multiple tempfiles, with given contents, in given
+  # directories, and execute the block in that context.
+  # When the block is finished, make sure all tempfiles are
+  # deleted.
+  #
+  # Pass an array of arrays, where each array is of the form:
+  # [prefix, contents, (optional)dir]
+  #
+  # I don't love inlining with_tempfile's contents into here.
+  # But calling it iteratively or recursively was difficult
+  # when I tried it the obvious ways.
+  #
+  # This method should be equivalent to calling with_tempfile
+  # once for each entry in the array, in a set of nested
+  # blocks.
+  #
+  # @param tf_specs [Array<Array>] The array of tempfile prefixes, contents and directories
+  # @yield The code to execute with those tempfiles present
+  # @yieldparam An array of paths to tempfiles, in the same order as tf_specs
+  def with_tempfiles(tf_specs, &block)
+    tempfiles = []
+    tf_specs.each do |prefix, contents, dir|
+      dir ||= Dir.tmpdir
+      t = Tempfile.new(prefix, dir)
+      tempfiles << t
+      t.write(contents)
+      t.flush # Make sure the contents are written out
+    end
+
+    args = tempfiles.map(&:path)
+    yield(args)
+  ensure
+    tempfiles.each do |t|
+      t.close
+      t.unlink
+    end
+  end
+end

--- a/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
+++ b/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Scarpe::Components
+  def self.segmented_file_load(path)
+    require "yaml" # Only load when needed
+    require "tempfile"
+    require "English"
+
+    contents = File.read(path)
+    _front_matter = {}
+
+    segments = contents.split("\n-----")
+
+    if segments[0].start_with?("---/n") || segments[0] == "---"
+      # We have YAML front matter at the start.
+      # Eventually this will specify what different code segments do.
+      _front_matter = YAML.load segments[0]
+      if segments.size == 1
+        raise "Illegal segmented Scarpe file: must have at least one code segment, not just front matter!"
+      end
+
+      segments = segments[1..-1]
+    elsif segments.size == 1
+      # Simplest segmented file there is: no front matter, no segments
+      # @todo: indicate to Scarpe in some way that this is a Scarpe-specific
+      #     file and extensions should be turned on?
+      return load path
+    end
+
+    # Beyond this point, our segmented file has at least one code segment with a five-plus-dashes divider
+    segmap = {}
+    segments.each do |segment|
+      if segment =~ /\A-*\s+(.*?)\n/
+        # named segment
+        segment = ::Regexp.last_match.post_match
+        segmap[::Regexp.last_match(1)] = segment
+      elsif segment[0] == "-"
+        # unnamed segment
+        segment =~ /\A-*/ || raise("Internal error! This regexp should always match!")
+        segment = ::Regexp.last_match.post_match
+        ctr = (1..10_000).detect { |i| !segmap.key?("%5d" % i) }
+        gen_name = "%5d" % ctr
+
+        segmap[gen_name] = segment
+      else
+        raise "Internal error when parsing segments in segmented app file!"
+      end
+    end
+
+    if segmap.size == 1
+      # If there's only one segment, load it as Shoes code
+      eval segmap.values[0]
+    elsif segmap.size == 2
+      # If there are two segments, the first is Shoes code and the second is APP_TEST_CODE
+      segs = segmap.values
+      with_tempfile("scarpe_seg_test_code", segs[1]) do |tf|
+        # This will get picked up when Scarpe.app() runs. It will execute in the Scarpe::App.
+        # Note that unlike app_test_code in test_helper this does *not* load CatsCradle or
+        # set it up for testing.
+        ENV["SCARPE_APP_TEST"] = tf
+        eval segs[0]
+      end
+    else
+      # Later there will be more interesting customisable options for what to do with
+      # different segments. For now, bail.
+      raise "More complex segmentation files are not yet implemented!"
+    end
+  end
+
+  # Can we share this with unit test helpers?
+  def self.with_tempfile(prefix, contents, dir: Dir.tmpdir)
+    t = Tempfile.new(prefix, dir)
+    t.write(contents)
+    t.flush # Make sure the contents are written out
+
+    yield(t.path)
+  ensure
+    t.close
+    t.unlink
+  end
+
+  # Load a .sca file with an optional YAML frontmatter prefix and
+  # multiple file sections which can be treated differently.
+  SEGMENTED_FILE_LOADER = lambda do |path|
+    if path.end_with?(".scas")
+      Scarpe::Components.segmented_file_load(path)
+      return true
+    end
+    false
+  end
+end
+
+# Shoes.add_file_loader Scarpe::Components::SEGMENTED_FILE_LOADER

--- a/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
+++ b/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
@@ -1,93 +1,158 @@
 # frozen_string_literal: true
 
+require "scarpe/components/file_helpers"
+
 module Scarpe::Components
-  def self.segmented_file_load(path)
-    require "yaml" # Only load when needed
-    require "tempfile"
-    require "English"
+  class SegmentedFileLoader
+    include Scarpe::Components::FileHelpers
 
-    contents = File.read(path)
-    _front_matter = {}
+    # Add a new segment type (e.g. "catscradle") with a different
+    # file handler.
+    #
+    # @param type [String] the new name for this segment type
+    # @param handler [Object] an object that will be called as obj.call(filename) - often a proc
+    # @return <void>
+    def add_segment_type(type, handler)
+      if segment_type_hash.key?(type)
+        raise "Segment type #{type.inspect} already exists!"
+      end
 
-    segments = contents.split("\n-----")
+      segment_type_hash[type] = handler
+    end
 
-    if segments[0].start_with?("---/n") || segments[0] == "---"
-      # We have YAML front matter at the start.
-      # Eventually this will specify what different code segments do.
-      _front_matter = YAML.load segments[0]
-      if segments.size == 1
+    # Return an Array of segment type labels, such as "code" and "app_test".
+    #
+    # @return Array<String> the segment type labels
+    def segment_types
+      segment_type_hash.keys
+    end
+
+    # Load a .sca file with an optional YAML frontmatter prefix and
+    # multiple file sections which can be treated differently.
+    #
+    # The file loader acts like a proc, being called with .call()
+    # and returning true or false for whether it has handled the
+    # file load. This allows chaining loaders in order and the
+    # first loader to recognise a file will run it.
+    #
+    # @param path [String] the file or directory to treat as a Scarpe app
+    # @return [Boolean] return true if the file is loaded as a segmented Scarpe app file
+    def call(path)
+      return false unless path.end_with?(".scas")
+
+      file_load(path)
+      true
+    end
+
+    private
+
+    def gen_name(segmap)
+      ctr = (1..10_000).detect { |i| !segmap.key?("%5d" % i) }
+      "%5d" % ctr
+    end
+
+    def tokenize_segments(contents)
+      require "yaml" # Only load when needed
+      require "English"
+
+      segments = contents.split(/\n-{5,}/)
+      front_matter = {}
+
+      # The very first segment can start with front matter, or with a divider, or with no divider.
+      if segments[0].start_with?("---\n") || segments[0] == "---"
+        # We have YAML front matter at the start. All later segments will have a divider.
+        front_matter = YAML.load segments[0]
+        front_matter ||= {} # If the front matter is just the three dashes it returns nil
+        segments = segments[1..-1]
+      elsif segments[0].start_with?("-----")
+        # We have a divider at the start. Great! We're already well set up for this case.
+      elsif segments.size == 1
+        # No front matter, no divider, a single unnamed segment. No more parsing needed.
+        return [{}, { "" => segments[0] }]
+      else
+        # No front matter, no divider before the first segment, multiple segments.
+        # We'll add an artificial divider to the first segment for uniformity.
+        segments = ["-----\n" + segments[0]] + segments[1..-1]
+      end
+
+      segmap = {}
+      segments.each do |segment|
+        if segment =~ /\A-* +(.*?)\n/
+          # named segment with separator
+          segmap[::Regexp.last_match(1)] = ::Regexp.last_match.post_match
+        elsif segment =~ /\A-* *\n/
+          # unnamed segment with separator
+          segmap[gen_name(segmap)] = ::Regexp.last_match.post_match
+        else
+          raise "Internal error when parsing segments in segmented app file! seg: #{segment.inspect}"
+        end
+      end
+
+      [front_matter, segmap]
+    end
+
+    def file_load(path)
+      contents = File.read(path)
+
+      front_matter, segmap = tokenize_segments(contents)
+
+      if segmap.empty?
         raise "Illegal segmented Scarpe file: must have at least one code segment, not just front matter!"
       end
 
-      segments = segments[1..-1]
-    elsif segments.size == 1
-      # Simplest segmented file there is: no front matter, no segments
-      # @todo: indicate to Scarpe in some way that this is a Scarpe-specific
-      #     file and extensions should be turned on?
-      return load path
-    end
+      # Match up front_matter[:segments] with the segments, or use the default of shoes and app_test.
 
-    # Beyond this point, our segmented file has at least one code segment with a five-plus-dashes divider
-    segmap = {}
-    segments.each do |segment|
-      if segment =~ /\A-*\s+(.*?)\n/
-        # named segment
-        segment = ::Regexp.last_match.post_match
-        segmap[::Regexp.last_match(1)] = segment
-      elsif segment[0] == "-"
-        # unnamed segment
-        segment =~ /\A-*/ || raise("Internal error! This regexp should always match!")
-        segment = ::Regexp.last_match.post_match
-        ctr = (1..10_000).detect { |i| !segmap.key?("%5d" % i) }
-        gen_name = "%5d" % ctr
+      if front_matter[:segments]
+        if front_matter[:segments].size != segmap.size
+          raise "Number of front matter :segments must equal number of file segments!"
+        end
 
-        segmap[gen_name] = segment
+        sth = segment_type_hash
+        sv = segmap.values
+        front_matter[:segments].each.with_index do |seg_name, idx|
+          unless sth.key?(seg_name)
+            raise "Unrecognized segment type #{seg_name.inspect}! No matching segment type available!"
+          end
+
+          # Match the segment-type loader with the segment contents
+          with_tempfile("scarpe_segment_contents", sv[idx]) do |segment_contents_path|
+            sth[seg_name].call(segment_contents_path)
+          end
+        end
+      elsif segmap.size == 1
+        # If there's only one segment, load it as Shoes code
+        eval segmap.values[0]
+      elsif segmap.size == 2
+        # If there are two segments, the first is Shoes code and the second is APP_TEST_CODE
+        # TODO: write a better loader for app_test code that doesn't set an env var and generally
+        #    break ordering.
+        segs = segmap.values
+        with_tempfile("scarpe_seg_test_code", segs[1]) do |tf|
+          # This will get picked up when Scarpe.app() runs. It will execute in the Scarpe::App.
+          # Note that unlike app_test_code in test_helper this does *not* load CatsCradle or
+          # set it up for testing.
+          ENV["SCARPE_APP_TEST"] = tf
+          eval segs[0]
+        end
       else
-        raise "Internal error when parsing segments in segmented app file!"
+        raise "Segmented files with more than two segments have to specify what they're for!"
       end
     end
 
-    if segmap.size == 1
-      # If there's only one segment, load it as Shoes code
-      eval segmap.values[0]
-    elsif segmap.size == 2
-      # If there are two segments, the first is Shoes code and the second is APP_TEST_CODE
-      segs = segmap.values
-      with_tempfile("scarpe_seg_test_code", segs[1]) do |tf|
-        # This will get picked up when Scarpe.app() runs. It will execute in the Scarpe::App.
-        # Note that unlike app_test_code in test_helper this does *not* load CatsCradle or
-        # set it up for testing.
-        ENV["SCARPE_APP_TEST"] = tf
-        eval segs[0]
-      end
-    else
-      # Later there will be more interesting customisable options for what to do with
-      # different segments. For now, bail.
-      raise "More complex segmentation files are not yet implemented!"
+    # The hash of segment type labels mapped to handlers which will be called.
+    # Normal client code shouldn't ever call this.
+    #
+    # @return Hash<String, Object> the name/handler pairs
+    def segment_type_hash
+      @segment_handlers ||= {
+        "shoes" => proc { |seg_file| load seg_file },
+        "app_test" => proc { |seg_file| ENV["SCARPE_APP_TEST"] = seg_file },
+      }
     end
-  end
-
-  # Can we share this with unit test helpers?
-  def self.with_tempfile(prefix, contents, dir: Dir.tmpdir)
-    t = Tempfile.new(prefix, dir)
-    t.write(contents)
-    t.flush # Make sure the contents are written out
-
-    yield(t.path)
-  ensure
-    t.close
-    t.unlink
-  end
-
-  # Load a .sca file with an optional YAML frontmatter prefix and
-  # multiple file sections which can be treated differently.
-  SEGMENTED_FILE_LOADER = lambda do |path|
-    if path.end_with?(".scas")
-      Scarpe::Components.segmented_file_load(path)
-      return true
-    end
-    false
   end
 end
 
-# Shoes.add_file_loader Scarpe::Components::SEGMENTED_FILE_LOADER
+# You can add additional segment types to the segmented file loader
+# loader = Scarpe::Components::SegmentedFileLoader.new
+# loader.add_segment_type "capybara", proc { |seg_file| load_file_as_capybara(seg_file) }
+# Shoes.add_file_loader loader

--- a/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
@@ -4,6 +4,8 @@ require "tempfile"
 require "json"
 require "fileutils"
 
+require "scarpe/components/file_helpers"
+
 module Scarpe::Test; end
 
 # We want test failures set up once *total*, not per Minitest::Test. So an instance var
@@ -14,64 +16,10 @@ ALREADY_SET_UP_LOGGED_TEST_FAILURES = { setup: false }
 # Helpers here should *not* use Webview-specific functionality.
 # The intention is that these are helpers for various Scarpe display
 # services that do *not* necessarily use Webview.
+
 module Scarpe::Test::Helpers
-  # Create a temporary file with the given prefix and contents.
-  # Execute the block of code with it in place. Make sure
-  # it gets cleaned up afterward.
-  #
-  # @param prefix [String] the prefix passed to Tempfile to identify this file on disk
-  # @param contents [String] the file contents that should be written to Tempfile
-  # @param dir [String] the directory to create the tempfile in
-  # @yield The code to execute with the tempfile present
-  # @yieldparam the path of the new tempfile
-  def with_tempfile(prefix, contents, dir: Dir.tmpdir)
-    t = Tempfile.new(prefix, dir)
-    t.write(contents)
-    t.flush # Make sure the contents are written out
-
-    yield(t.path)
-  ensure
-    t.close
-    t.unlink
-  end
-
-  # Create multiple tempfiles, with given contents, in given
-  # directories, and execute the block in that context.
-  # When the block is finished, make sure all tempfiles are
-  # deleted.
-  #
-  # Pass an array of arrays, where each array is of the form:
-  # [prefix, contents, (optional)dir]
-  #
-  # I don't love inlining with_tempfile's contents into here.
-  # But calling it iteratively or recursively was difficult
-  # when I tried it the obvious ways.
-  #
-  # This method should be equivalent to calling with_tempfile
-  # once for each entry in the array, in a set of nested
-  # blocks.
-  #
-  # @param tf_specs [Array<Array>] The array of tempfile prefixes, contents and directories
-  # @yield The code to execute with those tempfiles present
-  # @yieldparam An array of paths to tempfiles, in the same order as tf_specs
-  def with_tempfiles(tf_specs, &block)
-    tempfiles = []
-    tf_specs.each do |prefix, contents, dir|
-      dir ||= Dir.tmpdir
-      t = Tempfile.new(prefix, dir)
-      tempfiles << t
-      t.write(contents)
-      t.flush # Make sure the contents are written out
-    end
-
-    args = tempfiles.map(&:path)
-    yield(args)
-  ensure
-    tempfiles.each do |t|
-      t.close
-      t.unlink
-    end
-  end
+  # Very useful for tests
+  include Scarpe::Components::FileHelpers
 
   # Temporarily set env vars for the block of code inside. The old environment
   # variable values will be restored after the block finishes.

--- a/scarpe-components/test/test_helper.rb
+++ b/scarpe-components/test/test_helper.rb
@@ -10,7 +10,14 @@ require "minitest/reporters"
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 # For tests, default to simple print logger
+# TODO: switch to modular logger and failure-logged tests?
 require "shoes/log"
 require "scarpe/components/print_logger"
 Shoes::Log.instance = Scarpe::Components::PrintLogImpl.new
 Shoes::Log.configure_logger(Shoes::Log::DEFAULT_LOG_CONFIG)
+
+require "scarpe/components/unit_test_helpers"
+
+class Minitest::Test
+  include Scarpe::Test::Helpers
+end

--- a/scarpe-components/test/test_helper.rb
+++ b/scarpe-components/test/test_helper.rb
@@ -11,6 +11,6 @@ Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 # For tests, default to simple print logger
 require "shoes/log"
-require "scarpe/print_logger"
-Shoes::Log.instance = Scarpe::PrintLogImpl.new
+require "scarpe/components/print_logger"
+Shoes::Log.instance = Scarpe::Components::PrintLogImpl.new
 Shoes::Log.configure_logger(Shoes::Log::DEFAULT_LOG_CONFIG)

--- a/scarpe-components/test/test_promises.rb
+++ b/scarpe-components/test/test_promises.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-require "scarpe/promises"
+require "scarpe/components/promises"
 
 class TestPromises < Minitest::Test
   Promise = Scarpe::Promise

--- a/scarpe-components/test/test_segmented_app_files.rb
+++ b/scarpe-components/test/test_segmented_app_files.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "scarpe/components/segmented_file_loader"
+
+SEG_TEST_DATA = {}
+
+class TestSegmentedAppFiles < Minitest::Test
+  def setup
+    @orig_file_loaders = Shoes.file_loaders
+    Shoes.reset_file_loaders # create new loaders array with no overlap with @orig_file_loaders
+    SEG_TEST_DATA.clear
+
+    @loader = Scarpe::Components::SegmentedFileLoader.new
+    Shoes.add_file_loader @loader
+  end
+
+  def teardown
+    Shoes.set_file_loaders(@orig_file_loaders)
+  end
+
+  def test_add_segment_type
+    @loader.add_segment_type("new_seg_type", proc { true })
+  end
+
+  def test_default_single_segment_with_front_matter
+    app = <<~SEG_TEST_FILE
+      ---
+      front_matter: yes
+      ----- app code
+      SEG_TEST_DATA[:app_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_default_single_segment_no_front_matter_with_initial_name
+    app = <<~SEG_TEST_FILE
+      ----- app code
+      SEG_TEST_DATA[:app_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_default_single_segment_no_front_matter_no_initial_name
+    app = <<~SEG_TEST_FILE
+      SEG_TEST_DATA[:app_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_default_double_segment_with_front_matter
+    app = <<~SEG_TEST_FILE
+      ---
+      front_matter: yes
+      ----- app code
+      SEG_TEST_DATA[:app_ran] = true
+      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      ----- test code
+      SEG_TEST_DATA[:test_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true, test_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_empty_front_matter
+    app = <<~SEG_TEST_FILE
+      ---
+      ----- app code
+      SEG_TEST_DATA[:app_ran] = true
+      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      ----- test code
+      SEG_TEST_DATA[:test_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true, test_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_default_double_segment_no_front_matter_with_initial_name
+    app = <<~SEG_TEST_FILE
+      ----- app code
+      SEG_TEST_DATA[:app_ran] = true
+      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      ----- test code
+      SEG_TEST_DATA[:test_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true, test_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_unnamed_double_segments
+    app = <<~SEG_TEST_FILE
+      -----
+      SEG_TEST_DATA[:app_ran] = true
+      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      -----
+      SEG_TEST_DATA[:test_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true, test_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_default_double_segment_no_front_matter_no_initial_name
+    app = <<~SEG_TEST_FILE
+      SEG_TEST_DATA[:app_ran] = true
+      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      ----- test code
+      SEG_TEST_DATA[:test_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true, test_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_extra_dashes_in_dividers
+    app = <<~SEG_TEST_FILE
+      ---
+        front_matter: yes
+      ---------------- app code
+      SEG_TEST_DATA[:app_ran] = true
+      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      ------- test code
+      SEG_TEST_DATA[:test_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ app_ran: true, test_ran: true }, SEG_TEST_DATA)
+  end
+
+  def test_custom_segment_types
+    # "shoes" type already exists and evaluates the code, don't need to add it
+    @loader.add_segment_type("capybara", proc { |path| load path })
+    @loader.add_segment_type("extra_data", proc { |path| load path })
+
+    app = <<~SEG_TEST_FILE
+      ---
+      :segments:
+      - shoes
+      - capybara
+      - extra_data
+      -----
+      SEG_TEST_DATA[:shoes_ran] = true
+      -----
+      SEG_TEST_DATA[:capy_ran] = true
+      -----
+      SEG_TEST_DATA[:extra_data_ran] = true
+    SEG_TEST_FILE
+    with_tempfile(["segfile_test_app", ".scas"], app) do |app_file|
+      Shoes.run_app(app_file)
+    end
+
+    assert_equal({ shoes_ran: true, capy_ran: true, extra_data_ran: true }, SEG_TEST_DATA)
+  end
+end

--- a/test/test_catscradle.rb
+++ b/test/test_catscradle.rb
@@ -18,6 +18,26 @@ class TestCatsCradle < LoggedScarpeTest
     TEST_CODE
   end
 
+  def test_catscradle_segmented_app
+    run_test_scarpe_code(<<~'SCARPE_APP', test_extension: ".scas")
+      ---
+      ----- app_code
+        Shoes.app do
+          button "clicky"
+        end
+      ----- test code
+        require "scarpe/cats_cradle"
+        self.class.include Scarpe::Test::CatsCradle
+        event_init
+
+        on_heartbeat do
+          assert_include button().text, "clicky"
+
+          test_finished
+        end
+    SCARPE_APP
+  end
+
   def test_global_para
     run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
       Shoes.app do
@@ -139,5 +159,3 @@ class TestCatsCradle < LoggedScarpeTest
     TEST_CODE
   end
 end
-
-# How to get this to work with relay-display?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,10 +29,11 @@ class ScarpeWebviewTest < Minitest::Test
 
   def run_test_scarpe_code(
     scarpe_app_code,
+    test_extension: ".rb",
     **opts
   )
 
-    with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
+    with_tempfile(["scarpe_test_app", test_extension], scarpe_app_code) do |test_app_location|
       run_test_scarpe_app(test_app_location, **opts)
     end
   end


### PR DESCRIPTION
### Description

Two changes here. One, I extracted a lot of the interesting functionality in exe/scarpe into a scarpe_cli.rb file in Lacci. We can keep this pattern up for anything else that wants to be abstracted across multiple display libraries, but it doesn't actually need a command in Lacci. Probably better.

The other, as I've been saying for awhile, is that we want a way to start packaging multiple different chunks of code (in this case app and test) into a single combined Scarpe-specific app file. This is the simple version: add YAML front matter, divide chunks with a line containing at least 5 dashes. But we now have a really obvious way to add more test langs (identify which test lang in the front matter) and a really simple default (just eval the test code inside the Shoes::App object) that is still enough to package tests with the app if we want.

Eventually this should open up interesting options like a properly hosted-in-child reported-in-parent version of Minitest, which would be cleaner than the current jury-rigged assertion and reporting systems we use for most Scarpe Webview tests.

### Image(if needed, helps for a faster review)

```
      ---
      a: 1
      b: 2
      ----- app code
        Shoes.app do
          button "clicky"
        end
      ----- test code
        require "scarpe/cats_cradle"
        self.class.include Scarpe::Test::CatsCradle
        event_init

        on_heartbeat do
          assert_include button().text, "clicky"

          test_finished
        end
```

### Checklist

- [X] Run tests locally
- [X] Run linter(check for linter errors)
