### PR TITLE
Actually run Lacci and Scarpe-Components tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Run tests
+      - name: Run Lacci tests
+        run: CI_RUN='true' bundle exec rake lacci_test
+      - name: Run Scarpe-Component tests
+        run: CI_RUN='true' bundle exec rake component_test
+      - name: Run Scarpe tests
         run: CI_RUN='true' bundle exec rake test
       - name: upload test-fail logs
         if: '!cancelled()'

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,12 @@ Rake::TestTask.new(:lacci_test) do |t|
   t.test_files = FileList["lacci/test/**/test_*.rb"]
 end
 
+Rake::TestTask.new(:component_test) do |t|
+  t.libs << "scarpe-components/test"
+  t.libs << "scarpe-components/lib"
+  t.test_files = FileList["scarpe-components/test/**/test_*.rb"]
+end
+
 RuboCop::RakeTask.new
 
-task default: [:test, :lacci_test, :rubocop]
+task default: [:test, :lacci_test, :component_test, :rubocop]

--- a/scarpe-components/lib/scarpe/components/modular_logger.rb
+++ b/scarpe-components/lib/scarpe/components/modular_logger.rb
@@ -109,5 +109,5 @@ class Scarpe
   end
 end
 
-#Shoes::Log.instance = Scarpe::PrintLogImpl.new
+#Shoes::Log.instance = Scarpe::Components::ModularLogImpl.new
 #Shoes::Log.configure_logger(Shoes::Log::DEFAULT_LOG_CONFIG)

--- a/scarpe-components/test/test_helper.rb
+++ b/scarpe-components/test/test_helper.rb
@@ -11,6 +11,6 @@ Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 # For tests, default to simple print logger
 require "shoes/log"
-require "scarpe/print_logger"
-Shoes::Log.instance = Scarpe::PrintLogImpl.new
+require "scarpe/components/print_logger"
+Shoes::Log.instance = Scarpe::Components::PrintLogImpl.new
 Shoes::Log.configure_logger(Shoes::Log::DEFAULT_LOG_CONFIG)

--- a/scarpe-components/test/test_promises.rb
+++ b/scarpe-components/test/test_promises.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-require "scarpe/promises"
+require "scarpe/components/promises"
 
 class TestPromises < Minitest::Test
   Promise = Scarpe::Promise


### PR DESCRIPTION
### Description

We weren't running Scarpe-Components and Lacci tests in CI. Not that there's a lot there yet, but we should run them.

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
