### PR TITLE
Add x86_64-linux to Gemfile.lock so it works for our docs build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bloops (~> 0.5)


### PR DESCRIPTION
### Description

Simple one-line change to Gemfile.lock. Should fix the broken docs build, I believe.

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
