### PR TITLE
Small Scarpe CLI fixes

### DIFF
--- a/exe/scarpe
+++ b/exe/scarpe
@@ -76,7 +76,7 @@ when "-v"
   puts "Lacci #{Lacci::VERSION}"
 when "run"
   # Run the Scarpe app file
-  Shoes.run_app ARGV[0]
+  Shoes.run_app verb_target
 when "env"
   print_env
 else

--- a/lacci/lib/lacci/scarpe_cli.rb
+++ b/lacci/lib/lacci/scarpe_cli.rb
@@ -23,6 +23,7 @@ class Scarpe
     end
 
     def default_env_categories
+      require "shoes"
       {
         "Lacci" => [
           env_or_default("SCARPE_DISPLAY_SERVICE", "(none)"),


### PR DESCRIPTION
### Description

"exe/scarpe run" was broken since we weren't properly using the target var.

Useful to require Shoes, but only do so *inside* the method that uses the Shoes log constant for default logger config.

### Checklist

- [ ] Run tests locally
- [x] Run linter(check for linter errors)
