### PR TITLE
Make sure file_helpers can be required without requiring other Scarpe components

### DIFF
--- a/scarpe-components/lib/scarpe/components/file_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/file_helpers.rb
@@ -4,6 +4,7 @@ require "tempfile"
 
 # These can be used for unit tests, but also more generally.
 
+module Scarpe::Components; end
 module Scarpe::Components::FileHelpers
   # Create a temporary file with the given prefix and contents.
   # Execute the block of code with it in place. Make sure


### PR DESCRIPTION
### Description

This is just declaring the relevant module in case it doesn't already exist. Scarpe-components is meant to be require-able piecemeal.

### Checklist

- [x] Run tests locally
- [x] Run linter(check for linter errors)
