### PR TITLE
Make it easier to load segmented .scas files without immediately running the app and/or tests

### DIFF
--- a/scarpe-components/lib/scarpe/components/file_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/file_helpers.rb
@@ -4,7 +4,7 @@ require "tempfile"
 
 # These can be used for unit tests, but also more generally.
 
-module Scarpe::Components; end
+class Scarpe; module Components; end; end
 module Scarpe::Components::FileHelpers
   # Create a temporary file with the given prefix and contents.
   # Execute the block of code with it in place. Make sure


### PR DESCRIPTION
### Description

For some of the Shoes-spec stuff I'm prototyping, it's useful to load a segmented Scarpe app file but not immediately run it. This makes that easier. It also allows overriding the default behaviour of the first two segments of the app file.

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
