### PR TITLE
Collect Rubocop violations for 60 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     name: Tests
     runs-on: macos-latest
-    timeout-minutes: 10 
+    timeout-minutes: 10
     steps:
       - name: Install dependencies
         run: brew install pkg-config portaudio
@@ -34,18 +34,18 @@ jobs:
         with:
           name: test failure logs
           path: logger/test_failure*.out.log
-  linter:
-    name: Linter
-    runs-on: macos-latest
-    timeout-minutes: 10 
-    steps:
-      - name: Install dependencies
-        run: brew install pkg-config portaudio
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: Run linter
-        run: bundle exec rubocop
+  # linter:
+  #   name: Linter
+  #   runs-on: macos-latest
+  #   timeout-minutes: 10
+  #   steps:
+  #     - name: Install dependencies
+  #       run: brew install pkg-config portaudio
+  #     - name: Checkout code
+  #       uses: actions/checkout@v3
+  #     - name: Setup Ruby and install gems
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         bundler-cache: true
+  #     - name: Run linter
+  #       run: bundle exec rubocop


### PR DESCRIPTION
Being a non-production, non-commercial and community-based project, we are allowed to do some unorthodox things.

I am interested in what Rubocop cops are introducing silent friction for our engineers. I am disabling the Rubocop CI check for 60 days.

After this, I will review what violations we have. Following that, I will either commit an AllowList of what cops I find valuable, or use that emitted data to selectively disable a larger cross-section.

I will also talk with the team about my findings.

My editor will *still* use our rubocop to autoformat code I touch. So, in this time if I touch failing code it will autocorrect it which is fine.

I was tempted to introduce a time-bomb here. But I won't do that.

<!--
👋 Hi, thanks for sending a PR to Scarpe! 💖
-->

### Description

<!-- Please write a summary of the change, Please also include relevant motivation and context: -->

### Image(if needed, helps for a faster review)

<!-- Add image of the feature u added here -->

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
<!--
for Linter

bundle exec rubocop

this would autocorrect offenses if they are autocorrectable.
bundle exec rubocop . --autocorrect-all

-->
