### PR TITLE
Use error classes for Lacci and Scarpe-Components

### DIFF
--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -14,6 +14,7 @@ end
 
 module Shoes; end
 class Shoes::Error < StandardError; end
+require_relative "shoes/errors"
 
 require_relative "shoes/constants"
 

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -25,7 +25,7 @@ module Shoes
 
       if Shoes::App.instance
         @log.error("Trying to create a second Shoes::App in the same process! Fail!")
-        raise "Cannot create multiple Shoes::App objects!"
+        raise Scarpe::TooManyInstancesError, "Cannot create multiple Shoes::App objects!"
       else
         Shoes::App.instance = self
       end
@@ -70,7 +70,7 @@ module Shoes
       end
 
       @watch_for_event_loop = bind_shoes_event(event_name: "custom_event_loop") do |loop_type|
-        raise("Unknown event loop type: #{loop_type.inspect}!") unless CUSTOM_EVENT_LOOP_TYPES.include?(loop_type)
+        raise(InvalidAttributeValueError, "Unknown event loop type: #{loop_type.inspect}!") unless CUSTOM_EVENT_LOOP_TYPES.include?(loop_type)
 
         @event_loop_type = loop_type
       end
@@ -144,7 +144,7 @@ module Shoes
         # We can just return to the main event loop. But we shouldn't call destroy.
         # Presumably some event loop *outside* our event loop is handling things.
       else
-        raise "Internal error! Incorrect event loop type: #{@event_loop_type.inspect}!"
+        raise InvalidAttributeValueError, "Internal error! Incorrect event loop type: #{@event_loop_type.inspect}!"
       end
     end
 
@@ -181,18 +181,18 @@ module Shoes
               global_value = eval s
               widgets &= [global_value]
             rescue
-              raise "Error getting global variable: #{spec.inspect}"
+              raise InvalidAttributeValueError, "Error getting global variable: #{spec.inspect}"
             end
           when "@"
             if Shoes::App.instance.instance_variables.include?(spec.to_sym)
               widgets &= [self.instance_variable_get(spec)]
             else
-              raise "Can't find top-level instance variable: #{spec.inspect}!"
+              raise InvalidAttributeValueError, "Can't find top-level instance variable: #{spec.inspect}!"
             end
           else
           end
         else
-          raise("Don't know how to find widgets by #{spec.inspect}!")
+          raise(InvalidAttributeValueError, "Don't know how to find widgets by #{spec.inspect}!")
         end
       end
       widgets
@@ -243,7 +243,7 @@ class Shoes::App
   # Shape DSL methods
 
   def move_to(x, y)
-    raise("Pass only Numeric arguments to move_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
+    raise(InvalidAttributeValueError, "Pass only Numeric arguments to move_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
 
     if current_slot.is_a?(::Shoes::Shape)
       current_slot.add_shape_command(["move_to", x, y])
@@ -251,7 +251,7 @@ class Shoes::App
   end
 
   def line_to(x, y)
-    raise("Pass only Numeric arguments to line_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
+    raise(InvalidAttributeValueError, "Pass only Numeric arguments to line_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
 
     if current_slot.is_a?(::Shoes::Shape)
       current_slot.add_shape_command(["line_to", x, y])

--- a/lacci/lib/shoes/errors.rb
+++ b/lacci/lib/shoes/errors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Shoes
+  class InvalidAttributeValueError < Shoes::Error; end
+
+  class TooManyInstancesError < Shoes::Error; end
+end

--- a/lacci/lib/shoes/log.rb
+++ b/lacci/lib/shoes/log.rb
@@ -28,7 +28,7 @@ module Shoes
       attr_reader :current_log_config
 
       def instance=(impl_object)
-        raise(Shoes::Error, "Already have an instance for Shoes::Log!") if @instance
+        raise(Shoes::TooManyInstancesError, "Already have an instance for Shoes::Log!") if @instance
 
         @instance = impl_object
       end

--- a/lacci/lib/shoes/widgets/arc.rb
+++ b/lacci/lib/shoes/widgets/arc.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module Shoes
-  class InvalidAttributeValueError < Shoes::Error; end
-
   class Arc < Shoes::Widget
     display_properties :left, :top, :width, :height, :angle1, :angle2, :draw_context
 

--- a/lacci/lib/shoes/widgets/slot.rb
+++ b/lacci/lib/shoes/widgets/slot.rb
@@ -67,8 +67,8 @@ class Shoes::Slot < Shoes::Widget
   # @yield the block to call to replace children; will be called on the Shoes::App, appending to the called Slot as the current slot
   # @return [void]
   def append(&block)
-    raise("append requires a block!") unless block_given?
-    raise("Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
+    raise(InvalidAttributeValueError, "append requires a block!") unless block_given?
+    raise(InvalidAttributeValueError, "Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
 
     Shoes::App.instance.with_slot(self, &block)
   end

--- a/scarpe-components/lib/scarpe/components/errors.rb
+++ b/scarpe-components/lib/scarpe/components/errors.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Scarpe
+  class InternalError < Scarpe::Error; end
+
+  class FileContentError < Scarpe::Error; end
+
+  class NoOperationError < Scarpe::Error; end
+
+  class DuplicateFileError < Scarpe::Error; end
+
+  class NoSuchFile < Scarpe::Error; end
+
+  class MustOverrideMethod < Scarpe::Error; end
+
+  class InvalidHTMLTag < Scarpe::Error; end
+end

--- a/scarpe-components/lib/scarpe/components/html.rb
+++ b/scarpe-components/lib/scarpe/components/html.rb
@@ -37,7 +37,7 @@ class Scarpe::Components::HTML
 
   def tag(name, **attrs, &block)
     if VOID_TAGS.include?(name)
-      raise ArgumentError, "void tag #{name} cannot have content" if block_given?
+      raise Shoes::InvalidAttributeValueError, "void tag #{name} cannot have content" if block_given?
 
       @buffer += "<#{name}#{render_attributes(attrs)} />"
     else
@@ -62,10 +62,10 @@ class Scarpe::Components::HTML
   end
 
   def method_missing(name, *args, &block)
-    raise NoMethodError, "no method #{name} for #{self.class.name}" unless TAGS.include?(name)
+    raise Scarpe::InvalidHTMLTag, "no method #{name} for #{self.class.name}" unless TAGS.include?(name)
 
     if VOID_TAGS.include?(name)
-      raise ArgumentError, "void tag #{name} cannot have content" if block_given?
+      raise Shoes::InvalidAttributeValueError, "void tag #{name} cannot have content" if block_given?
 
       @buffer += "<#{name}#{render_attributes(*args)} />"
     else

--- a/scarpe-components/lib/scarpe/components/modular_logger.rb
+++ b/scarpe-components/lib/scarpe/components/modular_logger.rb
@@ -32,7 +32,7 @@ class Scarpe
       when "fatal"
         :fatal
       else
-        raise "Don't know how to treat #{data.inspect} as a logger severity!"
+        raise Shoes::InvalidAttributeValueError, "Don't know how to treat #{data.inspect} as a logger severity!"
       end
     end
 
@@ -45,7 +45,7 @@ class Scarpe
       when String
         Logging.appenders.file data, layout: @custom_log_layout
       else
-        raise "Don't know how to convert #{data.inspect} to an appender!"
+        raise Shoes::InvalidAttributeValueError, "Don't know how to convert #{data.inspect} to an appender!"
       end
     end
 
@@ -64,7 +64,7 @@ class Scarpe
 
         logger.level = name_to_severity(level)
       else
-        raise "Don't know how to use #{data.inspect} to specify a logger!"
+        raise Shoes::InvalidAttributeValueError, "Don't know how to use #{data.inspect} to specify a logger!"
       end
     end
 

--- a/scarpe-components/lib/scarpe/components/promises.rb
+++ b/scarpe-components/lib/scarpe/components/promises.rb
@@ -198,7 +198,7 @@ class Scarpe
       case @state
       when :fulfilled
         # Should this be a no-op instead?
-        raise "Registering an executor on an already fulfilled promise means it will never run!"
+        raise Scarpe::NoOperationError, "Registering an executor on an already fulfilled promise means it will never run!"
       when :rejected
         return
       when :unscheduled
@@ -207,7 +207,7 @@ class Scarpe
         @executor = block
         call_executor
       else
-        raise "Internal error, illegal state!"
+        raise Scarpe::InternalError, "Internal error, illegal state!"
       end
 
       self
@@ -222,16 +222,16 @@ class Scarpe
 
       # First, filter out illegal input
       unless PROMISE_STATES.include?(old_state)
-        raise "Internal Promise error! Internal state was #{old_state.inspect}! Legal states: #{PROMISE_STATES.inspect}"
+        raise Scarpe::InternalError, "Internal Promise error! Internal state was #{old_state.inspect}! Legal states: #{PROMISE_STATES.inspect}"
       end
 
       unless PROMISE_STATES.include?(new_state)
-        raise "Internal Promise error! Internal state was set to #{new_state.inspect}! " +
+        raise Scarpe::InternalError, "Internal Promise error! Internal state was set to #{new_state.inspect}! " +
           "Legal states: #{PROMISE_STATES.inspect}"
       end
 
       if new_state != :fulfilled && new_state != :rejected && !value_or_reason.nil?
-        raise "Internal promise error! Non-completed state transitions should not specify a value or reason!"
+        raise Scarpe::InternalError, "Internal promise error! Non-completed state transitions should not specify a value or reason!"
       end
 
       # Here's our state-transition grid for what we're doing here.
@@ -254,11 +254,11 @@ class Scarpe
 
       # Transitioning to any *different* state after being fulfilled or rejected? Nope. Those states are final.
       if complete?
-        raise "Internal Promise error! Trying to change state from #{old_state.inspect} to #{new_state.inspect}!"
+        raise Scarpe::InternalError, "Internal Promise error! Trying to change state from #{old_state.inspect} to #{new_state.inspect}!"
       end
 
       if old_state == :pending && new_state == :unscheduled
-        raise "Can't change state from :pending to :unscheduled! Scheduling is not reversible!"
+        raise Shoes::InvalidAttributeValueError, "Can't change state from :pending to :unscheduled! Scheduling is not reversible!"
       end
 
       # The next three checks should all be followed by calling handlers for the newly-changed state.
@@ -341,7 +341,7 @@ class Scarpe
         @on_scheduled.each { |h| h.call(*@parents.map(&:returned_value)) }
         @on_scheduled = []
       else
-        raise "Internal error! Trying to call handlers for #{state.inspect}!"
+        raise Scarpe::InternalError, "Internal error! Trying to call handlers for #{state.inspect}!"
       end
     end
 
@@ -367,7 +367,7 @@ class Scarpe
     end
 
     def call_executor
-      raise("Internal error! Should not call_executor with no executor!") unless @executor
+      raise(Scarpe::InternalError, "Internal error! Should not call_executor with no executor!") unless @executor
 
       begin
         result = @executor.call(*@parents.map(&:returned_value))
@@ -389,7 +389,7 @@ class Scarpe
     # @return [Scarpe::Promise] self
     def on_fulfilled(&handler)
       unless handler
-        raise "You must pass a block to on_fulfilled!"
+        raise Shoes::InvalidAttributeValueError, "You must pass a block to on_fulfilled!"
       end
 
       case @state
@@ -411,7 +411,7 @@ class Scarpe
     # @return [Scarpe::Promise] self
     def on_rejected(&handler)
       unless handler
-        raise "You must pass a block to on_rejected!"
+        raise Shoes::InvalidAttributeValueError, "You must pass a block to on_rejected!"
       end
 
       case @state
@@ -434,7 +434,7 @@ class Scarpe
     # @return [Scarpe::Promise] self
     def on_scheduled(&handler)
       unless handler
-        raise "You must pass a block to on_scheduled!"
+        raise Shoes::InvalidAttributeValueError, "You must pass a block to on_scheduled!"
       end
 
       # Add a pending handler or call it now

--- a/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
+++ b/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
@@ -14,7 +14,7 @@ module Scarpe::Components
     # @return <void>
     def add_segment_type(type, handler)
       if segment_type_hash.key?(type)
-        raise "Segment type #{type.inspect} already exists!"
+        raise Shoes::InvalidAttributeValueError, "Segment type #{type.inspect} already exists!"
       end
 
       segment_type_hash[type] = handler
@@ -95,7 +95,7 @@ module Scarpe::Components
           # unnamed segment with separator
           segmap[gen_name(segmap)] = ::Regexp.last_match.post_match
         else
-          raise "Internal error when parsing segments in segmented app file! seg: #{segment.inspect}"
+          raise Scarpe::InternalError, "Internal error when parsing segments in segmented app file! seg: #{segment.inspect}"
         end
       end
 
@@ -108,16 +108,16 @@ module Scarpe::Components
       front_matter, segmap = tokenize_segments(contents)
 
       if segmap.empty?
-        raise "Illegal segmented Scarpe file: must have at least one code segment, not just front matter!"
+        raise Scarpe::FileContentError, "Illegal segmented Scarpe file: must have at least one code segment, not just front matter!"
       end
 
       if front_matter[:segments]
         if front_matter[:segments].size != segmap.size
-          raise "Number of front matter :segments must equal number of file segments!"
+          raise Scarpe::FileContentError, "Number of front matter :segments must equal number of file segments!"
         end
       else
         if segmap.size > 2
-          raise "Segmented files with more than two segments have to specify what they're for!"
+          raise Scarpe::FileContentError, "Segmented files with more than two segments have to specify what they're for!"
         end
 
         # Set to default of shoes code only or shoes code and app test code.
@@ -132,7 +132,7 @@ module Scarpe::Components
       tf_specs = []
       front_matter[:segments].each.with_index do |seg_type, idx|
         unless sth.key?(seg_type)
-          raise "Unrecognized segment type #{seg_type.inspect}! No matching segment type available!"
+          raise Scarpe::FileContentError, "Unrecognized segment type #{seg_type.inspect}! No matching segment type available!"
         end
 
         tf_specs << ["scarpe_#{seg_type}_segment_contents", sv[idx]]

--- a/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
@@ -150,8 +150,8 @@ module Scarpe::Test::LoggedTest
     return if ALREADY_SET_UP_LOGGED_TEST_FAILURES[:setup]
 
     log_dir = self.class.logger_dir
-    raise("Must set logger directory!") unless log_dir
-    raise("Can't find logger directory!") unless File.directory?(log_dir)
+    raise(Scarpe::MustOverrideMethod, "Must set logger directory!") unless log_dir
+    raise(Scarpe::NoSuchFile, "Can't find logger directory!") unless File.directory?(log_dir)
 
     ALREADY_SET_UP_LOGGED_TEST_FAILURES[:setup] = true
     # Delete stale test failures, if any, before starting the first failure-logged test
@@ -181,11 +181,11 @@ module Scarpe::Test::LoggedTest
     out_loc = filepath.gsub(%r{.log\Z}, ".out.log")
 
     if out_loc == filepath
-      raise "Something is wrong! Could not figure out failure-log output path for #{filepath.inspect}!"
+      raise Shoes::InvalidAttributeValueError, "Something is wrong! Could not figure out failure-log output path for #{filepath.inspect}!"
     end
 
     if File.exist?(out_loc)
-      raise "Duplicate test file #{out_loc.inspect}? This file should *not* already exist!"
+      raise Scarpe::DuplicateFileError, "Duplicate test file #{out_loc.inspect}? This file should *not* already exist!"
     end
 
     out_loc

--- a/scarpe-components/test/test_html.rb
+++ b/scarpe-components/test/test_html.rb
@@ -58,7 +58,7 @@ class TestHTML < Minitest::Test
   end
 
   def test_raises_with_void_tag_blocks
-    assert_raises(ArgumentError, "void tag input cannot have content") do
+    assert_raises(Shoes::InvalidAttributeValueError, "void tag input cannot have content") do
       Scarpe::Components::HTML.render { |h| h.input(type: "text") { "foo" } }
     end
   end


### PR DESCRIPTION
### Description

We recently got a PR to use error classes, not just raw strings, for all of scarpe/lib/scarpe. However, it didn't cover Lacci or Scarpe-Components. This fixes that.

### Checklist

- [X] Run tests locally
