### PR TITLE
Add default per-widget styles to Lacci widgets, and a style() method

### DIFF
--- a/examples/button_style_changed.rb
+++ b/examples/button_style_changed.rb
@@ -1,0 +1,7 @@
+Shoes.app do
+  @p = para "This text will start red\n", stroke: :red
+  button "OK" do
+    @p.replace("... but turn green when you click it.")
+    @p.stroke = :green
+  end
+end

--- a/examples/button_styles_default.rb
+++ b/examples/button_styles_default.rb
@@ -1,0 +1,6 @@
+Shoes.app do
+  style Shoes::Para, stroke: :red
+  para "This text should be red\n"
+  para "But this text should be green\n", stroke: :green
+  button "OK"
+end

--- a/examples/legacy/not_checked/speedometer_app.rb
+++ b/examples/legacy/not_checked/speedometer_app.rb
@@ -1,0 +1,55 @@
+# Source: https://www.hanselman.com/blog/the-weekly-source-code-29-ruby-and-shoes-and-the-first-ruby-virus
+
+class Speedometer < Widget
+  attr_accessor :range, :tick, :position
+  def initialize opts = {}
+    @range = opts[:range] || 200
+    @tick = opts[:tick] || 10
+    @position = opts[:position] || 0
+    @cx, @cy = self.left + 110, self.top + 100
+ 
+    nostroke
+    rect :top => self.top, :left => self.left,
+      :width => 220, :height => 200
+    nofill
+    stroke white
+    oval :left => @cx - 50, :top => @cy - 50, :radius => 100
+    (ticks + 1).times do |i|
+      radial_line 225 + ((270.0 / ticks) * i), 70..80
+      radial_line 225 + ((270.0 / ticks) * i), 45..49
+    end
+    strokewidth 2
+    oval :left => @cx - 70, :top => @cy - 70, :radius => 140
+    stroke lightgreen
+    oval :left => @cx - 5, :top => @cy - 5, :radius => 10
+    @needle = radial_line 225 + ((270.0 / @range) * @position), 0..90
+  end
+  def ticks; @range / @tick end
+  def radial_line deg, r
+    pos = ((deg / 360.0) * (2.0 * Math::PI)) - (Math::PI / 2.0)
+    line (Math.cos(pos) * r.begin) + @cx, (Math.sin(pos) * r.begin) + @cy,
+      (Math.cos(pos) * r.end) + @cx, (Math.sin(pos) * r.end) + @cy
+  end
+  def position= pos
+    @position = pos
+    @needle.remove
+    append do
+      @needle = radial_line 225 + ((270.0 / @range) * @position), 0..90
+    end
+  end
+end
+ 
+Shoes.app do
+  stack do
+    para "Enter a number between 0 and 100"
+    flow do
+      @p = edit_line
+      button "OK" do
+        @s.position = @p.text.to_i
+      end
+    end
+ 
+    @s = speedometer :range => 100, :ticks => 10
+  end
+end
+

--- a/lacci/lib/shoes/colors.rb
+++ b/lacci/lib/shoes/colors.rb
@@ -2,6 +2,8 @@
 
 module Shoes
   module Colors
+    extend self
+
     COLORS = {
       aliceblue: [240, 248, 255],
       antiquewhite: [250, 235, 215],

--- a/lacci/lib/shoes/errors.rb
+++ b/lacci/lib/shoes/errors.rb
@@ -4,4 +4,8 @@ module Shoes
   class InvalidAttributeValueError < Shoes::Error; end
 
   class TooManyInstancesError < Shoes::Error; end
+
+  class NoSuchStyleError < Shoes::Error; end
+
+  class NoLinkableIdError < Shoes::Error; end
 end

--- a/lacci/lib/shoes/widgets/arc.rb
+++ b/lacci/lib/shoes/widgets/arc.rb
@@ -4,25 +4,24 @@ module Shoes
   class Arc < Shoes::Widget
     display_properties :left, :top, :width, :height, :angle1, :angle2, :draw_context
 
+    [:left, :top, :width, :height].each do |prop|
+      display_property(prop) { |val| convert_to_integer(val, prop) }
+    end
+
+    [:angle1, :angle2].each do |prop|
+      display_property(prop) { |val| convert_to_float(val, prop) }
+    end
+
     def initialize(*args)
-      @left, @top, @width, @height, @angle1, @angle2 = args
-
-      @left = convert_to_integer(@left, "left")
-      @top = convert_to_integer(@top, "top")
-      @width = convert_to_integer(@width, "width")
-      @height = convert_to_integer(@height, "height")
-      @angle1 = convert_to_float(@angle1, "angle1")
-      @angle2 = convert_to_float(@angle2, "angle2")
-
       @draw_context = Shoes::App.instance.current_draw_context
 
       super
+      self.left, self.top, self.width, self.height, self.angle1, self.angle2 = args
+
       create_display_widget
     end
 
-    private
-
-    def convert_to_integer(value, attribute_name)
+    def self.convert_to_integer(value, attribute_name)
       begin
         value = Integer(value)
         raise InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
@@ -34,7 +33,7 @@ module Shoes
       end
     end
 
-    def convert_to_float(value, attribute_name)
+    def self.convert_to_float(value, attribute_name)
       begin
         value = Float(value)
         raise InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0

--- a/lacci/lib/shoes/widgets/button.rb
+++ b/lacci/lib/shoes/widgets/button.rb
@@ -6,14 +6,12 @@ module Shoes
     display_properties :text, :width, :height, :top, :left, :color, :padding_top, :padding_bottom, :text_color, :size, :font_size
 
     def initialize(text, width: nil, height: nil, top: nil, left: nil, color: nil, padding_top: nil, padding_bottom: nil, size: 12, text_color: nil,
-      font_size: nil, & block)
+      font_size: nil, &block)
 
       log_init("Button")
 
       # Properties passed as positional args, not keywords, don't get auto-set
       @text = text
-      @color = color
-
       @block = block
 
       super

--- a/lacci/lib/shoes/widgets/edit_box.rb
+++ b/lacci/lib/shoes/widgets/edit_box.rb
@@ -5,10 +5,9 @@ module Shoes
     display_properties :text, :height, :width
 
     def initialize(text = "", height: nil, width: nil, &block)
+      super
       @text = text
       @callback = block
-
-      super
 
       bind_self_event("change") do |new_text|
         self.text = new_text

--- a/lacci/lib/shoes/widgets/edit_line.rb
+++ b/lacci/lib/shoes/widgets/edit_line.rb
@@ -5,10 +5,9 @@ module Shoes
     display_properties :text, :width
 
     def initialize(text = "", width: nil, &block)
+      super
       @block = block
       @text = text
-
-      super
 
       bind_self_event("change") do |new_text|
         self.text = new_text

--- a/lacci/lib/shoes/widgets/flow.rb
+++ b/lacci/lib/shoes/widgets/flow.rb
@@ -9,9 +9,8 @@ module Shoes
     display_properties :width, :height, :margin, :padding
 
     def initialize(width: "100%", height: nil, margin: nil, padding: nil, **options, &block)
-      @options = options
-
       super
+      @options = options
 
       # Create the display-side widget *before* instance_eval, which will add child widgets with their display widgets
       create_display_widget

--- a/lacci/lib/shoes/widgets/font.rb
+++ b/lacci/lib/shoes/widgets/font.rb
@@ -5,8 +5,8 @@ module Shoes
     display_properties :font
 
     def initialize(font)
-      @font = font
       super
+      @font = font
 
       create_display_widget
     end

--- a/lacci/lib/shoes/widgets/image.rb
+++ b/lacci/lib/shoes/widgets/image.rb
@@ -5,9 +5,8 @@ module Shoes
     display_properties :url, :width, :height, :top, :left, :click
 
     def initialize(url, width: nil, height: nil, top: nil, left: nil, click: nil)
-      @url = url
-
       super
+      @url = url
 
       # Get the image dimensions
       # @width, @height = size

--- a/lacci/lib/shoes/widgets/line.rb
+++ b/lacci/lib/shoes/widgets/line.rb
@@ -5,13 +5,14 @@ module Shoes
     display_properties :left, :top, :x2, :y2, :draw_context
 
     def initialize(left, top, x2, y2)
+      super
+
       @left = left
       @top = top
       @x2 = x2
       @y2 = y2
       @draw_context = Shoes::App.instance.current_draw_context
 
-      super
       create_display_widget
     end
   end

--- a/lacci/lib/shoes/widgets/link.rb
+++ b/lacci/lib/shoes/widgets/link.rb
@@ -5,12 +5,12 @@ module Shoes
     display_properties :text, :click, :has_block
 
     def initialize(text, click: nil, &block)
+      super
+
       @text = text
       @block = block
       # We can't send a block to the display widget, but we can send a boolean
       @has_block = !block.nil?
-
-      super
 
       # The click property should be changed before it gets sent to the display widget
       @click ||= "#"
@@ -20,6 +20,14 @@ module Shoes
       end
 
       create_display_widget
+    end
+  end
+
+  # In Shoes, the LinkHover pseudo-class is used to set default styles for links when
+  # hovered over. The functionality isn't present in Lacci yet.
+  class LinkHover < Link
+    def initialize
+      raise "This class should never be instantiated! Use link, not link_hover!"
     end
   end
 end

--- a/lacci/lib/shoes/widgets/list_box.rb
+++ b/lacci/lib/shoes/widgets/list_box.rb
@@ -5,9 +5,10 @@ module Shoes
     display_properties :selected_item, :items, :height, :width
 
     def initialize(args = {}, &block)
+      super
+
       @items = args[:items] || []
       @selected_item = args[:selected_item]
-      super()
 
       bind_self_event("change") do |new_item|
         self.selected_item = new_item

--- a/lacci/lib/shoes/widgets/para.rb
+++ b/lacci/lib/shoes/widgets/para.rb
@@ -2,9 +2,12 @@
 
 module Shoes
   class Para < Shoes::Widget
-    display_properties :text_items, :stroke, :size, :font, :html_attributes, :hidden
+    display_properties :text_items, :size, :font, :html_attributes, :hidden
+    display_property(:stroke) { |val| Shoes::Colors.to_rgb(val) }
 
     def initialize(*args, stroke: nil, size: :para, font: nil, hidden: false, **html_attributes)
+      super
+
       @text_children = args || []
       if hidden
         @hidden_text_items = text_children_to_items(@text_children)
@@ -15,11 +18,8 @@ module Shoes
         @text_items = text_children_to_items(@text_children)
         @hidden_text_items = []
       end
-      stroke = to_rgb(stroke)
 
       @html_attributes = html_attributes || {}
-
-      super
 
       create_display_widget
     end

--- a/lacci/lib/shoes/widgets/radio.rb
+++ b/lacci/lib/shoes/widgets/radio.rb
@@ -7,10 +7,10 @@ module Shoes
   class Radio < Shoes::Widget
     display_properties :group, :checked
 
-    def initialize(group = nil, checked = nil, &block)
+    def initialize(group = nil, checked: nil, &block)
+      super
       @group = group
       @block = block
-      super
 
       bind_self_event("click") { click }
       create_display_widget

--- a/lacci/lib/shoes/widgets/shape.rb
+++ b/lacci/lib/shoes/widgets/shape.rb
@@ -13,8 +13,6 @@ module Shoes
     display_properties :left, :top, :shape_commands, :draw_context
 
     def initialize(left: nil, top: nil, &block)
-      @left = left
-      @top = top
       @shape_commands = []
       @draw_context = Shoes::App.instance.current_draw_context
 

--- a/lacci/lib/shoes/widgets/span.rb
+++ b/lacci/lib/shoes/widgets/span.rb
@@ -5,13 +5,13 @@ module Shoes
     display_properties :text, :stroke, :size, :font, :html_attributes
 
     def initialize(text, stroke: nil, size: :span, font: nil, **html_attributes)
+      super
+
       @text = text
       @stroke = stroke
       @size = size
       @font = font
       @html_attributes = html_attributes
-
-      super
 
       create_display_widget
     end

--- a/lacci/lib/shoes/widgets/star.rb
+++ b/lacci/lib/shoes/widgets/star.rb
@@ -4,20 +4,22 @@ module Shoes
   class Star < Shoes::Widget
     display_properties :left, :top, :points, :outer, :inner, :draw_context
 
+    display_property(:points) { |val| convert_to_integer(val, "points") }
+    display_property(:outer) { |val| convert_to_float(val, "outer") }
+    display_property(:inner) { |val| convert_to_float(val, "inner") }
+
     def initialize(left, top, points = 10, outer = 100, inner = 50)
-      @points = convert_to_integer(points, "points", 10)
-      @outer = convert_to_float(outer, "outer", 100.0)
-      @inner = convert_to_float(inner, "inner", 50.0)
+      super
+      self.left, self.top, self.points, self.outer, self.inner = left, top, points, outer, inner
 
       @draw_context = Shoes::App.instance.current_draw_context
 
-      super
       create_display_widget
     end
 
     private
 
-    def convert_to_integer(value, attribute_name, default = 0)
+    def self.convert_to_integer(value, attribute_name)
       begin
         value = Integer(value)
         raise InvalidAttributeValueError, "Negative num '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
@@ -29,7 +31,7 @@ module Shoes
       end
     end
 
-    def convert_to_float(value, attribute_name, default = 0.0)
+    def self.convert_to_float(value, attribute_name)
       begin
         value = Float(value)
         raise InvalidAttributeValueError, "Negative num '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0

--- a/lacci/lib/shoes/widgets/text_widget.rb
+++ b/lacci/lib/shoes/widgets/text_widget.rb
@@ -9,6 +9,9 @@ module Shoes
       def inherited(subclass)
         Shoes::Widget.widget_classes ||= []
         Shoes::Widget.widget_classes << subclass
+
+        Shoes::Widget.widget_default_styles ||= {}
+        Shoes::Widget.widget_default_styles[subclass] = {}
       end
       # rubocop:enable Lint/MissingSuper
     end
@@ -23,9 +26,9 @@ module Shoes
         display_property :content
 
         def initialize(content)
-          @content = content
-
           super
+
+          @content = content
 
           create_display_widget
         end

--- a/lacci/lib/shoes/widgets/video.rb
+++ b/lacci/lib/shoes/widgets/video.rb
@@ -5,8 +5,8 @@ module Shoes
     display_properties :url
 
     def initialize(url)
-      @url = url
       super
+      @url = url
       create_display_widget
     end
 


### PR DESCRIPTION
### Description

* Add "validator" methods to display properties so the property can be normalised when set.
* Use those validator methods for widgets where we do validation so that it will happen with setters, etc too.
* Move instance-variable setting below "super" in widget initializers. Not mandatory, but makes disp-property assign and inst var assign more similar.
* Add 2 examples showing style changes.
* Add 1 example legacy app called speedometer I happened to find online.

### Checklist

- [X] Run tests locally
