### PR TITLE
Add "animate" and "every" Shoes calls

### DIFF
--- a/examples/animate.rb
+++ b/examples/animate.rb
@@ -1,0 +1,20 @@
+Shoes.app do
+  stack do
+    para "10 fps"
+    p = para "-"
+    animate do |frame|
+      p.replace(frame.to_s)
+    end
+    para "20 fps"
+    p2 = para "-"
+    animate(20) do |frame|
+      p2.replace(frame.to_s)
+    end
+    para "3spf"
+    p3 = para "-"
+    every(3) do |count|
+      p3.replace(count.to_s)
+    end
+  end
+end
+

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -210,16 +210,13 @@ class Shoes::App
     current_slot.border(...)
   end
 
-  def motion(&block)
-    subscription_item(shoes_api_name: "motion", &block)
-  end
+  # Event handler objects
 
-  def hover(&block)
-    subscription_item(shoes_api_name: "hover", &block)
-  end
-
-  def click(&block)
-    subscription_item(shoes_api_name: "click", &block)
+  events = [:motion, :hover, :leave, :click, :release, :keypress, :animate, :every, :timer]
+  events.each do |event|
+    define_method(event) do |*args, &block|
+      subscription_item(args:, shoes_api_name: event.to_s, &block)
+    end
   end
 
   # Draw context methods

--- a/lib/scarpe/wv/subscription_item.rb
+++ b/lib/scarpe/wv/subscription_item.rb
@@ -64,11 +64,11 @@ class Scarpe::Webview::SubscriptionItem < Scarpe::Webview::Widget
     when "hover"
       new_parent.set_event_callback(self, "onmouseenter", handler_js_code(@shoes_api_name))
     when "leave"
-      raise "Implement me!"
+      new_parent.set_event_callback(self, "onmouseleave", handler_js_code(@shoes_api_name))
     when "click"
       new_parent.set_event_callback(self, "onclick", handler_js_code(@shoes_api_name, "arguments[0].button", "arguments[0].x", "arguments[0].y"))
     when "release"
-      raise "Implement me!"
+      new_parent.set_event_callback(self, "onmouseup", handler_js_code(@shoes_api_name, "arguments[0].button", "arguments[0].x", "arguments[0].y"))
     when "keypress"
       raise "Implement me!"
     when "animate", "every", "timer"

--- a/lib/scarpe/wv/subscription_item.rb
+++ b/lib/scarpe/wv/subscription_item.rb
@@ -8,6 +8,32 @@ class Scarpe::Webview::SubscriptionItem < Scarpe::Webview::Widget
     bind(@shoes_api_name) do |*args|
       send_self_event(*args, event_name: @shoes_api_name)
     end
+
+    @wrangler = Scarpe::Webview::DisplayService.instance.wrangler
+
+    case @shoes_api_name
+    when "animate"
+      frame_rate = (@args[0] || 10)
+      @counter = 0
+      @wrangler.periodic_code("animate_#{@shoes_linkable_id}", 1.0 / frame_rate) do
+        @counter += 1
+        send_self_event(@counter, event_name: @shoes_api_name)
+      end
+    when "every"
+      delay = @args[0]
+      @counter = 0
+      @wrangler.periodic_code("every_#{@shoes_linkable_id}", delay) do
+        @counter += 1
+        send_self_event(@counter, event_name: @shoes_api_name)
+      end
+    when "timer"
+      # JS setTimeout?
+      raise "Implement me!"
+    when "motion", "hover", "leave", "click", "release", "keypress"
+      # Wait for set_parent
+    else
+      raise Scarpe::UnknownShoesEventAPIError, "Unknown Shoes event API: #{@shoes_api_name}!"
+    end
   end
 
   def element
@@ -37,15 +63,23 @@ class Scarpe::Webview::SubscriptionItem < Scarpe::Webview::Widget
       )
     when "hover"
       new_parent.set_event_callback(self, "onmouseenter", handler_js_code(@shoes_api_name))
+    when "leave"
+      raise "Implement me!"
     when "click"
       new_parent.set_event_callback(self, "onclick", handler_js_code(@shoes_api_name, "arguments[0].button", "arguments[0].x", "arguments[0].y"))
+    when "release"
+      raise "Implement me!"
+    when "keypress"
+      raise "Implement me!"
+    when "animate", "every", "timer"
+      # These were handled in initialize(), ignore them here
     else
       raise Scarpe::UnknownShoesEventAPIError, "Unknown Shoes event API: #{@shoes_api_name}!"
     end
   end
 
   def destroy_self
-    @parent.remove_event_callbacks(self)
+    @parent&.remove_event_callbacks(self)
     super
   end
 end

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -156,6 +156,8 @@ module Scarpe::Webview
     # so it should be invoked when the WebWrangler is in setup mode,
     # before the Webview is running.
     #
+    # TODO: add a way to stop this loop and unsubscribe.
+    #
     # @param name [String] the name of the Javascript init function, if needed
     # @param interval [Float] the duration between invoking this block
     # @yield the Ruby block to invoke periodically


### PR DESCRIPTION
...plus pre-work for timer, leave, release and keypress.

### Description

Animate and every work, and there's an example showing them. The other calls mentioned give a "not implemented," but they do it in the display library, so technically this should get them working in Lacci.

### Image(if needed, helps for a faster review)

<img width="503" alt="Screenshot 2023-09-29 at 10 49 17" src="https://github.com/scarpe-team/scarpe/assets/82408/6c685865-7321-400a-a0f6-19235365568a">

### Checklist

- [x] Run tests locally
