### PR TITLE
Use a specific test object for CatsCradle, not Shoes::App

### DIFF
--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -55,7 +55,8 @@ module Shoes
       if ENV["SCARPE_APP_TEST"]
         test_code = File.read ENV["SCARPE_APP_TEST"]
         if test_code != ""
-          self.instance_eval test_code
+          @test_obj = Object.new
+          @test_obj.instance_eval test_code
         end
       end
 


### PR DESCRIPTION
### Description

I've been mixing the CatsCradle module into Scarpe::App. That makes for a collision between para meaning "create a paragraph" and it meaning "find a paragraph that exists." This fixes that by creating a top-level test object to get the CatsCradle mixins instead of using Scarpe::App.

### Checklist

- [x] Run tests locally
