### PR TITLE
Importable/exportable Minitest assertions, ShoesSpec runner

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,4 +24,4 @@ end
 
 RuboCop::RakeTask.new
 
-task default: [:test, :lacci_test, :component_test, :rubocop]
+task default: [:test, :lacci_test, :component_test]

--- a/lacci/lib/shoes-spec.rb
+++ b/lacci/lib/shoes-spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Shoes
+  module Spec
+    def self.instance
+      @instance
+    end
+
+    def self.instance=(spec_inst)
+      if @instance && @instance != spec_inst
+        raise "Lacci can only use a single ShoesSpec implementation at one time!"
+      end
+      @instance = spec_inst
+    end
+  end
+end

--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -37,6 +37,10 @@ require_relative "shoes/drawables"
 
 require_relative "shoes/download"
 
+if ENV["SHOES_SPEC_TEST"]
+  require_relative "shoes-spec"
+end
+
 # The module containing Shoes in all its glory.
 # Shoes is a platform-independent GUI library, designed to create
 # small visual applications in Ruby.

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -64,7 +64,7 @@ module Shoes
         require "scarpe/components/minitest_export_reporter"
         Minitest::Reporters::ShoesExportReporter.activate!
         test_code = File.read ENV["SHOES_SPEC_TEST"]
-        if test_code != ""
+        unless test_code.empty?
           kwargs = {}
           kwargs[:class_name] = ENV["SHOES_MINITEST_CLASS_NAME"] if ENV["SHOES_MINITEST_CLASS_NAME"]
           kwargs[:test_name] = ENV["SHOES_MINITEST_METHOD_NAME"] if ENV["SHOES_MINITEST_METHOD_NAME"]

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -60,6 +60,18 @@ module Shoes
         end
       end
 
+      if ENV["SHOES_SPEC_TEST"]
+        require "scarpe/components/minitest_export_reporter"
+        Minitest::Reporters::ShoesExportReporter.activate!
+        test_code = File.read ENV["SHOES_SPEC_TEST"]
+        if test_code != ""
+          kwargs = {}
+          kwargs[:class_name] = ENV["SHOES_MINITEST_CLASS_NAME"] if ENV["SHOES_MINITEST_CLASS_NAME"]
+          kwargs[:test_name] = ENV["SHOES_MINITEST_METHOD_NAME"] if ENV["SHOES_MINITEST_METHOD_NAME"]
+          Shoes::Spec.instance.run_shoes_spec_test_code test_code, **kwargs
+        end
+      end
+
       @app_code_body = app_code_body
 
       # Try to de-dup as much as possible and not send repeat or multiple

--- a/lib/scarpe/errors.rb
+++ b/lib/scarpe/errors.rb
@@ -74,4 +74,6 @@ module Scarpe
   class InvalidClassError < Scarpe::Error; end
 
   class MissingClassError < Scarpe::Error; end
+
+  class MultipleShoesSpecRunsError < Scarpe::Error; end
 end

--- a/lib/scarpe/evented_assertions.rb
+++ b/lib/scarpe/evented_assertions.rb
@@ -101,7 +101,7 @@ module Scarpe::Test::EventedAssertions
   end
 
   # This does a final return of results. If it gets called
-  # multiple times, the test fails because that's not allowed.
+  # multiple times with different results, the test fails because that's not allowed.
   #
   # @param result_bool [Boolean] true if the results are success, false if failure
   # @param msg [String] the message included with the results

--- a/lib/scarpe/shoes_spec.rb
+++ b/lib/scarpe/shoes_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "minitest"
+require "scarpe/cats_cradle" # Currently needed for CCHelpers
+
+# Test framework code to allow Scarpe to execute Shoes-Spec test code.
+# This will run inside the exe/scarpe child process, then send
+# results back to the parent Minitest process.
+
+module Scarpe::Test
+  # Cut down from Rails camelize
+  def self.camelize(string)
+    string = string.sub(/^[a-z\d]*/) { |match| match.capitalize }
+    string.gsub(/(?:_|(\/))([a-z\d]*)/) { "#{$1}#{$2.capitalize}" }
+  end
+
+  # Is it at all reasonable to define more than one test to run in the same Shoes run? Probably not.
+  # They'll leave in-memory residue.
+  def self.run_shoes_spec_test_code(code, class_name: "TestShoesSpecCode", test_name: "test_shoes_spec")
+    if @shoes_spec_init
+      raise MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
+    end
+    @shoes_spec_init = true
+
+    require_relative "cats_cradle"
+
+    # We want Minitest assertions available in the test code.
+    # But this will normally run in a subprocess. So we need
+    # to run Minitest tests and then export the results.
+
+    test_obj = Object.new
+    class << test_obj
+      include Scarpe::Test::CatsCradle
+    end
+    test_obj.instance_eval do
+      event_init
+
+      on_heartbeat do
+        Minitest.run ARGV
+
+        test_finished_no_results
+      end
+    end
+
+    test_class = Class.new(Scarpe::ShoesSpecTest)
+    Object.const_set(camelize(class_name), test_class)
+    test_name = "test_" + test_name unless test_name.start_with?("test_")
+    test_class.define_method(test_name) do
+      eval(code)
+      #test_obj.instance_variable_get(:@cc_instance).instance_eval(code)
+    end
+  end
+end
+
+# When running ShoesSpec tests, we create a parent class for all of them
+# with the appropriate convenience methods and accessors.
+class Scarpe::ShoesSpecTest < Minitest::Test
+  include Scarpe::Test::CCHelpers
+end

--- a/lib/scarpe/wv.rb
+++ b/lib/scarpe/wv.rb
@@ -37,6 +37,11 @@ require "scarpe/components/segmented_file_loader"
 loader = Scarpe::Components::SegmentedFileLoader.new
 Shoes.add_file_loader loader
 
+if ENV["SHOES_SPEC_TEST"]
+  require_relative "shoes_spec"
+  Shoes::Spec.instance = Scarpe::Test
+end
+
 require_relative "wv/web_wrangler"
 require_relative "wv/control_interface"
 

--- a/lib/scarpe/wv/app.rb
+++ b/lib/scarpe/wv/app.rb
@@ -10,19 +10,13 @@ module Scarpe::Webview
     def initialize(properties)
       super
 
-      # It's possible to provide a Ruby script by setting
-      # SCARPE_TEST_CONTROL to its file path. This can
-      # allow pre-setting test options or otherwise
-      # performing additional actions not written into
-      # the Shoes app itself.
-      #
-      # The control interface is what lets these files see
-      # events, specify overrides and so on.
+      # Scarpe's ControlInterface sets up event handlers
+      # for the display service that aren't sent to
+      # Lacci (Shoes). In general it's used for setup
+      # and additional control or testing, outside the
+      # Shoes app. This is how CatsCradle and Shoes-Spec
+      # set up testing, for instance.
       @control_interface = ControlInterface.new
-      if ENV["SCARPE_TEST_CONTROL"]
-        require "scarpe/components/unit_test_helpers"
-        @control_interface.instance_eval File.read(ENV["SCARPE_TEST_CONTROL"])
-      end
 
       # TODO: rename @view
       @view = Scarpe::Webview::WebWrangler.new title: @title,

--- a/scarpe-components/lib/scarpe/components/calzini/slots.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/slots.rb
@@ -139,7 +139,6 @@ module Scarpe::Components::Calzini
     end
 
     unless spacing_styles.empty?
-      #STDERR.puts "Props: #{props.inspect} Attr: #{attr} SpStyle: #{spacing_styles.inspect}"
       return styles.merge(spacing_styles)
     end
 

--- a/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Have to require this to get DefaultReporter and the Minitest::Reporters namespace.
+ENV["MINITEST_REPORTER"] = "ShoesExportReporter"
+require "minitest/reporters"
+require "json"
+require "json/add/exception"
+
+module Minitest
+  module Reporters
+    # To use this Scarpe component, you'll need minitest-reporters in your Gemfile,
+    # probably in the "test" group. You'll need to require and activate it to
+    # register it as Minitest's reporter:
+    #
+    #     require "scarpe/components/minitest_export_reporter"
+    #     Minitest::Reporters::ShoesExportReporter.activate!
+    #
+    # Select a destination to export JSON test results to:
+    #
+    #     export SHOES_MINITEST_EXPORT_FILE=/tmp/shoes_test_export.json
+    #
+    # This class overrides the MINITEST_REPORTER environment variable when you call activate.
+    # If MINITEST_REPORTER isn't set then when you run via Vim, TextMate, RubyMine, etc,
+    # the reporter will be automatically overridden and print to console instead.
+    #
+    # Based on https://gist.github.com/davidwessman/09a13840a8a80080e3842ac3051714c7
+    class ShoesExportReporter < DefaultReporter
+      def self.activate!
+        unless ENV["SHOES_MINITEST_EXPORT_FILE"]
+          raise "ShoesExportReporter is available, but no export file was specified! Set SHOES_MINITEST_EXPORT_FILE!"
+        end
+
+        Minitest::Reporters.use!
+      end
+
+      def serialize_failures(failures)
+        failures.map do |fail|
+          case fail
+          when Minitest::UnexpectedError
+            ["unexpected", fail.to_json, fail.error.to_json]
+          when Exception
+            ["exception", fail.to_json]
+          else
+            raise "Not sure how to serialize failure object! #{fail.inspect}"
+          end
+        end
+      end
+
+      def report
+        super
+
+        results = tests.map do |result|
+          failures = serialize_failures result.failures
+          {
+            name: result.name,
+            klass: test_class(result),
+            assertions: result.assertions,
+            failures: failures,
+            time: result.time,
+            metadata: result.metadata,
+            source_location: (result.source_location rescue ["unknown", -1]),
+          }
+        end
+
+        out_file = ENV["SHOES_MINITEST_EXPORT_FILE"]
+        puts "Writing Minitest results to #{out_file.inspect}."
+        File.write(out_file, JSON.dump(results))
+      end
+    end
+  end
+end

--- a/scarpe-components/lib/scarpe/components/minitest_import_runnable.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_import_runnable.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "minitest"
+require "json"
+require "json/add/exception"
+
+class Scarpe; module Components; end; end
+module Scarpe::Components::ImportRunnables
+  # Minitest Runnables are unusual - we expect to declare a class (like a Test) with
+  # a lot of methods to run. The ImportRunnable is a single Runnable. But whenever
+  # you tell it to import a JSON file, it will add all of the described tests to
+  # its runnable methods.
+  #
+  # Normally that means that your subclass tests will run up front and produce
+  # JSON files, then Minitest will autorun at the end and report all their
+  # results.
+  #
+  # It wouldn't really make sense to create these runnables during the testing
+  # phase, because Minitest has already decided what to run at that point.
+  class ImportRunnable #< Minitest::Runnable
+    # Import JSON from an exported Minitest run. Note that running this multiple
+    # times with overlapping class names may be really bad.
+    def self.import_json(json_file)
+      @imported_classes ||= {}
+      @imported_tests ||= {}
+
+      data = JSON.load(File.read json_file)
+      data.each do |item|
+        klass = item["klass"]
+        meth = item["name"]
+        @imported_tests[klass] ||= {}
+        @imported_tests[klass][meth] = item
+      end
+
+      @imported_tests.each do |klass_name, test_method_hash|
+        klass = @imported_classes[klass_name]
+        unless klass
+          new_klass = Class.new(Minitest::Runnable)
+          @imported_classes[klass_name] = new_klass
+          ImportRunnable.const_set(klass_name, new_klass)
+          klass = new_klass
+
+          klass.define_singleton_method(:run_one_method) do |klass, method_name, reporter|
+            reporter.prerecord klass, method_name
+            imp = test_method_hash[method_name]
+
+            res = Minitest::Result.new imp["name"]
+            res.klass = imp["klass"]
+            res.assertions = imp["assertions"]
+            res.time = imp["time"]
+            res.failures = ImportRunnable.deserialize_failures imp["failures"]
+            res.metadata = imp["metadata"] if imp["metadata"]
+
+            # Record the synthetic result built from imported data
+            reporter.record res
+          end
+        end
+
+        # Update "runnables" method to reflect all current known runnable tests
+        klass_methods = test_method_hash.keys
+        klass.define_singleton_method(:runnable_methods) do
+          klass_methods
+        end
+      end
+    end
+
+    def self.json_to_err(err_json)
+      klass = Object.const_get(err_json['json_class']) rescue nil
+      if klass && klass <= Minitest::Assertion
+        klass.json_create(err_json)
+      else
+        err = Exception.json_create(err_json)
+        Minitest::UnexpectedError.new(err)
+      end
+    end
+
+    def self.deserialize_failures(failures)
+      failures.map do |fail|
+        # Instantiate the Minitest::Assertion or Minitest::UnexpectedError
+        if fail[0] == "exception"
+          exc_json = JSON.parse(fail[1])
+          json_to_err exc_json
+        elsif fail[0] == "unexpected"
+          unexpected_json = JSON.parse(fail[1])
+          inner_json = JSON.parse(fail[2])
+          outer_err = json_to_err unexpected_json
+          inner_err = json_to_err inner_json
+          outer_err.error = inner_err
+        else
+          raise "Unknown exception data when trying to deserialize! #{fail.inspect}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

Shoes-Spec will eventually be a set of tests that can run in a display-lib-independent test language. But for that, we want to use Minitest assertions, because keeping our own assertion library is no good.

This permits running Shoes-Spec code with Minitest assertions and failures running, being exported, and being collectible in a parent Minitest process -- very useful when you want to run a lot of Shoes apps with Minitest assertions and then collect the test results at the top level.

I'm submitting this as a draft PR for right now because it's still quite messy and generally prototype quality.

This isn't the Shoes-Spec repo, which will live elsewhere.

### Image(if needed, helps for a faster review)

<img width="532" alt="Screenshot 2023-10-05 at 19 07 26" src="https://github.com/scarpe-team/scarpe/assets/82408/dcc89a81-219c-4b79-a6e9-c69f26d32337">

### Checklist

- [X] Run tests locally
