### PR TITLE
fetch release name and build type from changelog

### DIFF
--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -42,6 +42,8 @@ require_relative "shoes/download"
 # small visual applications in Ruby.
 #
 module Shoes
+  include Shoes::Constants
+
   class << self
     # Creates a Shoes app with a new window. The block parameter is used to create
     # widgets and set up handlers. Arguments are passed to Shoes::App.new internally.

--- a/lacci/lib/shoes/changelog.rb
+++ b/lacci/lib/shoes/changelog.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "log"
+# require "scarpe/components/modular_logger"
+
+module Shoes
+  class Changelog
+    # include Shoes::Log
+
+    def initialize
+      #TODO : refer to  https://github.com/scarpe-team/scarpe/pull/400
+      #       and figure out how to use scarpe logger here wtihout getting duplicate or nil error
+      # Shoes::Log.instance = Scarpe::Components::ModularLogImpl.new
+      # log_init("Changelog")
+    end
+
+    def get_latest_release_info
+      changelog_content = File.read("CHANGELOG.md")
+
+      release_name_pattern = /^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})$/m
+
+      release_matches = changelog_content.scan(release_name_pattern)
+
+      latest_release = release_matches.max_by { |version, _date| Gem::Version.new(version) }
+
+      if latest_release
+        puts "Found release #{latest_release[0]} in CHANGELOG.md"
+        # @log.debug("Found release #{latest_release[0]} in CHANGELOG.md")
+        { RELEASE_NAME: latest_release[0], RELEASE_BUILD_DATE: latest_release[1] }
+      else
+        puts "No release found in CHANGELOG.md"
+        { RELEASE_NAME: nil, RELEASE_BUILD_DATE: nil }
+      end
+    end
+  end
+end

--- a/lacci/lib/shoes/constants.rb
+++ b/lacci/lib/shoes/constants.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "changelog"
 module Shoes
   module Constants
     def self.find_lib_dir
@@ -28,17 +29,9 @@ module Shoes
     PI = 3.14159265358979323846
   end
 
-  changelog_content = File.read("CHANGELOG.md")
-
-  release_name_pattern = /^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})$/m
-
-  release_matches = changelog_content.scan(release_name_pattern)
-
-  latest_release = release_matches.max_by { |version, _date| Gem::Version.new(version) }
-
-  if latest_release
-    RELEASE_NAME, RELEASE_BUILD_DATE = latest_release
-  else
-    puts "most likely something wrong in constants.rb file. or changelog"
-  end
+  # Access and assign the release constants
+  changelog_instance = Shoes::Changelog.new
+  RELEASE_INFO = changelog_instance.get_latest_release_info
+  RELEASE_NAME = RELEASE_INFO[:RELEASE_NAME]
+  RELEASE_BUILD_DATE = RELEASE_INFO[:RELEASE_BUILD_DATE]
 end

--- a/lacci/lib/shoes/constants.rb
+++ b/lacci/lib/shoes/constants.rb
@@ -14,6 +14,7 @@ module Shoes
         [ENV["HOME"], ".shoes"],
         [Dir.tmpdir, "shoes"],
       ]
+
       top, file = homes.detect { |home_top, _| home_top && File.exist?(home_top) }
       File.join(top, file)
     end
@@ -25,5 +26,19 @@ module Shoes
     TWO_PI = 6.28318530717958647693
     HALF_PI = 1.57079632679489661923
     PI = 3.14159265358979323846
+  end
+
+  changelog_content = File.read("CHANGELOG.md")
+
+  release_name_pattern = /^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})$/m
+
+  release_matches = changelog_content.scan(release_name_pattern)
+
+  latest_release = release_matches.max_by { |version, _date| Gem::Version.new(version) }
+
+  if latest_release
+    RELEASE_NAME, RELEASE_BUILD_DATE = latest_release
+  else
+    puts "most likely something wrong in constants.rb file. or changelog"
   end
 end


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to Scarpe! 💖
-->

### Description

fetching release name and build type from change log shoes also has release_type constant but idk what it even means tbh.  and i dont think we have anything abt release_type in changelog too.

<!-- Please write a summary of the change, Please also include relevant motivation and context: -->

### Image(if needed, helps for a faster review)

<!-- Add image of the feature u added here -->

### Checklist

- [ ] Run tests locally
- [ ] Run linter(check for linter errors)
<!--
for Linter

bundle exec rubocop

this would autocorrect offenses if they are autocorrectable.
bundle exec rubocop . --autocorrect-all

-->
