### PR TITLE
Add new custom drawable-to-HTML renderer called Tiranti

### DIFF
--- a/exe/scarpe
+++ b/exe/scarpe
@@ -38,6 +38,7 @@ add_env_categories("Scarpe::WV" => [
   env_or_default("SCARPE_TEST_CONTROL", "(none)"),
   env_or_default("SCARPE_TEST_RESULTS", "(none)"),
   env_or_default("SCARPE_TEST_DEBUG", "(none)"),
+  env_or_default("SCARPE_HTML_RENDERER", "calzini"),
 ])
 
 verb = "run"

--- a/lib/scarpe/errors.rb
+++ b/lib/scarpe/errors.rb
@@ -76,4 +76,6 @@ module Scarpe
   class MissingClassError < Scarpe::Error; end
 
   class MultipleShoesSpecRunsError < Scarpe::Error; end
+
+  class EmptyPageNotSetError < Scarpe::Error; end
 end

--- a/lib/scarpe/wv.rb
+++ b/lib/scarpe/wv.rb
@@ -15,13 +15,12 @@ require "scarpe/components/promises"
 # Module to contain the various Scarpe Webview classes
 module Scarpe::Webview
   HTML = Scarpe::Components::HTML
-
-  class Drawable < Shoes::Linkable
-    # This is where we would make the HTML renderer modular by choosing another
-    require "scarpe/components/calzini"
-    include Scarpe::Components::Calzini
-  end
 end
+
+# Set up Scarpe-Webview's HTML renderer
+ren = ENV["SCARPE_HTML_RENDERER"] || "calzini"
+# This should *not* be require_relative so that other gems can implement HTML renderers.
+require "scarpe/components/#{ren}"
 
 # Set up hierarchical logging using the SCARPE_LOG_CONFIG var for configuration
 log_config = if ENV["SCARPE_LOG_CONFIG"]

--- a/lib/scarpe/wv/app.rb
+++ b/lib/scarpe/wv/app.rb
@@ -57,6 +57,8 @@ module Scarpe::Webview
     def run
       @control_interface.dispatch_event(:init)
 
+      @view.empty_page = empty_page_element
+
       # This takes control of the main thread and never returns. And it *must* be run from
       # the main thread. And it stops any Ruby background threads.
       # That's totally cool and normal, right?

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -362,6 +362,8 @@ module Scarpe::Webview
 
     public
 
+    attr_writer :empty_page
+
     # After setup, we call run to go to "running" mode.
     # No more setup callbacks should be called, only running callbacks.
     def run
@@ -376,7 +378,10 @@ module Scarpe::Webview
 
       @webview.set_title(@title)
       @webview.set_size(@width, @height, hint)
-      @webview.navigate("data:text/html, #{CGI.escape empty}")
+      unless @empty_page
+        raise Scarpe::EmptyPageNotSetError, "No empty page markup was set!"
+      end
+      @webview.navigate("data:text/html, #{CGI.escape @empty_page}")
 
       monkey_patch_console(@webview)
 

--- a/scarpe-components/lib/scarpe/components/calzini.rb
+++ b/scarpe-components/lib/scarpe/components/calzini.rb
@@ -131,3 +131,9 @@ module Scarpe::Components::Calzini
     radians * (180.0 / Math::PI)
   end
 end
+
+if ENV["SCARPE_HTML_RENDERER"].nil? || ENV["SCARPE_HTML_RENDERER"] == "calzini"
+  class Scarpe::Webview::Drawable < Shoes::Linkable
+    include Scarpe::Components::Calzini
+  end
+end

--- a/scarpe-components/lib/scarpe/components/html.rb
+++ b/scarpe-components/lib/scarpe/components/html.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Scarpe::Components::HTML
-  CONTENT_TAGS = [:div, :p, :button, :ul, :li, :textarea, :a, :video, :strong, :style, :em, :code, :defs, :marker, :u, :line, :span, :svg].freeze
+  CONTENT_TAGS = [:div, :p, :button, :ul, :li, :textarea, :a, :video, :strong, :style, :em, :code, :defs, :marker, :u, :line, :span, :svg, :h1, :h2, :h3, :h4, :h5].freeze
   VOID_TAGS = [:input, :img, :polygon, :source, :link, :path, :rect].freeze
 
   TAGS = (CONTENT_TAGS + VOID_TAGS).freeze

--- a/scarpe-components/lib/scarpe/components/tiranti.rb
+++ b/scarpe-components/lib/scarpe/components/tiranti.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+# In Italian, tiranti are bootstraps -- the literal pull-on-a-boot kind, not a step to something better.
+# Tiranti.rb builds on calzini.rb, but renders a Bootstrap-decorated version of the HTML output.
+# You would ordinarily set either Calzini or Tiranti as the top-level HTML renderer, not both.
+# You'll include both if you use Tiranti, because it falls back to Calzini for a lot of its rendering.
+
+require "scarpe/components/calzini"
+
+# The Tiranti module expects to be included by a class defining
+# the following methods:
+#
+#     * html_id - the HTML ID for the specific rendered DOM object
+#     * handler_js_code(event_name) - the JS handler code for this DOM object and event name
+#     * (optional) display_properties - the display properties for this object, unless overridden in render()
+module Scarpe::Components::Tiranti
+  include Scarpe::Components::Calzini
+  extend self
+
+  # Currently we're using Bootswatch 5
+  BOOTSWATCH_THEMES = [
+    "cerulean",
+    "cosmo",
+    "cyborg",
+    "darkly",
+    "flatly",
+    "journal",
+    "litera",
+    "lumen",
+    "lux",
+    "materia",
+    "minty",
+    "morph",
+    "pulse",
+    "quartz",
+    "sandstone",
+    "simplex",
+    "sketchy",
+    "slate",
+    "solar",
+    "spacelab",
+    "superhero",
+    "united",
+    "vapor",
+    "yeti",
+    "zephyr",
+  ]
+
+  BOOTSWATCH_THEME = ENV["SCARPE_BOOTSTRAP_THEME"] || "sketchy"
+
+  def empty_page_element
+    <<~HTML
+      <html>
+        <head id='head-wvroot'>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+          <link rel="stylesheet" href="https://bootswatch.com/5/#{BOOTSWATCH_THEME}/bootstrap.css">
+          <link rel="stylesheet" href="https://bootswatch.com/_vendor/bootstrap-icons/font/bootstrap-icons.min.css">
+          <style id='style-wvroot'>
+            /** Style resets **/
+            body {
+              height: 100%;
+              overflow: hidden;
+            }
+          </style>
+        </head>
+        <body id='body-wvroot'>
+          <div id='wrapper-wvroot'></div>
+
+          <script src="https://bootswatch.com/_vendor/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+        </body>
+      </html>
+    HTML
+  end
+
+  # def render_stack
+  # end
+  # def render_flow
+  # end
+
+  public
+
+  # How do we want to handle theme-specific colours and primary/secondary buttons in Bootstrap?
+  # "Disabled" could be checked in properties. Is there any way we can/should use "outline" buttons?
+  def button_element(props)
+    HTML.render do |h|
+      h.button(id: html_id, type: "button", class: "btn btn-primary", onclick: handler_js_code("click"), style: button_style(props)) do
+        props["text"]
+      end
+    end
+  end
+
+  private
+
+  def button_style(props)
+    styles = drawable_style(props)
+
+    styles[:"background-color"] = props["color"] if props["color"]
+    styles[:"padding-top"] = props["padding_top"] if props["padding_top"]
+    styles[:"padding-bottom"] = props["padding_bottom"] if props["padding_bottom"]
+    styles[:color] = props["text_color"] if props["text_color"]
+    styles[:width] = dimensions_length(props["width"]) if props["width"]
+    styles[:height] = dimensions_length(props["height"]) if props["height"]
+    styles[:"font-size"] = props["font_size"] if props["font_size"]
+
+    styles[:top] = dimensions_length(props["top"]) if props["top"]
+    styles[:left] = dimensions_length(props["left"]) if props["left"]
+    styles[:position] = "absolute" if props["top"] || props["left"]
+    styles[:"font-size"] = dimensions_length(text_size(props["size"])) if props["size"]
+    styles[:"font-family"] = props["font"] if props["font"]
+
+    styles
+  end
+
+  public
+
+  def alert_element(props)
+    onclick = handler_js_code("click")
+
+    HTML.render do |h|
+      h.div(id: html_id, class: "modal", tabindex: -1, role: "dialog", style: alert_overlay_style(props)) do
+        h.div(class: "modal-dialog", role: "document") do
+          h.div(class: "modal-content", style: alert_modal_style) do
+            h.div(class: "modal-header") do
+              h.h5(class: "modal-title") { "Alert" }
+              h.button(type: "button", class: "close", data_dismiss: "modal", aria_label: "Close") do
+                h.span(aria_hidden: "true") { "&times;" }
+              end
+            end
+            h.div(class: "modal-body") do
+              h.p { props["text"] }
+            end
+            h.div(class: "modal-footer") do
+              h.button(type: "button", onclick:, class: "btn btn-primary") { "OK" }
+              #h.button(type: "button", class: "btn btn-secondary") { "Close" }
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def check_element(props)
+    HTML.render do |h|
+      h.div class: "form-check" do
+        h.input type: :checkbox,
+          id: html_id,
+          class: "form-check-input",
+          onclick: handler_js_code("click"),
+          value: props["text"],
+          checked: props["checked"],
+          style: drawable_style(props)
+      end
+    end
+  end
+
+  # para_element is a bit of a hard one, since it does not-entirely-trivial
+  # mapping between display objects and IDs. But we don't want Calzini
+  # messing with the display service or display objects.
+  def para_element(props, &block)
+    tag, opts = para_elt_and_opts(props)
+
+    HTML.render do |h|
+      h.send(tag, **opts, &block)
+    end
+  end
+
+  private
+
+  ELT_AND_SIZE = {
+    inscription: [:p, 10],
+    ins: [:p, 10],
+    para: [:p, 12],
+    caption: [:p, 14],
+    tagline: [:p, 18],
+    subtitle: [:h3, 26],
+    title: [:h2, 34],
+    banner: [:h1, 48],
+  }.freeze
+
+  def para_elt_and_opts(props)
+    elt, size = para_elt_and_size(props)
+    size = dimensions_length(size)
+
+    para_style = drawable_style(props).merge({
+      color: rgb_to_hex(props["stroke"]),
+      "font-size": para_font_size(props),
+      "font-family": props["font"],
+    }.compact)
+
+    opts = (props["html_attributes"] || {}).merge(id: html_id, style: para_style)
+
+    [elt, opts]
+  end
+
+  def para_elt_and_size(props)
+    return [:p, nil] unless props["size"]
+
+    ps = props["size"].to_s.to_sym
+    if ELT_AND_SIZE.key?(ps)
+      ELT_AND_SIZE[ps]
+    else
+      sz = props["size"].to_i
+      if sz > 18
+        [:h2, sz]
+      else
+        [:p, sz]
+      end
+    end
+  end
+end
+
+if ENV["SCARPE_HTML_RENDERER"] == "tiranti"
+  class Scarpe::Webview::Drawable < Shoes::Linkable
+    include Scarpe::Components::Tiranti
+  end
+end

--- a/scarpe-components/test/test_helper.rb
+++ b/scarpe-components/test/test_helper.rb
@@ -2,6 +2,9 @@
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
+# Prevent Calzini or Tiranti from registering itself with Scarpe::Webview, which isn't present here
+ENV["SCARPE_HTML_RENDERER"] = "NONE"
+
 require "shoes"
 
 require "minitest/autorun"

--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -74,6 +74,7 @@ class TestWebWranglerMocked < LoggedScarpeTest
           webview.expect :destroy, nil
         end
       end
+      @web_wrangler.empty_page = CALZINI_EMPTY_PAGE
       @web_wrangler.run
     end
   end
@@ -226,6 +227,28 @@ class TestWebWranglerMocked < LoggedScarpeTest
       assert_equal :fulfilled, update_p3.state, "Update promise should be fulfilled after update is finished (2)"
     end
   end
+
+  CALZINI_EMPTY_PAGE = <<~HTML
+      <html>
+        <head id='head-wvroot'>
+          <style id='style-wvroot'>
+            /** Style resets **/
+            body {
+              font-family: arial, Helvetica, sans-serif;
+              margin: 0;
+              height: 100%;
+              overflow: hidden;
+            }
+            p {
+              margin: 0;
+            }
+          </style>
+        </head>
+        <body id='body-wvroot'>
+          <div id='wrapper-wvroot'></div>
+        </body>
+      </html>
+    HTML
 end
 
 class TestWebWranglerAsyncJS < LoggedScarpeTest


### PR DESCRIPTION
### Description

This is still a little rough. But basically works. Need to figure out how we want to do examples - would make sense to check them with both renderers, but that'll take a lot longer.

### Image(if needed, helps for a faster review)

For the image below, use "SCARPE_HTML_RENDERER=tiranti ./exe/scarpe --dev examples/edit_box.rb".

<img width="491" alt="Screenshot 2023-10-12 at 17 14 28" src="https://github.com/scarpe-team/scarpe/assets/82408/59e171b6-a24d-4dab-9cef-121c7247ef73">

SCARPE_HTML_RENDERER=tiranti ./exe/scarpe --dev examples/motion_events.rb

<img width="602" alt="Screenshot 2023-10-12 at 17 22 33" src="https://github.com/scarpe-team/scarpe/assets/82408/b5f39c9f-cc8e-4fea-a7c1-5f8e508e0321">

Can also use any of the Bootswatch themes, for now loaded from bootswatch.com. Here's Cyborg, a dark-background theme: "SCARPE_HTML_RENDERER=tiranti SCARPE_BOOTSTRAP_THEME=cyborg bundle exec ./exe/scarpe examples/para/rainbow.rb"

<img width="493" alt="Screenshot 2023-10-12 at 17 49 41" src="https://github.com/scarpe-team/scarpe/assets/82408/1c23b7d2-d073-4575-bbb8-9adc9755db75">

### Checklist

- [X] Run tests locally
