### PR TITLE
Have Tiranti respect the configurability of the callback

### DIFF
--- a/lib/scarpe/wv/app.rb
+++ b/lib/scarpe/wv/app.rb
@@ -79,7 +79,11 @@ module Scarpe::Webview
     # All JS callbacks to Scarpe drawables are dispatched
     # via this handler
     def handle_callback(name, *args)
-      @callbacks[name].call(*args)
+      if @callbacks.key?(name)
+        @callbacks[name].call(*args)
+      else
+        raise Scarpe::UnknownEventTypeError, "No such Webview callback: #{name.inspect}!"
+      end
     end
 
     # Bind a Scarpe callback name; see handle_callback above.

--- a/scarpe-components/lib/scarpe/components/tiranti.rb
+++ b/scarpe-components/lib/scarpe/components/tiranti.rb
@@ -115,7 +115,7 @@ module Scarpe::Components::Tiranti
   public
 
   def alert_element(props)
-    onclick = handler_js_code("click")
+    onclick = handler_js_code(props["event_name"] || "click")
 
     HTML.render do |h|
       h.div(id: html_id, class: "modal", tabindex: -1, role: "dialog", style: alert_overlay_style(props)) do


### PR DESCRIPTION
...so it can handle alert rendering; better error msg for bad callback name

Fixes #422

### Checklist

- [ ] Run tests locally
