### PR TITLE
Make button click and hover events be different from each other.

### DIFF
--- a/lacci/lib/shoes/drawables/button.rb
+++ b/lacci/lib/shoes/drawables/button.rb
@@ -23,7 +23,7 @@ module Shoes
       end
 
       bind_self_event("hover") do
-        @block&.call
+        @hover&.call
       end
 
       create_display_drawable
@@ -35,7 +35,7 @@ module Shoes
     end
 
     def hover(&block)
-      @block = block
+      @hover = block
     end
   end
 end


### PR DESCRIPTION
### Description

Buttons were triggering their click handlers on hover because of a bug with the recent button-hover PR.

### Checklist

- [ ] Run tests locally
