### PR TITLE
Require all Lacci drawables to register their list of Shoes events

### DIFF
--- a/lacci/lib/shoes/drawables/arc.rb
+++ b/lacci/lib/shoes/drawables/arc.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Arc < Shoes::Drawable
     shoes_style :draw_context
+    shoes_events() # No Arc-specific events yet
 
     [:left, :top, :width, :height].each do |prop|
       shoes_style(prop) { |val| convert_to_integer(val, prop) }

--- a/lacci/lib/shoes/drawables/arrow.rb
+++ b/lacci/lib/shoes/drawables/arrow.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Arrow < Shoes::Drawable
     shoes_style :draw_context
+    shoes_events() # No Arrow-specific events yet
 
     [:left, :top, :width].each do |prop|
       shoes_style(prop) { |val| val.is_a?(Hash) ? val : convert_to_integer(val, prop) }

--- a/lacci/lib/shoes/drawables/button.rb
+++ b/lacci/lib/shoes/drawables/button.rb
@@ -4,6 +4,7 @@ module Shoes
   class Button < Shoes::Drawable
     include Shoes::Log
     shoes_styles :text, :width, :height, :top, :left, :color, :padding_top, :padding_bottom, :text_color, :size, :font_size,:tooltip
+    shoes_events :click, :hover
 
     def initialize(text, width: nil, height: nil, top: nil, left: nil, color: nil, padding_top: nil, padding_bottom: nil, size: 12, text_color: nil,
       font_size: nil,tooltip: nil, &block)

--- a/lacci/lib/shoes/drawables/check.rb
+++ b/lacci/lib/shoes/drawables/check.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Check < Shoes::Drawable
     shoes_styles :checked
+    shoes_events :click
 
     def initialize(checked = nil, &block)
       @block = block

--- a/lacci/lib/shoes/drawables/document_root.rb
+++ b/lacci/lib/shoes/drawables/document_root.rb
@@ -2,6 +2,8 @@
 
 module Shoes
   class DocumentRoot < Shoes::Flow
+    shoes_events() # No DocumentRoot-specific events yet
+
     def initialize
       @height = "100%"
       @width = @margin = @padding = nil

--- a/lacci/lib/shoes/drawables/edit_box.rb
+++ b/lacci/lib/shoes/drawables/edit_box.rb
@@ -3,6 +3,7 @@
 module Shoes
   class EditBox < Shoes::Drawable
     shoes_styles :text, :height, :width
+    shoes_events :change
 
     def initialize(text = "", height: nil, width: nil, &block)
       super

--- a/lacci/lib/shoes/drawables/edit_line.rb
+++ b/lacci/lib/shoes/drawables/edit_line.rb
@@ -3,6 +3,7 @@
 module Shoes
   class EditLine < Shoes::Drawable
     shoes_styles :text, :width
+    shoes_events :change
 
     def initialize(text = "", width: nil, &block)
       super

--- a/lacci/lib/shoes/drawables/flow.rb
+++ b/lacci/lib/shoes/drawables/flow.rb
@@ -7,6 +7,7 @@ module Shoes
     include Shoes::Spacing
 
     shoes_styles :width, :height, :margin, :padding
+    shoes_events()
 
     def initialize(width: "100%", height: nil, margin: nil, padding: nil, **options, &block)
       super

--- a/lacci/lib/shoes/drawables/image.rb
+++ b/lacci/lib/shoes/drawables/image.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Image < Shoes::Drawable
     shoes_styles :url, :width, :height, :top, :left, :click
+    shoes_events() # No Image-specific events yet
 
     def initialize(url, width: nil, height: nil, top: nil, left: nil, click: nil)
       super

--- a/lacci/lib/shoes/drawables/line.rb
+++ b/lacci/lib/shoes/drawables/line.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Line < Shoes::Drawable
     shoes_styles :left, :top, :x2, :y2, :draw_context
+    shoes_events() # No Line-specific events yet
 
     def initialize(left, top, x2, y2)
       super

--- a/lacci/lib/shoes/drawables/link.rb
+++ b/lacci/lib/shoes/drawables/link.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Link < Shoes::TextDrawable
     shoes_styles :text, :click, :has_block
+    shoes_events :click
 
     def initialize(text, click: nil, &block)
       super

--- a/lacci/lib/shoes/drawables/list_box.rb
+++ b/lacci/lib/shoes/drawables/list_box.rb
@@ -3,6 +3,7 @@
 module Shoes
   class ListBox < Shoes::Drawable
     shoes_styles :selected_item, :items, :height, :width, :choose
+    shoes_events :change
 
     def initialize(args = {}, &block)
       super

--- a/lacci/lib/shoes/drawables/para.rb
+++ b/lacci/lib/shoes/drawables/para.rb
@@ -5,6 +5,8 @@ module Shoes
     shoes_styles :text_items, :size, :font, :html_attributes, :hidden
     shoes_style(:stroke) { |val| Shoes::Colors.to_rgb(val) }
 
+    shoes_events() # No Para-specific events yet
+
     def initialize(*args, stroke: nil, size: :para, font: nil, hidden: false, **html_attributes)
       super
 

--- a/lacci/lib/shoes/drawables/progress.rb
+++ b/lacci/lib/shoes/drawables/progress.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Progress < Shoes::Drawable
     shoes_styles :fraction
+    shoes_events() # No Progress-specific events yet
 
     def initialize(fraction: nil)
       super

--- a/lacci/lib/shoes/drawables/radio.rb
+++ b/lacci/lib/shoes/drawables/radio.rb
@@ -6,6 +6,7 @@ module Shoes
   # radio buttons in the same slot being treated as being in the same group.
   class Radio < Shoes::Drawable
     shoes_styles :group, :checked
+    shoes_events :click
 
     def initialize(group = nil, checked: nil, &block)
       super

--- a/lacci/lib/shoes/drawables/rect.rb
+++ b/lacci/lib/shoes/drawables/rect.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Rect < Shoes::Drawable
     shoes_styles :left, :top, :width, :height, :draw_context, :curve
+    shoes_events() # No Rect-specific events yet
 
     def initialize(*args)
       @draw_context = Shoes::App.instance.current_draw_context

--- a/lacci/lib/shoes/drawables/shape.rb
+++ b/lacci/lib/shoes/drawables/shape.rb
@@ -11,6 +11,7 @@ module Shoes
   # @incompatibility A Shoes3 Shape is *not* a slot; Scarpe does *not* do union shapes
   class Shape < Shoes::Slot
     shoes_styles :left, :top, :shape_commands, :draw_context
+    shoes_events() # No Shape-specific events yet
 
     def initialize(left: nil, top: nil, &block)
       @shape_commands = []

--- a/lacci/lib/shoes/drawables/slot.rb
+++ b/lacci/lib/shoes/drawables/slot.rb
@@ -4,6 +4,8 @@ class Shoes::Slot < Shoes::Drawable
   # @incompatibility Shoes uses #content, not #children, for this
   attr_reader :children
 
+  shoes_events() # No Slot-specific events yet
+
   # Do not call directly, use set_parent
   def remove_child(child)
     @children ||= []

--- a/lacci/lib/shoes/drawables/span.rb
+++ b/lacci/lib/shoes/drawables/span.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Span < Shoes::Drawable
     shoes_styles :text, :stroke, :size, :font, :html_attributes
+    shoes_events() # No Span-specific events yet
 
     def initialize(text, stroke: nil, size: :span, font: nil, **html_attributes)
       super

--- a/lacci/lib/shoes/drawables/stack.rb
+++ b/lacci/lib/shoes/drawables/stack.rb
@@ -9,6 +9,8 @@ module Shoes
     # TODO: sort out various margin and padding properties, including putting stuff into spacing
     shoes_styles :width, :height, :scroll
 
+    shoes_events() # No Stack-specific events yet
+
     def initialize(width: nil, height: nil, margin: nil, padding: nil, scroll: false, margin_top: nil, margin_bottom: nil, margin_left: nil,
       margin_right: nil, **options, &block)
 

--- a/lacci/lib/shoes/drawables/star.rb
+++ b/lacci/lib/shoes/drawables/star.rb
@@ -8,6 +8,8 @@ module Shoes
     shoes_style(:outer) { |val| convert_to_float(val, "outer") }
     shoes_style(:inner) { |val| convert_to_float(val, "inner") }
 
+    shoes_events() # No Star-specific events yet
+
     def initialize(left, top, points = 10, outer = 100, inner = 50)
       super
       self.left, self.top, self.points, self.outer, self.inner = left, top, points, outer, inner

--- a/lacci/lib/shoes/drawables/subscription_item.rb
+++ b/lacci/lib/shoes/drawables/subscription_item.rb
@@ -14,6 +14,7 @@
 # start is first draw, finish is drawable destroyed
 class Shoes::SubscriptionItem < Shoes::Drawable
   shoes_styles :shoes_api_name, :args
+  shoes_events :animate, :every, :timer, :hover, :leave, :motion, :click, :release, :keypress
 
   def initialize(args: [], shoes_api_name:, &block)
     super
@@ -60,13 +61,13 @@ class Shoes::SubscriptionItem < Shoes::Drawable
     when "release"
       # Click has block params button, left, top
       # button is the button number, left and top are coords
-      @unsub_id = bind_self_event("click") do |button, x, y, **_kwargs|
+      @unsub_id = bind_self_event("release") do |button, x, y, **_kwargs|
         @callback&.call(button, x, y)
       end
     when "keypress"
       # Keypress passes the key string or symbol to the handler
       # Do anything special for serialisation here?
-      @unsub_id = bind_self_event("click") do |key|
+      @unsub_id = bind_self_event("keypress") do |key|
         @callback&.call(key)
       end
     else

--- a/lacci/lib/shoes/drawables/text_drawable.rb
+++ b/lacci/lib/shoes/drawables/text_drawable.rb
@@ -15,6 +15,8 @@ module Shoes
       end
       # rubocop:enable Lint/MissingSuper
     end
+
+    shoes_events() # No TextDrawable-specific events yet
   end
 
   class << self
@@ -44,6 +46,8 @@ module Shoes
       Shoes.const_set class_name, drawable_class
       drawable_class.class_eval do
         shoes_style :content
+
+        shoes_events() # No specific events
       end
     end
   end

--- a/lacci/lib/shoes/drawables/video.rb
+++ b/lacci/lib/shoes/drawables/video.rb
@@ -3,6 +3,7 @@
 module Shoes
   class Video < Shoes::Drawable
     shoes_styles :url
+    shoes_events() # No specific events yet
 
     def initialize(url)
       super

--- a/lacci/lib/shoes/drawables/widget.rb
+++ b/lacci/lib/shoes/drawables/widget.rb
@@ -40,6 +40,8 @@ class Shoes::Widget < Shoes::Slot
   include Shoes::Border
   include Shoes::Spacing
 
+  shoes_events()
+
   def self.method_added(name)
     # We're only looking for the initialize() method, and only on subclasses
     # of Shoes::Widget, not Shoes::Widget itself.

--- a/lacci/lib/shoes/errors.rb
+++ b/lacci/lib/shoes/errors.rb
@@ -12,4 +12,6 @@ module Shoes
   class NoLinkableIdError < Shoes::Error; end
 
   class BadLinkableIdError < Shoes::Error; end
+
+  class UnregisteredShoesEvent < Shoes::Error; end
 end


### PR DESCRIPTION
### Description

When binding events, check that event names match the list.

Fixes #318.

### Checklist

- [X] Run tests locally
