### PR TITLE
ShoesSpec: basic events

### DIFF
--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -62,14 +62,9 @@ module Shoes
       end
 
       if ENV["SHOES_SPEC_TEST"]
-        require "scarpe/components/minitest_export_reporter"
-        Minitest::Reporters::ShoesExportReporter.activate!
         test_code = File.read ENV["SHOES_SPEC_TEST"]
         unless test_code.empty?
-          kwargs = {}
-          kwargs[:class_name] = ENV["SHOES_MINITEST_CLASS_NAME"] if ENV["SHOES_MINITEST_CLASS_NAME"]
-          kwargs[:test_name] = ENV["SHOES_MINITEST_METHOD_NAME"] if ENV["SHOES_MINITEST_METHOD_NAME"]
-          Shoes::Spec.instance.run_shoes_spec_test_code test_code, **kwargs
+          Shoes::Spec.instance.run_shoes_spec_test_code test_code
         end
       end
 

--- a/lacci/lib/shoes/drawable.rb
+++ b/lacci/lib/shoes/drawable.rb
@@ -264,6 +264,7 @@ module Shoes
     public
 
     attr_reader :parent
+    attr_reader :destroyed
 
     def set_parent(new_parent)
       @parent&.remove_child(self)
@@ -275,6 +276,8 @@ module Shoes
     # Removes the element from the Shoes::Drawable tree and removes all event subscriptions
     def destroy
       @parent&.remove_child(self)
+      @parent = nil
+      @destroyed = true
       unsub_all_shoes_events
       send_shoes_event(event_name: "destroy", target: linkable_id)
     end

--- a/lib/scarpe/cats_cradle.rb
+++ b/lib/scarpe/cats_cradle.rb
@@ -35,7 +35,7 @@ module Scarpe::Test
     end
   end
 
-  module CCHelpers
+  module DrawableFinders
     # What to do about TextDrawables? Link, code, em, strong?
     # Also, wait, what's up with span? What *is* that?
     Shoes::Drawable.drawable_classes.each do |drawable_class|
@@ -59,7 +59,7 @@ module Scarpe::Test
     include Shoes::Log
     include Scarpe::Test::EventedAssertions
     include Scarpe::Test::Helpers
-    include Scarpe::Test::CCHelpers
+    include Scarpe::Test::DrawableFinders
 
     def self.instance
       @instance ||= CCInstance.new

--- a/lib/scarpe/shoes_spec.rb
+++ b/lib/scarpe/shoes_spec.rb
@@ -11,11 +11,17 @@ require "scarpe/components/string_helpers"
 module Scarpe::Test
   # Is it at all reasonable to define more than one test to run in the same Shoes run? Probably not.
   # They'll leave in-memory residue.
-  def self.run_shoes_spec_test_code(code, class_name: "TestShoesSpecCode", test_name: "test_shoes_spec")
+  def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
     if @shoes_spec_init
       raise MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
     end
     @shoes_spec_init = true
+
+    require "scarpe/components/minitest_export_reporter"
+    Minitest::Reporters::ShoesExportReporter.activate!
+
+    class_name ||= ENV["SHOES_MINITEST_CLASS_NAME"] || "TestShoesSpecCode"
+    test_name ||= ENV["SHOES_MINITEST_METHOD_NAME"] || "test_shoes_spec"
 
     require_relative "cats_cradle"
 

--- a/lib/scarpe/shoes_spec.rb
+++ b/lib/scarpe/shoes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest"
-require "scarpe/cats_cradle" # Currently needed for CCHelpers
+require "scarpe/cats_cradle"
 require "scarpe/components/string_helpers"
 
 # Test framework code to allow Scarpe to execute Shoes-Spec test code.
@@ -23,6 +23,15 @@ module Scarpe::Test
     # But this will normally run in a subprocess. So we need
     # to run Minitest tests and then export the results.
 
+    # We create a test object based on CatsCradle, which will
+    # run the test as straight-line code, wait for appropriate
+    # events and generally make things well-behaved. But the
+    # test DSL isn't CatsCradle. It's based on Minitest and
+    # ShoesSpecTest (see below).
+    #
+    # Note that that means that using CatsCradle to "bounce"
+    # control back and forth for evented tricks isn't really
+    # an option. We may need to revisit all of this later...
     test_obj = Object.new
     class << test_obj
       include Scarpe::Test::CatsCradle
@@ -42,13 +51,66 @@ module Scarpe::Test
     test_name = "test_" + test_name unless test_name.start_with?("test_")
     test_class.define_method(test_name) do
       eval(code)
-      #test_obj.instance_variable_get(:@cc_instance).instance_eval(code)
     end
+  end
+end
+
+# This is based on the CatsCradle proxies initially, but will diverge over time
+class Scarpe::ShoesSpecProxy
+  attr_reader :obj
+  attr_reader :linkable_id
+  attr_reader :display
+
+  JS_EVENTS = [:click, :hover, :leave]
+
+  def initialize(obj)
+    @obj = obj
+    @linkable_id = obj.linkable_id
+    @display = ::Shoes::DisplayService.display_service.query_display_drawable_for(obj.linkable_id)
+  end
+
+  def method_missing(method, ...)
+    if @obj.respond_to?(method)
+      self.singleton_class.define_method(method) do |*args, **kwargs, &block|
+        @obj.send(method, *args, **kwargs, &block)
+      end
+      send(method, ...)
+    else
+      super # raise an exception
+    end
+  end
+
+  def trigger(event_name, *args)
+    name = "#{@linkable_id}-#{event_name}"
+    Scarpe::Webview::DisplayService.instance.app.handle_callback(name, *args)
+  end
+
+  JS_EVENTS.each do |ev|
+    define_method "trigger_#{ev}" do |*args|
+      trigger(ev, *args)
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    @obj.respond_to_missing?(method_name, include_private)
   end
 end
 
 # When running ShoesSpec tests, we create a parent class for all of them
 # with the appropriate convenience methods and accessors.
 class Scarpe::ShoesSpecTest < Minitest::Test
-  include Scarpe::Test::CCHelpers
+  Shoes::Drawable.drawable_classes.each do |drawable_class|
+    finder_name = drawable_class.dsl_name
+
+    define_method(finder_name) do |*args|
+      app = Shoes::App.instance
+
+      drawables = app.find_drawables_by(drawable_class, *args)
+      raise Scarpe::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
+      raise Scarpe::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
+
+      Scarpe::ShoesSpecProxy.new(drawables[0])
+    end
+  end
+
 end

--- a/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
@@ -62,7 +62,7 @@ module Minitest
           }
         end
 
-        out_file = ENV["SHOES_MINITEST_EXPORT_FILE"]
+        out_file = File.expand_path ENV["SHOES_MINITEST_EXPORT_FILE"]
         puts "Writing Minitest results to #{out_file.inspect}."
         File.write(out_file, JSON.dump(results))
       end

--- a/scarpe-components/lib/scarpe/components/minitest_import_runnable.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_import_runnable.rb
@@ -4,7 +4,7 @@ require "minitest"
 require "json"
 require "json/add/exception"
 
-class Scarpe; module Components; end; end
+module Scarpe; module Components; end; end
 module Scarpe::Components::ImportRunnables
   # Minitest Runnables are unusual - we expect to declare a class (like a Test) with
   # a lot of methods to run. The ImportRunnable is a single Runnable. But whenever
@@ -20,12 +20,11 @@ module Scarpe::Components::ImportRunnables
   class ImportRunnable #< Minitest::Runnable
     # Import JSON from an exported Minitest run. Note that running this multiple
     # times with overlapping class names may be really bad.
-    def self.import_json(json_file)
+    def self.import_json_data(data)
       @imported_classes ||= {}
       @imported_tests ||= {}
 
-      data = JSON.load(File.read json_file)
-      data.each do |item|
+      JSON.parse(data).each do |item|
         klass = item["klass"]
         meth = item["name"]
         @imported_tests[klass] ||= {}


### PR DESCRIPTION
### Description

As I work toward ShoesSpec (see https://github.com/scarpe-team/shoes-spec/), I'm adding capabilities to the queryable object proxies.

Add basic click/hover/leave events to ShoesSpec proxy objects.

### Checklist

- [X] Run tests locally
