### PR TITLE
When adding alerts or fonts, modify just the alerts or fonts, don't do full redraw

### DIFF
--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -750,6 +750,7 @@ class Scarpe::Webview::WebWrangler
     # @param html_id [String] the HTML ID for the DOM element
     def initialize(html_id)
       @webwrangler = ::Scarpe::Webview::DisplayService.instance.wrangler
+      raise Scarpe::MissingWranglerError, "Can't get WebWrangler!" unless @webwrangler
       @html_id = html_id
     end
 


### PR DESCRIPTION
### Description

Before, the doc root would just redraw everything when an alert or font got added.

### Checklist

- [x] Run tests locally
