### PR TITLE
Move progress-bar rendering to Calzini and Tiranti.

### DIFF
--- a/lib/scarpe/wv/progress.rb
+++ b/lib/scarpe/wv/progress.rb
@@ -6,21 +6,14 @@ module Scarpe::Webview
       super
     end
 
+    # For now do *not* catch properties_changed and do a small update.
+    # Tiranti updates some additional fields (e.g. aria-valuenow) that
+    # Calzini does not. We'll want Calzini and Tiranti to handle the
+    # updates more for themselves. See issue #419 for updates on how
+    # we'll handle this. But for right now we re-render the whole
+    # drawable every time we change the progress fraction.
     def element
-      HTML.render do |h|
-        h.progress(id: html_id, style: style, max: 1, value: @fraction) do
-        end
-      end
-    end
-
-    private
-
-    def style
-      styles = {}
-
-      #ADD YOUR STYLES HERE
-
-      styles.compact
+      render("progress")
     end
   end
 end

--- a/scarpe-components/lib/scarpe/components/calzini/misc.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/misc.rb
@@ -90,6 +90,12 @@ module Scarpe::Components::Calzini
     end
   end
 
+  def progress_element(props)
+    HTML.render do |h|
+      h.progress(id: html_id, style: drawable_style(props), role: "progressbar", "aria-valuenow": props["fraction"], "aria-valuemin": 0.0, "aria-valuemax": 1.0, max: 1, value: props["fraction"])
+    end
+  end
+
   private
 
   def edit_box_style(props)

--- a/scarpe-components/lib/scarpe/components/tiranti.rb
+++ b/scarpe-components/lib/scarpe/components/tiranti.rb
@@ -154,6 +154,15 @@ module Scarpe::Components::Tiranti
     end
   end
 
+  def progress_element(props)
+    HTML.render do |h|
+      h.div(class: "progress", style: "width: 90%") do
+        pct = "%.1f" % ((props["fraction"] || 0.0) * 100.0)
+        h.div(class: "progress-bar progress-bar-striped progress-bar-animated", role: "progressbar", "aria-valuenow": pct, "aria-valuemin": 0, "aria-valuemax": 100, style: "width: #{pct}%")
+      end
+    end
+  end
+
   # para_element is a bit of a hard one, since it does not-entirely-trivial
   # mapping between display objects and IDs. But we don't want Calzini
   # messing with the display service or display objects.


### PR DESCRIPTION
### Description

Before progress bars had HTML rendering directly in the Webview Drawable. By moving to Calzini, it's easy to override with Tiranti to get a nice Bootstrap-friendly version (see image below.)

As it says in the comment here, the constant re-rendering is because we're not catching properties_changed and so we're letting it fall back to re-rendering the whole DOM. Once #437 is merged the comment will be accurate and it will re-render only the progress bar. But right now we shouldn't do better than that because Calzini and Tiranti have a different set of styles/attributes that would need to be updated, so we can't have a properties_changed without it knowing what needs updating. This is the problem that inspired issue #419.

### Image(if needed, helps for a faster review)

<img width="412" alt="Screenshot 2023-10-26 at 15 33 08" src="https://github.com/scarpe-team/scarpe/assets/82408/5f18dbb4-f41e-4bcb-bada-9138e625f13d">

### Checklist

- [X] Run tests locally
