### PR TITLE
More fixes for Shoes-Spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     name: Tests
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Install dependencies
         run: brew install pkg-config portaudio

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -202,7 +202,9 @@ module Shoes
     def find_drawables_by(*specs)
       drawables = all_drawables
       specs.each do |spec|
-        if spec.is_a?(Class)
+        if spec == Shoes::App
+          drawables = [Shoes::App.instance]
+        elsif spec.is_a?(Class)
           drawables.select! { |w| spec === w }
         elsif spec.is_a?(Symbol) || spec.is_a?(String)
           s = spec.to_s
@@ -222,6 +224,13 @@ module Shoes
               raise InvalidAttributeValueError, "Can't find top-level instance variable: #{spec.inspect}!"
             end
           else
+            if s.start_with?("id:")
+              find_id = Integer(s[3..-1])
+              drawable = Shoes::Drawable.drawable_by_id(find_id)
+              drawables &= [drawable]
+            else
+              raise InvalidAttributeValueError, "Don't know how to find drawables by #{spec.inspect}!"
+            end
           end
         else
           raise(InvalidAttributeValueError, "Don't know how to find drawables by #{spec.inspect}!")

--- a/lacci/lib/shoes/drawable.rb
+++ b/lacci/lib/shoes/drawable.rb
@@ -163,6 +163,22 @@ module Shoes
       generate_debug_id
     end
 
+    # Calling stack.app or drawable.app will execute the block
+    # with the Shoes::App as self, and with that stack or
+    # flow as the current slot.
+    #
+    # @incompatibility In Shoes Classic this is the only way
+    #   to change self, while Scarpe will also change self
+    #   with the other Slot Manipulation methods: #clear,
+    #   #append, #prepend, #before and #after.
+    #
+    # @return [Shoes::App] the Shoes app
+    # @yield the block to call with the Shoes App as self
+    def app(&block)
+      Shoes::App.instance.with_slot(self, &block) if block_given?
+      Shoes::App.instance
+    end
+
     private
 
     def generate_debug_id

--- a/lacci/lib/shoes/drawable.rb
+++ b/lacci/lib/shoes/drawable.rb
@@ -14,7 +14,7 @@ module Shoes
     include Shoes::Log
     include Shoes::Colors
 
-    # All Drawables have these so they go in Shoes::Drawable
+    # All Drawables have these so they go in Shoes::Drawable and are inherited
     @shoes_events = ["parent", "destroy", "prop_change"]
 
     class << self
@@ -90,6 +90,24 @@ module Shoes
         @drawable_id_counter
       end
 
+      def register_drawable_id(id, drawable)
+        @drawables_by_id ||= {}
+        @drawables_by_id[id] = drawable
+      end
+
+      def unregister_drawable_id(id)
+        @drawables_by_id ||= {}
+        @drawables_by_id.delete(id)
+      end
+
+      def drawable_by_id(id, none_ok: false)
+        val = @drawables_by_id[id]
+        unless val || none_ok
+          raise "No Drawable Found! #{@drawables_by_id.inspect}"
+        end
+        val
+      end
+
       private
 
       def linkable_properties
@@ -159,6 +177,7 @@ module Shoes
       end
 
       super(linkable_id: Shoes::Drawable.allocate_drawable_id)
+      Shoes::Drawable.register_drawable_id(self.linkable_id, self)
 
       generate_debug_id
     end
@@ -296,6 +315,7 @@ module Shoes
       @destroyed = true
       unsub_all_shoes_events
       send_shoes_event(event_name: "destroy", target: linkable_id)
+      Shoes::Drawable.unregister_drawable_id(linkable_id)
     end
     alias_method :remove, :destroy
 

--- a/lacci/lib/shoes/drawables/list_box.rb
+++ b/lacci/lib/shoes/drawables/list_box.rb
@@ -11,7 +11,7 @@ module Shoes
 
     shoes_events :change
 
-    def initialize(args = {}, &block)
+    def initialize(**args, &block)
       super
 
       @items = args[:items] || []

--- a/lacci/lib/shoes/drawables/slot.rb
+++ b/lacci/lib/shoes/drawables/slot.rb
@@ -52,22 +52,6 @@ class Shoes::Slot < Shoes::Drawable
     false
   end
 
-  # Calling stack.app or flow.app will execute the block
-  # with the Shoes::App as self, and with that stack or
-  # flow as the current slot.
-  #
-  # @incompatibility Shoes Classic will only change self
-  #   via this method, while Scarpe will also change self
-  #   with the other Slot Manipulation methods: #clear,
-  #   #append, #prepend, #before and #after.
-  #
-  # @return [Shoes::App] the Shoes app
-  # @yield the block to call with the Shoes App as self
-  def app(&block)
-    Shoes::App.instance.with_slot(self, &block) if block_given?
-    Shoes::App.instance
-  end
-
   # Remove all children from this drawable. If a block
   # is given, call the block to replace the children with
   # new contents from that block.


### PR DESCRIPTION
### Description

Move app method from Slot to Drawable since it should be available on other drawables according to Shoes3 docs.

Fix list_box initialize args.

Increase build time - we were getting occasional failures with Tiranti examples.

Register drawables' linkable_ids with Shoes::App so we can search by them.

### Checklist

- [ ] Run tests locally
