### PR TITLE
Niente, a "no-op" display service for testing

### DIFF
--- a/lacci/lib/scarpe/niente.rb
+++ b/lacci/lib/scarpe/niente.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Niente -- Italian for "nothing" -- is a null display service
+# that doesn't display anything. It does very little, while
+# keeping a certain amount of "mental model" or schema of
+# how a real display service should act.
+module Niente; end
+
+require_relative "niente/logger"
+Shoes::Log.instance = Niente::LogImpl.new
+
+require_relative "niente/drawable"
+require_relative "niente/app"
+require_relative "niente/display_service"
+
+if ENV["SHOES_SPEC_TEST"]
+  require_relative "niente/shoes_spec"
+  Shoes::Spec.instance = Niente::Test
+end
+
+Shoes::DisplayService.set_display_service_class(Niente::DisplayService)
+

--- a/lacci/lib/scarpe/niente/app.rb
+++ b/lacci/lib/scarpe/niente/app.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Niente
+  class App < Drawable
+    def initialize(properties)
+      super
+
+      bind_shoes_event(event_name: "init") { init }
+      bind_shoes_event(event_name: "run") { run }
+      bind_shoes_event(event_name: "destroy") { destroy }
+    end
+
+    def init
+    end
+
+    def run
+      send_shoes_event("wait", event_name: "custom_event_loop")
+    end
+
+    def destroy
+    end
+  end
+end

--- a/lacci/lib/scarpe/niente/display_service.rb
+++ b/lacci/lib/scarpe/niente/display_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Niente
+  # This is a "null" DisplayService, doing as little as it
+  # can get away with.
+  class DisplayService < Shoes::DisplayService
+    include Shoes::Log
+
+    class << self
+      attr_accessor :instance
+    end
+
+    def initialize
+      if Niente::DisplayService.instance
+        raise Scarpe::SingletonError, "ERROR! This is meant to be a singleton!"
+      end
+
+      Niente::DisplayService.instance = self
+
+      log_init("Niente::DisplayService")
+      super()
+    end
+
+    # Create a fake display drawable for a specific Shoes drawable, and pair it with
+    # the linkable ID for this Shoes drawable.
+    #
+    # @param drawable_class_name [String] The class name of the Shoes drawable, e.g. Shoes::Button
+    # @param drawable_id [String] the linkable ID for drawable events
+    # @param properties [Hash] a JSON-serialisable Hash with the drawable's Shoes styles
+    # @param is_widget [Boolean] whether the class is a user-defined Shoes::Widget subclass
+    # @return [Webview::Drawable] the newly-created Webview drawable
+    def create_display_drawable_for(drawable_class_name, drawable_id, properties, is_widget:)
+      existing = query_display_drawable_for(drawable_id, nil_ok: true)
+      if existing
+        @log.warn("There is already a display drawable for #{drawable_id.inspect}! Returning #{existing.class.name}.")
+        return existing
+      end
+
+      if drawable_class_name == "App"
+        @app = Niente::App.new(properties)
+        set_drawable_pairing(drawable_id, @app)
+
+        return @app
+      end
+
+      display_drawable = Niente::Drawable.new(properties)
+      display_drawable.shoes_type = drawable_class_name
+      set_drawable_pairing(drawable_id, display_drawable)
+
+      return display_drawable
+    end
+
+    # Destroy the display service and the app. Quit the process (eventually.)
+    #
+    # @return [void]
+    def destroy
+      @app.destroy
+      DisplayService.instance = nil
+    end
+  end
+end
+

--- a/lacci/lib/scarpe/niente/drawable.rb
+++ b/lacci/lib/scarpe/niente/drawable.rb
@@ -1,0 +1,57 @@
+module Niente
+  class Drawable < Shoes::Linkable
+    attr_reader :shoes_linkable_id
+    attr_reader :parent
+    attr_reader :children
+
+    attr_accessor :shoes_type
+
+    def initialize(props)
+      @shoes_linkable_id = props.delete("shoes_linkable_id") || props.delete(:shoes_linkable_id)
+      @data = props
+
+      super(linkable_id: @shoes_linkable_id)
+
+      bind_shoes_event(event_name: "parent", target: shoes_linkable_id) do |new_parent_id|
+        display_parent = DisplayService.instance.query_display_drawable_for(new_parent_id)
+        if @parent != display_parent
+          set_parent(display_parent)
+        end
+      end
+
+      # When Shoes drawables change properties, we get a change notification here
+      bind_shoes_event(event_name: "prop_change", target: shoes_linkable_id) do |prop_changes|
+        prop_changes.each do |k, v|
+          instance_variable_set("@" + k, v)
+        end
+        properties_changed(prop_changes) if respond_to?(:properties_changed)
+      end
+
+      bind_shoes_event(event_name: "destroy", target: shoes_linkable_id) do
+      end
+    end
+
+    def set_parent(new_parent)
+      @parent&.remove_child(self)
+      new_parent&.add_child(self)
+      @parent = new_parent
+    end
+
+    # Do not call directly, use set_parent
+    def remove_child(child)
+      @children ||= []
+      unless @children.include?(child)
+        STDERR.puts("remove_child: no such child(#{child.inspect}) for"\
+          " parent(#{parent.inspect})!")
+      end
+      @children.delete(child)
+    end
+
+    # Do not call directly, use set_parent
+    def add_child(child)
+      @children ||= []
+      @children << child
+    end
+  end
+end
+

--- a/lacci/lib/scarpe/niente/logger.rb
+++ b/lacci/lib/scarpe/niente/logger.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "shoes/log"
+require "json"
+
+module Niente; end
+class Niente::LogImpl
+  include Shoes::Log # for constants
+
+  class PrintLogger
+    def initialize(_)
+    end
+
+    [:error, :warn, :debug, :info].each do |level|
+      define_method(level) do |msg|
+        puts "#{level}: #{msg}"
+      end
+    end
+  end
+
+  def logger_for_component(component)
+    PrintLogger.new(component.to_s)
+  end
+
+  def configure_logger(log_config)
+  end
+end
+
+#Shoes::Log.instance = Niente::LogImpl.new

--- a/lacci/lib/scarpe/niente/shoes_spec.rb
+++ b/lacci/lib/scarpe/niente/shoes_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "minitest"
+require "scarpe/components/string_helpers"
+
+module Niente; end
+
+class Niente::Test
+  def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
+    if @shoes_spec_init
+      raise MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
+    end
+    @shoes_spec_init = true
+
+    require "scarpe/components/minitest_export_reporter"
+    Minitest::Reporters::ShoesExportReporter.activate!
+
+    class_name ||= ENV["SHOES_MINITEST_CLASS_NAME"] || "TestShoesSpecCode"
+    test_name ||= ENV["SHOES_MINITEST_METHOD_NAME"] || "test_shoes_spec"
+
+    Shoes::DisplayService.subscribe_to_event("heartbeat", nil) do
+      unless @hb_init
+        Minitest.run []
+        Shoes::App.instance.destroy
+      end
+      @hb_init = true
+    end
+
+    test_class = Class.new(Niente::ShoesSpecTest)
+    Object.const_set(Scarpe::Components::StringHelpers.camelize(class_name), test_class)
+    test_name = "test_" + test_name unless test_name.start_with?("test_")
+    test_class.define_method(test_name) do
+      STDERR.puts "Started running #{class_name.inspect}::#{test_name.inspect}"
+      eval(code)
+    end
+  end
+end
+
+class Niente::ShoesSpecTest < Minitest::Test
+  Shoes::Drawable.drawable_classes.each do |drawable_class|
+    finder_name = drawable_class.dsl_name
+
+    define_method(finder_name) do |*args|
+      app = Shoes::App.instance
+
+      drawables = app.find_drawables_by(drawable_class, *args)
+      raise Scarpe::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
+      raise Scarpe::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
+
+      Niente::ShoesSpecProxy.new(drawables[0])
+    end
+  end
+end
+
+class Niente::ShoesSpecProxy
+  attr_reader :obj
+  attr_reader :linkable_id
+  attr_reader :display
+
+  def initialize(obj)
+    @obj = obj
+    @linkable_id = obj.linkable_id
+    @display = ::Shoes::DisplayService.display_service.query_display_drawable_for(obj.linkable_id)
+  end
+
+  def method_missing(method, ...)
+    if @obj.respond_to?(method)
+      self.singleton_class.define_method(method) do |*args, **kwargs, &block|
+        @obj.send(method, *args, **kwargs, &block)
+      end
+      send(method, ...)
+    else
+      super # raise an exception
+    end
+  end
+
+  JS_EVENTS = [:click, :hover, :leave]
+  JS_EVENTS.each do |event|
+    define_method("trigger_#{event}") do |*args, **kwargs|
+      ::Shoes::DisplayService.dispatch_event(event.to_s, @linkable_id, *args, **kwargs)
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    @obj.respond_to_missing?(method_name, include_private)
+  end
+end

--- a/lacci/lib/shoes-spec.rb
+++ b/lacci/lib/shoes-spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Shoes
+  # A Scarpe-compatible display service can set Shoes::Spec.instance to
+  # a ShoesSpec testing class, and use it to run Shoes-Spec code.
+  # A Shoes application should never do this. It's intended to be used
+  # by display services.
   module Spec
     def self.instance
       @instance
@@ -12,6 +16,78 @@ class Shoes
       end
 
       @instance = spec_inst
+    end
+  end
+
+  # ShoesSpec testing objects can optionally inherit from this object,
+  # which shows the ShoesSpec testing API.
+  #
+  # @see {Shoes::Spec.instance=}
+  class SpecInstance
+    # Once a Shoes app has been created, this method can be called to
+    # execute Shoes-Spec testing code for that application. Shoes-Spec
+    # uses Minitest for most of its APIs, and Minitest generally reports
+    # results with a class name and test name. If those aren't passed
+    # explicitly, the SpecInstance can choose reasonable defaults.
+    #
+    # The test code should be set up to run automatically from the
+    # display service's existing hooks. For instance, the code might
+    # run in response to the first heartbeat, if the display service
+    # uses heartbeats.
+    #
+    # The test code will export assertion data in its native format.
+    # Multiple display services choose to use the Scarpe-Component
+    # for Minitest data export, which is straightforward to import
+    # into the Shoes-Spec test harness.
+    #
+    # @param code [String] the ShoesSpec code to execute
+    # @param class_name [String|NilClass] the Minitest class name for reporting or nil
+    # @param test_name [String|NilClass] the Minitest test name for reporting or nil
+    # @return [void]
+    def run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
+      raise "Child class should override this!"
+    end
+  end
+
+  # ShoesSpec instances support finder methods like button() that return
+  # a proxy to the corresponding drawable. Those proxies should support
+  # standard Shoes::Drawable methods, including the ones appropriate to
+  # the same drawable object. They should also support certain other
+  # testing-specific methods like "trigger_click" that are used to
+  # simulate display-side events during testing.
+  #
+  # Keep in mind that a proxy will often be in a different process from
+  # the Shoes app. So the proxy can't portably return the object or
+  # display object, though it could possibly return another proxy for such
+  # a thing.
+  class SpecProxy
+    # The proxy will have finder methods for all drawables, such as
+    # button(), edit_line(), etc. How to document those?
+
+    # Trigger a click on a button or button-like drawable. Not every
+    # drawable will support this operation.
+    def trigger_click()
+      raise "Child class should override this!"
+    end
+
+    # Trigger a hover over a hoverable drawable. Not every
+    # drawable will support this operation. A drawable that supports
+    # hover should support leave and vice-versa.
+    def trigger_hover()
+      raise "Child class should override this!"
+    end
+
+    # Trigger ending hover over a hoverable drawable. Not every
+    # drawable will support this operation. A drawable that supports
+    # hover should support leave and vice-versa.
+    def trigger_leave()
+      raise "Child class should override this!"
+    end
+
+    # Trigger a change in value for a drawable like a list_box
+    # with multiple values.
+    def trigger_change(value)
+      raise "Child class should override this!"
     end
   end
 end

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -168,7 +168,9 @@ class Shoes
       case @event_loop_type
       when "wait"
         # Display lib wants us to busy-wait instead of it.
-        sleep 0.1 until @do_shutdown
+        until @do_shutdown
+          Shoes::DisplayService.dispatch_event("heartbeat", nil)
+        end
       when "displaylib"
         # If run event returned, that means we're done.
         destroy

--- a/lacci/lib/shoes/display_service.rb
+++ b/lacci/lib/shoes/display_service.rb
@@ -147,6 +147,7 @@ class Shoes
     end
 
     def query_display_drawable_for(id, nil_ok: false)
+      @display_drawable_for ||= {}
       display_drawable = @display_drawable_for[id]
       unless display_drawable || nil_ok
         raise "Could not find display drawable for linkable ID #{id.inspect}!"
@@ -173,6 +174,7 @@ class Shoes
     def initialize(linkable_id: object_id)
       @linkable_id = linkable_id
       @subscriptions = {}
+      @display_drawable_for ||= {}
     end
 
     def send_self_event(*args, event_name:, **kwargs)

--- a/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
@@ -57,12 +57,8 @@ module Minitest
             assertions: result.assertions,
             failures: failures,
             time: result.time,
-            metadata: result.metadata,
-            source_location: begin
-              result.source_location
-            rescue
-              ["unknown", -1]
-            end,
+            metadata: (result.respond_to?(:metadata) ? result.metadata : {}),
+            source_location: (result.source_location rescue ["unknown", -1]),
           }
         end
 


### PR DESCRIPTION
### Description

Niente ("nothing" in Italian) is a no-dependencies no-display display library. The idea is that over time, Niente will grow to a "mental model" of a Shoes app, passing most (all?) Shoes-Spec tests. It would be really useful to add Shoes-Spec tests for certain things that are hard to support with Wasm or Webview (e.g. multiple windows), but would be easy to add in a no-op display service.

### Checklist

- [x] Run tests locally
