### PR TITLE
Error cleanup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ PATH
   remote: lacci
   specs:
     lacci (0.3.0)
+      scarpe-components
 
 PATH
   remote: scarpe-components

--- a/lacci/Gemfile
+++ b/lacci/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "scarpe-components", path: "../scarpe-components"
+
 gem "rake", "~> 13.0"
 
 group :test do

--- a/lacci/Gemfile.lock
+++ b/lacci/Gemfile.lock
@@ -1,7 +1,13 @@
 PATH
+  remote: ../scarpe-components
+  specs:
+    scarpe-components (0.3.0)
+
+PATH
   remote: .
   specs:
     lacci (0.3.0)
+      scarpe-components
 
 GEM
   remote: https://rubygems.org/
@@ -66,6 +72,7 @@ DEPENDENCIES
   redcarpet
   rubocop (~> 1.21)
   rubocop-shopify
+  scarpe-components!
   yard
 
 BUNDLED WITH

--- a/lacci/lacci.gemspec
+++ b/lacci/lacci.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  #spec.add_dependency ""
+  spec.add_dependency "scarpe-components" # Scarpe-Components has no dependencies, and includes useful infrastructure
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lacci/lib/lacci/scarpe_core.rb
+++ b/lacci/lib/lacci/scarpe_core.rb
@@ -15,6 +15,7 @@ end
 module Scarpe; end
 
 # The base error class for Scarpe errors, but not necessarily {Shoes::Error}s
+class Shoes::Error < StandardError; end
 class Scarpe::Error < StandardError; end
 
 require "lacci/version"

--- a/lacci/lib/scarpe/niente/display_service.rb
+++ b/lacci/lib/scarpe/niente/display_service.rb
@@ -12,7 +12,7 @@ module Niente
 
     def initialize
       if Niente::DisplayService.instance
-        raise Scarpe::SingletonError, "ERROR! This is meant to be a singleton!"
+        raise Shoes::SingletonError, "ERROR! This is meant to be a singleton!"
       end
 
       Niente::DisplayService.instance = self

--- a/lacci/lib/scarpe/niente/shoes_spec.rb
+++ b/lacci/lib/scarpe/niente/shoes_spec.rb
@@ -8,7 +8,7 @@ module Niente; end
 class Niente::Test
   def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
     if @shoes_spec_init
-      raise MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
+      raise Shoes::Errors::MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
     end
     @shoes_spec_init = true
 
@@ -44,8 +44,8 @@ class Niente::ShoesSpecTest < Minitest::Test
       app = Shoes::App.instance
 
       drawables = app.find_drawables_by(drawable_class, *args)
-      raise Scarpe::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
-      raise Scarpe::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
+      raise Shoes::Errors::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
+      raise Shoes::Errors::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
 
       Niente::ShoesSpecProxy.new(drawables[0])
     end

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -25,7 +25,7 @@ class Shoes
 
       if Shoes::App.instance
         @log.error("Trying to create a second Shoes::App in the same process! Fail!")
-        raise Scarpe::TooManyInstancesError, "Cannot create multiple Shoes::App objects!"
+        raise Shoes::Errors::TooManyInstancesError, "Cannot create multiple Shoes::App objects!"
       else
         Shoes::App.instance = self
       end
@@ -79,7 +79,7 @@ class Shoes
       end
 
       @watch_for_event_loop = bind_shoes_event(event_name: "custom_event_loop") do |loop_type|
-        raise(InvalidAttributeValueError, "Unknown event loop type: #{loop_type.inspect}!") unless CUSTOM_EVENT_LOOP_TYPES.include?(loop_type)
+        raise(Shoes::Errors::InvalidAttributeValueError, "Unknown event loop type: #{loop_type.inspect}!") unless CUSTOM_EVENT_LOOP_TYPES.include?(loop_type)
 
         @event_loop_type = loop_type
       end
@@ -178,7 +178,7 @@ class Shoes
         # We can just return to the main event loop. But we shouldn't call destroy.
         # Presumably some event loop *outside* our event loop is handling things.
       else
-        raise InvalidAttributeValueError, "Internal error! Incorrect event loop type: #{@event_loop_type.inspect}!"
+        raise Shoes::Errors::InvalidAttributeValueError, "Internal error! Incorrect event loop type: #{@event_loop_type.inspect}!"
       end
     end
 
@@ -217,13 +217,13 @@ class Shoes
               global_value = eval s
               drawables &= [global_value]
             rescue
-              raise InvalidAttributeValueError, "Error getting global variable: #{spec.inspect}"
+              raise Shoes::Errors::InvalidAttributeValueError, "Error getting global variable: #{spec.inspect}"
             end
           when "@"
             if Shoes::App.instance.instance_variables.include?(spec.to_sym)
               drawables &= [self.instance_variable_get(spec)]
             else
-              raise InvalidAttributeValueError, "Can't find top-level instance variable: #{spec.inspect}!"
+              raise Shoes::Errors::InvalidAttributeValueError, "Can't find top-level instance variable: #{spec.inspect}!"
             end
           else
             if s.start_with?("id:")
@@ -231,11 +231,11 @@ class Shoes
               drawable = Shoes::Drawable.drawable_by_id(find_id)
               drawables &= [drawable]
             else
-              raise InvalidAttributeValueError, "Don't know how to find drawables by #{spec.inspect}!"
+              raise Shoes::Errors::InvalidAttributeValueError, "Don't know how to find drawables by #{spec.inspect}!"
             end
           end
         else
-          raise(InvalidAttributeValueError, "Don't know how to find drawables by #{spec.inspect}!")
+          raise(Shoes::Errors::InvalidAttributeValueError, "Don't know how to find drawables by #{spec.inspect}!")
         end
       end
       drawables
@@ -285,7 +285,7 @@ class Shoes::App < Shoes::Drawable
   # Shape DSL methods
 
   def move_to(x, y)
-    raise(InvalidAttributeValueError, "Pass only Numeric arguments to move_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
+    raise(Shoes::Errors::InvalidAttributeValueError, "Pass only Numeric arguments to move_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
 
     if current_slot.is_a?(::Shoes::Shape)
       current_slot.add_shape_command(["move_to", x, y])
@@ -293,7 +293,7 @@ class Shoes::App < Shoes::Drawable
   end
 
   def line_to(x, y)
-    raise(InvalidAttributeValueError, "Pass only Numeric arguments to line_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
+    raise(Shoes::Errors::InvalidAttributeValueError, "Pass only Numeric arguments to line_to!") unless x.is_a?(Numeric) && y.is_a?(Numeric)
 
     if current_slot.is_a?(::Shoes::Shape)
       current_slot.add_shape_command(["line_to", x, y])

--- a/lacci/lib/shoes/display_service.rb
+++ b/lacci/lib/shoes/display_service.rb
@@ -134,12 +134,12 @@ class Shoes
 
     def set_drawable_pairing(id, display_drawable)
       if id.nil?
-        raise BadLinkableIdError, "Linkable ID may not be nil!"
+        raise Shoes::Errors::BadLinkableIdError, "Linkable ID may not be nil!"
       end
 
       @display_drawable_for ||= {}
       if @display_drawable_for[id]
-        raise DuplicateCreateDrawableError, "There is already a drawable for #{id.inspect}! Not setting a new one."
+        raise Shoes::Errors::DuplicateCreateDrawableError, "There is already a drawable for #{id.inspect}! Not setting a new one."
       end
 
       @display_drawable_for[id] = display_drawable

--- a/lacci/lib/shoes/drawable.rb
+++ b/lacci/lib/shoes/drawable.rb
@@ -55,7 +55,7 @@ class Shoes
         hashes = shoes_style_hashes
 
         h = hashes.detect { |hash| hash[:name] == prop_name }
-        raise(Shoes::NoSuchStyleError, "Can't find property #{prop_name.inspect} in #{self} property list: #{hashes.inspect}!") unless h
+        raise(Shoes::Errors::NoSuchStyleError, "Can't find property #{prop_name.inspect} in #{self} property list: #{hashes.inspect}!") unless h
 
         return value if h[:validator].nil?
 
@@ -229,7 +229,7 @@ class Shoes
     end
 
     def bind_self_event(event_name, &block)
-      raise(Shoes::NoLinkableIdError, "Drawable has no linkable_id! #{inspect}") unless linkable_id
+      raise(Shoes::Errors::NoLinkableIdError, "Drawable has no linkable_id! #{inspect}") unless linkable_id
 
       validate_event_name(event_name)
 
@@ -270,7 +270,7 @@ class Shoes
         prop_names = self.class.shoes_style_names
         unknown_styles = kwargs.keys.select { |k| !prop_names.include?(k.to_s) }
         unless unknown_styles.empty?
-          raise Shoes::NoSuchStyleError, "Unknown styles for drawable type #{self.class.name}: #{unknown_styles.join(", ")}"
+          raise Shoes::Errors::NoSuchStyleError, "Unknown styles for drawable type #{self.class.name}: #{unknown_styles.join(", ")}"
         end
 
         kwargs.each do |name, val|
@@ -282,7 +282,7 @@ class Shoes
           Shoes::Drawable.drawable_default_styles[args[0]][name.to_sym] = val
         end
       else
-        raise Shoes::InvalidAttributeValueError, "Unexpected arguments to style! args: #{args.inspect}, keyword args: #{kwargs.inspect}"
+        raise Shoes::Errors::InvalidAttributeValueError, "Unexpected arguments to style! args: #{args.inspect}, keyword args: #{kwargs.inspect}"
       end
     end
 
@@ -344,7 +344,7 @@ class Shoes
         prop_name = name_s[0..-2]
         if self.class.shoes_style_name?(prop_name)
           self.class.define_method(name) do |new_value|
-            raise(Shoes::NoLinkableIdError, "Trying to set Shoes styles in an object with no linkable ID! #{inspect}") unless linkable_id
+            raise(Shoes::Errors::NoLinkableIdError, "Trying to set Shoes styles in an object with no linkable ID! #{inspect}") unless linkable_id
 
             new_value = self.class.validate_as(prop_name, new_value)
             instance_variable_set("@" + prop_name, new_value)
@@ -357,7 +357,7 @@ class Shoes
 
       if self.class.shoes_style_name?(name_s)
         self.class.define_method(name) do
-          raise(Shoes::NoLinkableIdError, "Trying to get Shoes styles in an object with no linkable ID! #{inspect}") unless linkable_id
+          raise(Shoes::Errors::NoLinkableIdError, "Trying to get Shoes styles in an object with no linkable ID! #{inspect}") unless linkable_id
 
           instance_variable_get("@" + name_s)
         end

--- a/lacci/lib/shoes/drawables/arc.rb
+++ b/lacci/lib/shoes/drawables/arc.rb
@@ -25,24 +25,24 @@ class Shoes
     def self.convert_to_integer(value, attribute_name)
       begin
         value = Integer(value)
-        raise InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
+        raise Shoes::Errors::InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
 
         value
       rescue ArgumentError
         error_message = "Invalid value '#{value}' provided for attribute '#{attribute_name}'. The value should be a number."
-        raise InvalidAttributeValueError, error_message
+        raise Shoes::Errors::InvalidAttributeValueError, error_message
       end
     end
 
     def self.convert_to_float(value, attribute_name)
       begin
         value = Float(value)
-        raise InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
+        raise Shoes::Errors::InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
 
         value
       rescue ArgumentError
         error_message = "Invalid value '#{value}' provided for attribute '#{attribute_name}'. The value should be a number."
-        raise InvalidAttributeValueError, error_message
+        raise Shoes::Errors::InvalidAttributeValueError, error_message
       end
     end
   end

--- a/lacci/lib/shoes/drawables/arrow.rb
+++ b/lacci/lib/shoes/drawables/arrow.rb
@@ -29,12 +29,12 @@ class Shoes
     def self.convert_to_integer(value, attribute_name)
       begin
         value = Integer(value)
-        raise InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
+        raise Shoes::Errors::InvalidAttributeValueError, "Negative number '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
 
         value
       rescue ArgumentError
         error_message = "Invalid value '#{value}' provided for attribute '#{attribute_name}'. The value should be a number."
-        raise InvalidAttributeValueError, error_message
+        raise Shoes::Errors::InvalidAttributeValueError, error_message
       end
     end
   end

--- a/lacci/lib/shoes/drawables/list_box.rb
+++ b/lacci/lib/shoes/drawables/list_box.rb
@@ -31,7 +31,7 @@ class Shoes
     # @return [void]
     def choose(item)
       unless self.items.include?(item)
-        raise Shoes::NoSuchListItemError, "List items (#{self.items.inspect}) do not contain item #{item.inspect}!"
+        raise Shoes::Errors::NoSuchListItemError, "List items (#{self.items.inspect}) do not contain item #{item.inspect}!"
       end
 
       @chosen = item

--- a/lacci/lib/shoes/drawables/slot.rb
+++ b/lacci/lib/shoes/drawables/slot.rb
@@ -79,8 +79,8 @@ class Shoes::Slot < Shoes::Drawable
   # @yield the block to call to replace children; will be called on the Shoes::App, appending to the called Slot as the current slot
   # @return [void]
   def append(&block)
-    raise(InvalidAttributeValueError, "append requires a block!") unless block_given?
-    raise(InvalidAttributeValueError, "Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
+    raise(Shoes::Errors::InvalidAttributeValueError, "append requires a block!") unless block_given?
+    raise(Shoes::Errors::InvalidAttributeValueError, "Don't append to something that isn't a slot!") unless self.is_a?(Shoes::Slot)
 
     Shoes::App.instance.with_slot(self, &block)
   end

--- a/lacci/lib/shoes/drawables/star.rb
+++ b/lacci/lib/shoes/drawables/star.rb
@@ -26,24 +26,24 @@ class Shoes
     def self.convert_to_integer(value, attribute_name)
       begin
         value = Integer(value)
-        raise InvalidAttributeValueError, "Negative num '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
+        raise Shoes::Errors::InvalidAttributeValueError, "Negative num '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
 
         value
       rescue ArgumentError
         error_message = "Invalid value '#{value}' provided for attribute '#{attribute_name}'. The value should be a number."
-        raise InvalidAttributeValueError, error_message
+        raise Shoes::Errors::InvalidAttributeValueError, error_message
       end
     end
 
     def self.convert_to_float(value, attribute_name)
       begin
         value = Float(value)
-        raise InvalidAttributeValueError, "Negative num '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
+        raise Shoes::Errors::InvalidAttributeValueError, "Negative num '#{value}' not allowed for attribute '#{attribute_name}'" if value < 0
 
         value
       rescue ArgumentError
         error_message = "Invalid value '#{value}' provided for attribute '#{attribute_name}'. The value should be a number."
-        raise InvalidAttributeValueError, error_message
+        raise Shoes::Errors::InvalidAttributeValueError, error_message
       end
     end
   end

--- a/lacci/lib/shoes/errors.rb
+++ b/lacci/lib/shoes/errors.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-class Shoes
+class Shoes; end
+class Shoes::Errors
   class InvalidAttributeValueError < Shoes::Error; end
 
   class TooManyInstancesError < Shoes::Error; end

--- a/lacci/lib/shoes/errors.rb
+++ b/lacci/lib/shoes/errors.rb
@@ -10,6 +10,10 @@ class Shoes::Errors
 
   class DuplicateCreateDrawableError < Shoes::Error; end
 
+  class MultipleDrawablesFoundError < Shoes::Error; end
+
+  class NoDrawablesFoundError < Shoes::Error; end
+
   class NoSuchStyleError < Shoes::Error; end
 
   class NoLinkableIdError < Shoes::Error; end
@@ -17,4 +21,8 @@ class Shoes::Errors
   class BadLinkableIdError < Shoes::Error; end
 
   class UnregisteredShoesEvent < Shoes::Error; end
+
+  class SingletonError < Shoes::Error; end
+
+  class MultipleShoesSpecRunsError < Shoes::Error; end
 end

--- a/lacci/lib/shoes/log.rb
+++ b/lacci/lib/shoes/log.rb
@@ -28,7 +28,7 @@ class Shoes
       attr_reader :current_log_config
 
       def instance=(impl_object)
-        raise(Shoes::TooManyInstancesError, "Already have an instance for Shoes::Log!") if @instance
+        raise(Shoes::Errors::TooManyInstancesError, "Already have an instance for Shoes::Log!") if @instance
 
         @instance = impl_object
       end

--- a/lacci/test/test_helper.rb
+++ b/lacci/test/test_helper.rb
@@ -3,7 +3,61 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "shoes"
 
+require "scarpe/components/unit_test_helpers"
+
 require "minitest/autorun"
 
 require "minitest/reporters"
 Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
+
+# For testing Lacci, it's kind of silly to start a Webview application.
+# They're slow, unreliable and memory-hungry. So instead we start a
+# Niente do-nothing application for a simple API test. It's a lot like
+# mocking.
+class NienteTest < Minitest::Test
+  include ::Scarpe::Test::Helpers
+
+  SCARPE_EXE = File.expand_path("../../exe/scarpe", __dir__)
+
+  def run_test_niente_code(
+    scarpe_app_code,
+    test_extension: ".rb",
+    **opts
+  )
+    with_tempfile(["scarpe_test_app", test_extension], scarpe_app_code) do |test_app_location|
+      run_test_niente_app(test_app_location, **opts)
+    end
+  end
+
+  def run_test_niente_app(
+    test_app_location,
+    app_test_code: "",
+    timeout: 5.0,
+    class_name: self.class,
+    method_name: self.name,
+    display_service: "niente"
+  )
+    with_tempfiles([
+      #["scarpe_log_config.json", JSON.dump(log_config_for_test)],
+      [["shoes_spec_code", ".rb"], app_test_code],
+    ]) do |shoes_spec_path,_|
+      system(
+        "LOCALAPPDATA=\"#{Dir.tmpdir}\" " +
+        "SHOES_SPEC_TEST=\"#{shoes_spec_path}\" " +
+        "SCARPE_DISPLAY_SERVICE=\"#{display_service}\" " +
+        "SHOES_MINITEST_EXPORT_FILE=niente_test.json " +
+        "SHOES_MINITEST_CLASS_NAME=\"#{class_name}\" " +
+        "SHOES_MINITEST_METHOD_NAME=\"#{method_name}\" " +
+        "ruby #{SCARPE_EXE} --dev #{test_app_location}"
+      )
+    end
+
+    # Check if the process exited normally or crashed (segfault, failure, timeout)
+    unless $?.success?
+      assert(false, "Niente app failed with exit code: #{$?.exitstatus}")
+      return
+    end
+
+
+  end
+end

--- a/lacci/test/test_lacci.rb
+++ b/lacci/test/test_lacci.rb
@@ -2,8 +2,17 @@
 
 require_relative "test_helper"
 
-class TestLacci < Minitest::Test
-  def test_truth
-    assert_equal true, true
+class TestLacci < NienteTest
+  def test_simple_button_click
+    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
+    Shoes.app do
+      @b = button "OK" do
+        @b.text = "Yup"
+      end
+    end
+    SHOES_APP
+    button().trigger_click
+    assert_equal "Yup", button().text
+    SHOES_SPEC
   end
 end

--- a/lacci/test/test_shoes_errors.rb
+++ b/lacci/test/test_shoes_errors.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class TestShoesErrors < NienteTest
+  def test_drawable_attr_error
+    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
+    Shoes.app do
+      button "OK" do
+        star 10, 25, "sammy"
+      end
+    end
+    SHOES_APP
+    assert_raises Shoes::Errors::InvalidAttributeValueError do
+      button().trigger_click
+    end
+    SHOES_SPEC
+  end
+
+  def test_too_many_instances_error
+    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
+    $ruby_main = self
+    Shoes.app do
+    end
+    SHOES_APP
+    assert_raises Shoes::Errors::TooManyInstancesError do
+      $ruby_main.instance_eval do
+        Shoes.app {}
+      end
+    end
+    SHOES_SPEC
+  end
+
+  def test_drawables_found_errors
+    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
+    Shoes.app do
+      button "OK"
+      button "Not OK"
+    end
+    SHOES_APP
+    assert_raises Shoes::Errors::MultipleDrawablesFoundError do
+      button()
+    end
+    assert_raises Shoes::Errors::NoDrawablesFoundError do
+      edit_line()
+    end
+    SHOES_SPEC
+  end
+end

--- a/lib/scarpe/cats_cradle.rb
+++ b/lib/scarpe/cats_cradle.rb
@@ -56,8 +56,8 @@ module Scarpe::Test
         app = Shoes::App.instance
 
         drawables = app.find_drawables_by(drawable_class, *args)
-        raise Scarpe::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
-        raise Scarpe::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
+        raise Shoes::Errors::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
+        raise Shoes::Errors::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
 
         CCProxy.new(drawables[0])
       end

--- a/lib/scarpe/errors.rb
+++ b/lib/scarpe/errors.rb
@@ -11,10 +11,6 @@ module Scarpe
 
   class UnexpectedFiberTransferError < Scarpe::Error; end
 
-  class MultipleDrawablesFoundError < Scarpe::Error; end
-
-  class NoDrawablesFoundError < Scarpe::Error; end
-
   class InvalidPromiseError < Scarpe::Error; end
 
   class MissingAppError < Scarpe::Error; end
@@ -42,8 +38,6 @@ module Scarpe
   class NonexistentEvalResultError < Scarpe::Error; end
 
   class JSRedrawError < Scarpe::Error; end
-
-  class SingletonError < Scarpe::Error; end
 
   class ConnectionError < Scarpe::Error; end
 
@@ -76,8 +70,6 @@ module Scarpe
   class InvalidClassError < Scarpe::Error; end
 
   class MissingClassError < Scarpe::Error; end
-
-  class MultipleShoesSpecRunsError < Scarpe::Error; end
 
   class EmptyPageNotSetError < Scarpe::Error; end
 

--- a/lib/scarpe/shoes_spec.rb
+++ b/lib/scarpe/shoes_spec.rb
@@ -13,7 +13,7 @@ module Scarpe::Test
   # They'll leave in-memory residue.
   def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
     if @shoes_spec_init
-      raise MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
+      raise Shoes::Errors::MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
     end
 
     @shoes_spec_init = true
@@ -113,8 +113,8 @@ class Scarpe::ShoesSpecTest < Minitest::Test
       app = Shoes::App.instance
 
       drawables = app.find_drawables_by(drawable_class, *args)
-      raise Scarpe::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
-      raise Scarpe::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
+      raise Shoes::Errors::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
+      raise Shoes::Errors::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
 
       Scarpe::ShoesSpecProxy.new(drawables[0])
     end

--- a/lib/scarpe/wv/webview_local_display.rb
+++ b/lib/scarpe/wv/webview_local_display.rb
@@ -33,7 +33,7 @@ module Scarpe
     # able to create them and look them up.
     def initialize
       if Webview::DisplayService.instance
-        raise Scarpe::SingletonError, "ERROR! This is meant to be a singleton!"
+        raise Shoes::Errors::SingletonError, "ERROR! This is meant to be a singleton!"
       end
 
       Webview::DisplayService.instance = self

--- a/scarpe-components/Gemfile.lock
+++ b/scarpe-components/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ../lacci
   specs:
     lacci (0.3.0)
+      scarpe-components
 
 PATH
   remote: .

--- a/scarpe-components/lib/scarpe/components/html.rb
+++ b/scarpe-components/lib/scarpe/components/html.rb
@@ -60,7 +60,7 @@ class Scarpe::Components::HTML
 
   def tag(name, **attrs, &block)
     if VOID_TAGS.include?(name)
-      raise Shoes::InvalidAttributeValueError, "void tag #{name} cannot have content" if block_given?
+      raise Shoes::Errors::InvalidAttributeValueError, "void tag #{name} cannot have content" if block_given?
 
       @buffer += "<#{name}#{render_attributes(attrs)} />"
     else
@@ -88,7 +88,7 @@ class Scarpe::Components::HTML
     raise Scarpe::InvalidHTMLTag, "no method #{name} for #{self.class.name}" unless TAGS.include?(name)
 
     if VOID_TAGS.include?(name)
-      raise Shoes::InvalidAttributeValueError, "void tag #{name} cannot have content" if block_given?
+      raise Shoes::Errors::InvalidAttributeValueError, "void tag #{name} cannot have content" if block_given?
 
       @buffer += "<#{name}#{render_attributes(*args)} />"
     else

--- a/scarpe-components/lib/scarpe/components/modular_logger.rb
+++ b/scarpe-components/lib/scarpe/components/modular_logger.rb
@@ -32,7 +32,7 @@ module Scarpe
       when "fatal"
         :fatal
       else
-        raise Shoes::InvalidAttributeValueError, "Don't know how to treat #{data.inspect} as a logger severity!"
+        raise Shoes::Errors::InvalidAttributeValueError, "Don't know how to treat #{data.inspect} as a logger severity!"
       end
     end
 
@@ -45,7 +45,7 @@ module Scarpe
       when String
         Logging.appenders.file data, layout: @custom_log_layout
       else
-        raise Shoes::InvalidAttributeValueError, "Don't know how to convert #{data.inspect} to an appender!"
+        raise Shoes::Errors::InvalidAttributeValueError, "Don't know how to convert #{data.inspect} to an appender!"
       end
     end
 
@@ -64,7 +64,7 @@ module Scarpe
 
         logger.level = name_to_severity(level)
       else
-        raise Shoes::InvalidAttributeValueError, "Don't know how to use #{data.inspect} to specify a logger!"
+        raise Shoes::Errors::InvalidAttributeValueError, "Don't know how to use #{data.inspect} to specify a logger!"
       end
     end
 

--- a/scarpe-components/lib/scarpe/components/print_logger.rb
+++ b/scarpe-components/lib/scarpe/components/print_logger.rb
@@ -9,24 +9,28 @@ class Scarpe::Components::PrintLogImpl
   include Shoes::Log # for constants
 
   class PrintLogger
+    class << self
+      attr_accessor :silence
+    end
+
     def initialize(component_name)
       @comp_name = component_name
     end
 
     def error(msg)
-      puts "#{@comp_name} error: #{msg}"
+      puts "#{@comp_name} error: #{msg}" unless PrintLogger.silence
     end
 
     def warn(msg)
-      puts "#{@comp_name} warn: #{msg}"
+      puts "#{@comp_name} warn: #{msg}" unless PrintLogger.silence
     end
 
     def debug(msg)
-      puts "#{@comp_name} debug: #{msg}"
+      puts "#{@comp_name} debug: #{msg}" unless PrintLogger.silence
     end
 
     def info(msg)
-      puts "#{@comp_name} info: #{msg}"
+      puts "#{@comp_name} info: #{msg}" unless PrintLogger.silence
     end
   end
 

--- a/scarpe-components/lib/scarpe/components/promises.rb
+++ b/scarpe-components/lib/scarpe/components/promises.rb
@@ -258,7 +258,7 @@ module Scarpe
       end
 
       if old_state == :pending && new_state == :unscheduled
-        raise Shoes::InvalidAttributeValueError, "Can't change state from :pending to :unscheduled! Scheduling is not reversible!"
+        raise Shoes::Errors::InvalidAttributeValueError, "Can't change state from :pending to :unscheduled! Scheduling is not reversible!"
       end
 
       # The next three checks should all be followed by calling handlers for the newly-changed state.
@@ -389,7 +389,7 @@ module Scarpe
     # @return [Scarpe::Promise] self
     def on_fulfilled(&handler)
       unless handler
-        raise Shoes::InvalidAttributeValueError, "You must pass a block to on_fulfilled!"
+        raise Shoes::Errors::InvalidAttributeValueError, "You must pass a block to on_fulfilled!"
       end
 
       case @state
@@ -411,7 +411,7 @@ module Scarpe
     # @return [Scarpe::Promise] self
     def on_rejected(&handler)
       unless handler
-        raise Shoes::InvalidAttributeValueError, "You must pass a block to on_rejected!"
+        raise Shoes::Errors::InvalidAttributeValueError, "You must pass a block to on_rejected!"
       end
 
       case @state
@@ -434,7 +434,7 @@ module Scarpe
     # @return [Scarpe::Promise] self
     def on_scheduled(&handler)
       unless handler
-        raise Shoes::InvalidAttributeValueError, "You must pass a block to on_scheduled!"
+        raise Shoes::Errors::InvalidAttributeValueError, "You must pass a block to on_scheduled!"
       end
 
       # Add a pending handler or call it now

--- a/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
+++ b/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
@@ -14,7 +14,7 @@ module Scarpe::Components
     # @return <void>
     def add_segment_type(type, handler)
       if segment_type_hash.key?(type)
-        raise Shoes::InvalidAttributeValueError, "Segment type #{type.inspect} already exists!"
+        raise Shoes::Errors::InvalidAttributeValueError, "Segment type #{type.inspect} already exists!"
       end
 
       segment_type_hash[type] = handler

--- a/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
@@ -181,7 +181,7 @@ module Scarpe::Test::LoggedTest
     out_loc = filepath.gsub(%r{.log\Z}, ".out.log")
 
     if out_loc == filepath
-      raise Shoes::InvalidAttributeValueError, "Something is wrong! Could not figure out failure-log output path for #{filepath.inspect}!"
+      raise Shoes::Errors::InvalidAttributeValueError, "Something is wrong! Could not figure out failure-log output path for #{filepath.inspect}!"
     end
 
     if File.exist?(out_loc)

--- a/scarpe-components/test/test_html.rb
+++ b/scarpe-components/test/test_html.rb
@@ -58,7 +58,7 @@ class TestHTML < Minitest::Test
   end
 
   def test_raises_with_void_tag_blocks
-    assert_raises(Shoes::InvalidAttributeValueError, "void tag input cannot have content") do
+    assert_raises(Shoes::Errors::InvalidAttributeValueError, "void tag input cannot have content") do
       Scarpe::Components::HTML.render { |h| h.input(type: "text") { "foo" } }
     end
   end

--- a/scarpe-components/test/test_promises.rb
+++ b/scarpe-components/test/test_promises.rb
@@ -6,18 +6,19 @@ require "scarpe/components/promises"
 
 class TestPromises < Minitest::Test
   Promise = Scarpe::Promise
+  PrintLogger = Scarpe::Components::PrintLogImpl::PrintLogger
 
   def setup
     # Save so we can restore it post-test
-    @normal_log_config = Shoes::Log.current_log_config
+    @silenced = PrintLogger.silence
 
     # For these tests, don't log anything
-    Shoes::Log.configure_logger("default" => "fatal")
+    PrintLogger.silence = true
   end
 
   def teardown
-    # Restore previous log config
-    Shoes::Log.configure_logger(@normal_log_config)
+    # Restore previous log state
+    PrintLogger.silence = @silenced
   end
 
   def empty_promise_with_checker(state: nil, parents: [])


### PR DESCRIPTION
### Description

Now that we have a PR for Niente, a do-nothing display library that doesn't have a ton of Webview incidental complexity, we can use it for Lacci testing.

I've started by doing a bit of an error cleanup. We want a Shoes::Errors namespace so that the online docs don't look so messy with a ton of random error classes mixed with everything else. We also want a bunch of Scarpe errors that are really in Shoes code to move into Shoes (see issue #440, which this doesn't fix, but helps.)

I also (again) got rid of that annoying backtrace printed to console on every successful run of the promises unit tests -- those started printing the whole backtrace again when I switched the tests to use the simple print logger instead of the complicated configurable logger.

### Image(if needed, helps for a faster review)

Not actually an image, but here's what the Niente-based Lacci tests look like now for errors:

```
  def test_drawables_found_errors
    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
    Shoes.app do
      button "OK"
      button "Not OK"
    end
    SHOES_APP
    assert_raises Shoes::Errors::MultipleDrawablesFoundError do
      button()
    end
    assert_raises Shoes::Errors::NoDrawablesFoundError do
      edit_line()
    end
    SHOES_SPEC
  end
```

Very pretty, I think!

### Checklist

- [X] Run tests locally
