### PR TITLE
Fix Timmy.rb

### DIFF
--- a/lib/scarpe/wv/drawable.rb
+++ b/lib/scarpe/wv/drawable.rb
@@ -99,11 +99,11 @@ module Scarpe::Webview
       if changes.key?("hidden")
         hidden = changes.delete("hidden")
         if hidden
-          html_wrapper_element.set_style("display", "none")
+          html_element.set_style("display", "none")
         else
           new_style = style # Get current display CSS property, which may vary by subclass
           disp = new_style[:display]
-          html_wrapper_element.set_style("display", disp || "block")
+          html_element.set_style("display", disp || "block")
         end
       end
 
@@ -182,21 +182,11 @@ module Scarpe::Webview
 
     # This gets an accessor for just this element's HTML ID.
     # It is normally called by the drawable itself to do its DOM management.
-    # Some drawables don't use their html_id for their outermost element,
-    # and so we add an outer wrapping div to make sure that remove(),
-    # hidden() etc. affect every part of the drawable. This accessor
-    # does *not* necessarily affect the outermost elements.
+    # Drawables are required to use their html_id for their outermost element,
+    # to make sure that remove(), hidden() etc. affect every part of the drawable.
     #
     # @return [Scarpe::WebWrangler::ElementWrangler] a DOM object manager
     def html_element
-      @elt_wrangler ||= Scarpe::Webview::WebWrangler::ElementWrangler.new(html_id)
-    end
-
-    # This gets an accessor for just this element's outer wrapping div.
-    # This allows replacing the entire drawable, not just its "main" element.
-    #
-    # @return [Scarpe::WebWrangler::ElementWrangler] a DOM object manager
-    def html_wrapper_element
       @elt_wrangler ||= Scarpe::Webview::WebWrangler::ElementWrangler.new(html_id)
     end
 
@@ -223,7 +213,7 @@ module Scarpe::Webview
     def to_html
       @children ||= []
       child_markup = @children.map(&:to_html).join
-      "<div id='#{html_id}-wrap'>" + element { child_markup } + "</div>"
+      element { child_markup }
     end
 
     # This binds a Scarpe JS callback, handled via a single dispatch point in the app
@@ -244,7 +234,7 @@ module Scarpe::Webview
     def destroy_self
       @parent&.remove_child(self)
       unsub_all_shoes_events
-      html_wrapper_element.remove
+      html_element.remove
     end
 
     # Request a full redraw of the entire window, including the entire tree of
@@ -265,7 +255,7 @@ module Scarpe::Webview
     #
     # @return [void]
     def needs_update!
-      html_wrapper_element.outer_html = to_html
+      html_element.outer_html = to_html
     end
 
     # Generate JS code to trigger a specific event name on this drawable with the supplies arguments.

--- a/scarpe-components/lib/scarpe/components/calzini/art_widgets.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/art_widgets.rb
@@ -159,10 +159,10 @@ module Scarpe::Components::Calzini
     fill = "black" if !fill || fill == ""
     stroke = "black" if !stroke || stroke == ""
 
-    stroke_widthk = width / 4
+    stroke_width = width / 4
 
     HTML.render do |h|
-      h.div(id: html_id, style: arrow_div_style(left, top)) do
+      h.div(id: html_id, style: arrow_div_style(props)) do
         h.svg do
           h.defs do
             h.marker(
@@ -185,7 +185,7 @@ module Scarpe::Components::Calzini
             y1: end_y.to_s,
             fill: fill.to_s,
             stroke: stroke.to_s,
-            "stroke-width" => stroke_widthk.to_s,
+            "stroke-width" => stroke_width.to_s,
             "marker-end" => "url(#head)",
             transform: "rotate(#{rotate}, #{left + width / 2}, #{top})",
           )
@@ -193,11 +193,11 @@ module Scarpe::Components::Calzini
       end
     end
   end
-  def arrow_div_style(left, top)
-    {
+  def arrow_div_style(props)
+    drawable_style(props).merge({
       position: "absolute",
-      left: "#{left}px",
-      top: "#{top}px",
-    }
+      left: "#{props["left"]}px",
+      top: "#{props["top"]}px",
+    })
   end
 end

--- a/test/test_drawables.rb
+++ b/test/test_drawables.rb
@@ -11,6 +11,7 @@ class TestDrawables < ShoesSpecLoggedTest
       Shoes.app do
         @drawables = []
         @drawables << arc(400, 0, 120, 100, 175, 175)
+        @drawables << arrow(100, 100, 30)
         @drawables << button("Press Me")
         @drawables << check
         @drawables << edit_line("foo")
@@ -20,6 +21,7 @@ class TestDrawables < ShoesSpecLoggedTest
         @drawables << line(0, 0, 100, 100)
         @drawables << list_box(items: ['A', 'B'])
         @drawables << para("Hello")
+        @drawables << progress
         @drawables << radio("ooga")
         @drawables << rect(0, 0, 50, 100, 5)
         @drawables << shape { line(0, 0, 10, 10) }
@@ -48,6 +50,19 @@ class TestDrawables < ShoesSpecLoggedTest
 
       # Okay, so what's weird about this is that if we use the DOM style setter to set display, it gets a space...
       assert_includes dom_html, "display: none"
+
+      # Let's test that every drawable has a div with its HTML ID as the outermost element
+      # so that a .remove() works correctly.
+      w.each do |i|
+        d = i.display
+        html = d.to_html
+        unless html =~ /\A<([^>]+)>/
+          assert false, "Can't parse first tag from #{html.inspect}!"
+        end
+        first_tag = $1
+
+        assert html.include?("id=\"#{d.html_id}"), "#{d.class} doesn't use an outer div with html_id correctly! #{html}"
+      end
     TEST_CODE
   end
 


### PR DESCRIPTION
### Description

Require that every drawable use its html_id on its outermost HTML element. That guarantees a hide or remove can successfully affect the whole element without a whole-DOM redraw.

I've updated test_drawables.rb to include all drawables, and fixed a hide/show error in arrow that I missed because it wasn't in there.

I got rid of the extra wrapper div that was causing formatting trouble for timmy.rb (and others, no doubt.)

### Checklist

- [x] Run tests locally
