### PR TITLE
Allow directly running Shoes-Spec specs on the command line.

### DIFF
--- a/lacci/lib/scarpe/niente.rb
+++ b/lacci/lib/scarpe/niente.rb
@@ -13,10 +13,8 @@ require_relative "niente/drawable"
 require_relative "niente/app"
 require_relative "niente/display_service"
 
-if ENV["SHOES_SPEC_TEST"]
-  require_relative "niente/shoes_spec"
-  Shoes::Spec.instance = Niente::Test
-end
+require_relative "niente/shoes_spec"
+Shoes::Spec.instance = Niente::Test
 
 Shoes::DisplayService.set_display_service_class(Niente::DisplayService)
 

--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -45,9 +45,10 @@ require_relative "shoes/drawables"
 
 require_relative "shoes/download"
 
-if ENV["SHOES_SPEC_TEST"]
-  require_relative "shoes-spec"
-end
+# No easy way to tell at this point whether
+# we will later load Shoes-Spec code, e.g.
+# by running a segmented app with test code.
+require_relative "shoes-spec"
 
 # The module containing Shoes in all its glory.
 # Shoes is a platform-independent GUI library, designed to create

--- a/lib/scarpe/wv.rb
+++ b/lib/scarpe/wv.rb
@@ -63,10 +63,8 @@ Shoes::FONTS.push(
   "Monaco",
 )
 
-if ENV["SHOES_SPEC_TEST"]
-  require_relative "shoes_spec"
-  Shoes::Spec.instance = Scarpe::Test
-end
+require_relative "shoes_spec"
+Shoes::Spec.instance = Scarpe::Test
 
 require_relative "wv/web_wrangler"
 require_relative "wv/control_interface"

--- a/scarpe-components/test/test_segmented_app_files.rb
+++ b/scarpe-components/test/test_segmented_app_files.rb
@@ -61,13 +61,15 @@ class TestSegmentedAppFiles < Minitest::Test
     assert_equal({ app_ran: true }, SEG_TEST_DATA)
   end
 
+  # TODO: this test is partially updated to ShoesSpec rather
+  # than CatsCradle, but we could use a proper version.
   def test_default_double_segment_with_front_matter
     app = <<~SEG_TEST_FILE
       ---
       front_matter: yes
       ----- app code
       SEG_TEST_DATA[:app_ran] = true
-      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      eval File.read(ENV['SHOES_SPEC_TEST']) # run test code
       ----- test code
       SEG_TEST_DATA[:test_ran] = true
     SEG_TEST_FILE
@@ -83,7 +85,7 @@ class TestSegmentedAppFiles < Minitest::Test
       ---
       ----- app code
       SEG_TEST_DATA[:app_ran] = true
-      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      eval File.read(ENV['SHOES_SPEC_TEST']) # run test code
       ----- test code
       SEG_TEST_DATA[:test_ran] = true
     SEG_TEST_FILE
@@ -98,7 +100,7 @@ class TestSegmentedAppFiles < Minitest::Test
     app = <<~SEG_TEST_FILE
       ----- app code
       SEG_TEST_DATA[:app_ran] = true
-      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      eval File.read(ENV['SHOES_SPEC_TEST']) # run test code
       ----- test code
       SEG_TEST_DATA[:test_ran] = true
     SEG_TEST_FILE
@@ -113,7 +115,7 @@ class TestSegmentedAppFiles < Minitest::Test
     app = <<~SEG_TEST_FILE
       -----
       SEG_TEST_DATA[:app_ran] = true
-      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      eval File.read(ENV['SHOES_SPEC_TEST']) # run test code
       -----
       SEG_TEST_DATA[:test_ran] = true
     SEG_TEST_FILE
@@ -127,7 +129,7 @@ class TestSegmentedAppFiles < Minitest::Test
   def test_default_double_segment_no_front_matter_no_initial_name
     app = <<~SEG_TEST_FILE
       SEG_TEST_DATA[:app_ran] = true
-      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      eval File.read(ENV['SHOES_SPEC_TEST']) # run test code
       ----- test code
       SEG_TEST_DATA[:test_ran] = true
     SEG_TEST_FILE
@@ -144,7 +146,7 @@ class TestSegmentedAppFiles < Minitest::Test
         front_matter: yes
       ---------------- app code
       SEG_TEST_DATA[:app_ran] = true
-      eval File.read(ENV['SCARPE_APP_TEST']) # run test code
+      eval File.read(ENV['SHOES_SPEC_TEST']) # run test code
       ------- test code
       SEG_TEST_DATA[:test_ran] = true
     SEG_TEST_FILE

--- a/test/test_catscradle.rb
+++ b/test/test_catscradle.rb
@@ -25,7 +25,7 @@ class TestCatsCradle < LoggedScarpeTest
     TEST_CODE
   end
 
-  def test_catscradle_segmented_app
+  def test_shoes_spec_segmented_app
     run_test_scarpe_code(<<~'SCARPE_APP', test_extension: ".scas")
       ---
       ----- app_code
@@ -33,15 +33,13 @@ class TestCatsCradle < LoggedScarpeTest
           button "clicky"
         end
       ----- test code
-        require "scarpe/cats_cradle"
-        self.class.include Scarpe::Test::CatsCradle
-        event_init
+      assert_equal button().text, "clicky"
 
-        on_heartbeat do
-          assert_include button().text, "clicky"
-
-          test_finished
-        end
+      # When we convert the outer test class to a ShoesSpec class,
+      # this can go away
+      catscradle_dsl do
+        test_finished
+      end
     SCARPE_APP
   end
 


### PR DESCRIPTION
### Description

Run Shoes-Spec test code (not older-style CatsCradle) for segmented apps, including in tests. Allow directly running .sspec files on the command line, including without setting an env var first.

### Checklist

- [x] Run tests locally
