### PR TITLE
Niente: support directly loading sspec files, and support drawable() test query

### DIFF
--- a/lacci/lib/scarpe/niente.rb
+++ b/lacci/lib/scarpe/niente.rb
@@ -16,5 +16,9 @@ require_relative "niente/display_service"
 require_relative "niente/shoes_spec"
 Shoes::Spec.instance = Niente::Test
 
+require "scarpe/components/segmented_file_loader"
+loader = Scarpe::Components::SegmentedFileLoader.new
+Shoes.add_file_loader loader
+
 Shoes::DisplayService.set_display_service_class(Niente::DisplayService)
 

--- a/lacci/lib/scarpe/niente/shoes_spec.rb
+++ b/lacci/lib/scarpe/niente/shoes_spec.rb
@@ -50,6 +50,13 @@ class Niente::ShoesSpecTest < Minitest::Test
       Niente::ShoesSpecProxy.new(drawables[0])
     end
   end
+
+  def drawable(*specs)
+    drawables = Shoes::App.instance.find_drawables_by(*specs)
+    raise Shoes::Errors::MultipleDrawablesFoundError, "Found more than one #{finder_name} matching #{args.inspect}!" if drawables.size > 1
+    raise Shoes::Errors::NoDrawablesFoundError, "Found no #{finder_name} matching #{args.inspect}!" if drawables.empty?
+    Niente::ShoesSpecProxy.new(drawables[0])
+  end
 end
 
 class Niente::ShoesSpecProxy


### PR DESCRIPTION
### Description

Niente in main will fail if you directly load an sspec file. Here's how you can try that:

    SCARPE_DISPLAY_SERVICE=niente ./exe/scarpe --dev ../shoes-spec/cases/dsl/app/add_drawables.sspec

With this change, the above will succeed. And this PR also adds the drawable() query, which can be used like this:

```
---
----------- app code
Shoes.app do
  @b = button "OK"
end
----------- test code
assert drawable("@b"), "Need a drawable() query method in test code!"
```

Drawable is important because sometimes you could have e.g. an instance variable and not be sure ahead of time what type it contains. Also, certain classes don't have a well-defined query interface yet (e.g. widget). The drawable() ShoesSpec DSL query permits "grey area" cases of that general type.

### Checklist

- [X] Run tests locally
