### PR TITLE
Scarpe (and other) Shoes Extensions

### DIFF
--- a/examples/scarpe_ext.rb
+++ b/examples/scarpe_ext.rb
@@ -1,0 +1,4 @@
+Shoes.app(features: :scarpe) do
+  para "This text could be CSS-ified", html_attributes: { class: "button_css_class" }
+  button "OK"
+end

--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -76,6 +76,7 @@ class Shoes
     # @param width [Integer] The new app window width
     # @param height [Integer] The new app window height
     # @param resizable [Boolean] Whether the app window should be resizeable
+    # @param features [Symbol,Array<Symbol>] Additional Shoes extensions requested by the app
     # @return [void]
     # @see Shoes::App#new
     def app(
@@ -83,9 +84,11 @@ class Shoes
       width: 480,
       height: 420,
       resizable: true,
+      features: [],
       &app_code_body
     )
-      app = Shoes::App.new(title:, width:, height:, resizable:, &app_code_body)
+      f = [features].flatten # Make sure this is a list, not a single symbol
+      app = Shoes::App.new(title:, width:, height:, resizable:, features: f, &app_code_body)
       app.init
       app.run
       nil

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -10,7 +10,12 @@ class Shoes
 
     attr_reader :document_root
 
-    shoes_styles :title, :width, :height, :resizable
+    shoes_styles :title, :width, :height, :resizable, :features
+
+    # This is defined to avoid the linkable-id check in the Shoes-style method_missing def'n
+    def features
+      @features
+    end
 
     CUSTOM_EVENT_LOOP_TYPES = ["displaylib", "return", "wait"]
 
@@ -20,6 +25,7 @@ class Shoes
       width: 480,
       height: 420,
       resizable: true,
+      features: [],
       &app_code_body
     )
       log_init("Shoes::App")
@@ -33,6 +39,18 @@ class Shoes
 
       @do_shutdown = false
       @event_loop_type = "displaylib" # the default
+
+      @features = features
+
+      unknown_ext = features - Shoes::FEATURES - Shoes::EXTENSIONS
+      unsupported_features = unknown_ext & Shoes::KNOWN_FEATURES
+      unless unsupported_features.empty?
+        @log.error("Shoes app requires feature(s) not supported by this display service: #{unsupported_features.inspect}!")
+        raise Shoes::Errors::UnsupportedFeature, "Shoes app needs features: #{unsupported_features.inspect}"
+      end
+      unless unknown_ext.empty?
+        @log.warn("Shoes app requested unknown features #{unknown_ext.inspect}! Known: #{(Shoes::FEATURES + Shoes::EXTENSIONS).inspect}")
+      end
 
       super
 

--- a/lacci/lib/shoes/constants.rb
+++ b/lacci/lib/shoes/constants.rb
@@ -38,6 +38,23 @@ class Shoes
 
     # Fonts currently loaded and available
     FONTS = []
+
+    # Standard features available in this display service - see KNOWN_FEATURES.
+    # These may or may not require the Shoes.app requesting them per-app.
+    FEATURES = []
+
+    # Nonstandard extensions, e.g. Scarpe extensions, supported by this display lib.
+    # An application may have to request the extensions for them to be available so
+    # that a casual reader can see Shoes.app(features: :scarpe) and realize why
+    # there are nonstandard styles or drawables.
+    EXTENSIONS = []
+
+    # These are all known features supported by this version of Lacci.
+    # Features on this list are allowed to be in FEATURES. Anything else
+    # goes in EXTENSIONS and is nonstandard.
+    KNOWN_FEATURES = [
+      :html, # Supports .to_html on display objects, HTML classes on drawables, etc.
+    ].freeze
   end
 
   # Access and assign the release constants

--- a/lacci/lib/shoes/drawable.rb
+++ b/lacci/lib/shoes/drawable.rb
@@ -164,26 +164,55 @@ class Shoes
       # If a block is passed to shoes_style, that's the validation for the property. It should
       # convert a given value to a valid value for the property or throw an exception.
       #
+      # If feature is non-nil, it's the feature that an app must request in order to see this
+      # property.
+      #
       # @param name [String,Symbol] the style name
+      # @param feature [Symbol,NilClass] the feature that must be defined for an app to request this style, or nil
       # @block if block is given, call it to map the given style value to a valid value, or raise an exception
-      def shoes_style(name, &validator)
+      def shoes_style(name, feature: nil, &validator)
         name = name.to_s
 
         return if linkable_properties_hash[name]
 
-        linkable_properties << { name: name, validator: }
+        linkable_properties << { name: name, validator:, feature: }
         linkable_properties_hash[name] = true
       end
 
-      # Add these names as Shoes styles with the given validator, if any
-      def shoes_styles(*names, &validator)
-        names.each { |n| shoes_style(n, &validator) }
+      # Add these names as Shoes styles with the given validator and feature, if any
+      def shoes_styles(*names, feature: nil, &validator)
+        names.each { |n| shoes_style(n, feature:, &validator) }
       end
 
-      def shoes_style_names
-        parent_prop_names = self != Shoes::Drawable ? self.superclass.shoes_style_names : []
+      # Query what feature, if any, is required to use a specific shoes_style.
+      # If no specific feature is needed, nil will be returned.
+      def feature_for_shoes_style(style_name)
+        style_name = style_name.to_s
+        lp = linkable_properties.detect { |prop| prop[:name] == style_name }
+        return lp[:feature] if lp
 
-        parent_prop_names | linkable_properties.map { |prop| prop[:name] }
+        # If we get to the top of the superclass tree and we didn't find it, it's not here
+        if self.class == ::Shoes::Drawable
+          raise Shoes::Errors::NoSuchStyleError, "Can't find information for style #{style_name.inspect}!"
+        end
+
+        super
+      end
+
+      # Return a list of shoes_style names with the given features. If with_features is nil,
+      # return them with a list of features for the current Shoes::App. For the list of
+      # styles available with no features requested, pass nil to with_features.
+      def shoes_style_names(with_features: nil)
+        # No with_features given? Use the ones requested by this Shoes::App
+        with_features ||= Shoes::App.instance.features
+        parent_prop_names = self != Shoes::Drawable ? self.superclass.shoes_style_names(with_features:) : []
+
+        if with_features == :all
+          subclass_props = linkable_properties
+        else
+          subclass_props = linkable_properties.select { |prop| !prop[:feature] || with_features.include?(prop[:feature]) }
+        end
+        parent_prop_names | subclass_props.map { |prop| prop[:name] }
       end
 
       def shoes_style_hashes
@@ -205,6 +234,22 @@ class Shoes
 
     def initialize(*args, **kwargs)
       log_init("Shoes::#{self.class.name}") unless @log
+
+      # First, get the list of allowed and disallowed styles for the given features
+      # and make sure no disallowed styles were given.
+
+      app_features = Shoes::App.instance.features
+      this_app_styles = self.class.shoes_style_names.map(&:to_sym)
+      not_this_app_styles = self.class.shoes_style_names(with_features: :all).map(&:to_sym) - this_app_styles
+
+      bad_styles = kwargs.keys & not_this_app_styles
+      unless bad_styles.empty?
+        features_needed = bad_styles.map { |s| self.class.feature_for_shoes_style(s) }.uniq
+        raise Shoes::Errors::UnsupportedFeature, "The style(s) #{bad_styles.inspect} are only defined for applications that request specific features: #{features_needed.inspect} (you requested #{app_features.inspect})!"
+      end
+
+      # Next, check positional arguments and make sure the correct number and type
+      # were passed and match positional args with style names.
 
       supplied_args = kwargs.keys
 
@@ -237,6 +282,8 @@ class Shoes
         end
       end
 
+      # Styles that were *not* passed should be set to defaults
+
       default_styles = Shoes::Drawable.drawable_default_styles[self.class]
       this_drawable_styles = self.class.shoes_style_names.map(&:to_sym)
 
@@ -246,7 +293,7 @@ class Shoes
         instance_variable_set("@#{key}", val)
       end
 
-      # If we have a keyword arg for a style, set it normally.
+      # If we have a keyword arg for a style, set it as specified.
       (this_drawable_styles & kwargs.keys).each do |key|
         val = self.class.validate_as(key, kwargs[key])
         instance_variable_set("@#{key}", val)
@@ -427,7 +474,7 @@ class Shoes
         prop_name = name_s[0..-2]
         if self.class.shoes_style_name?(prop_name)
           self.class.define_method(name) do |new_value|
-            raise(Shoes::Errors::NoLinkableIdError, "Trying to set Shoes styles in an object with no linkable ID! #{inspect}") unless linkable_id
+            raise(Shoes::Errors::NoLinkableIdError, "Trying to set Shoes styles in a #{self.class} with no linkable ID!") unless linkable_id
 
             new_value = self.class.validate_as(prop_name, new_value)
             instance_variable_set("@" + prop_name, new_value)

--- a/lacci/lib/shoes/drawables/flow.rb
+++ b/lacci/lib/shoes/drawables/flow.rb
@@ -12,6 +12,9 @@ class Shoes
     def initialize(width: "100%", height: nil, margin: nil, padding: nil, **options, &block)
       super
       @options = options
+      unless @options.empty?
+        STDERR.puts "FLOW OPTIONS: #{@options.inspect}"
+      end
 
       # Create the display-side drawable *before* instance_eval, which will add child drawables with their display drawables
       create_display_drawable

--- a/lacci/lib/shoes/drawables/para.rb
+++ b/lacci/lib/shoes/drawables/para.rb
@@ -5,6 +5,12 @@ class Shoes
     shoes_styles :text_items, :size, :font
     shoes_style(:stroke) { |val| Shoes::Colors.to_rgb(val) }
 
+    shoes_style(:align) do |val|
+      unless ["left", "center", "right"].include?(val)
+        raise(Shoes::Errors::InvalidAttributeValueError, "Align must be one of left, center or right!")
+      end
+    end
+
     Shoes::Drawable.drawable_default_styles[Shoes::Para][:size] = :para
 
     shoes_events # No Para-specific events yet
@@ -12,11 +18,7 @@ class Shoes
     # Initializes a new instance of the `Para` widget.
     #
     # @param args The text content of the paragraph.
-    # @param stroke [String, nil] The color of the text stroke.
-    # @param size [Symbol] The size of the paragraph text.
-    # @param font [String, nil] The font of the paragraph text.
-    # @param hidden [Boolean] Determines if the paragraph is initially hidden.
-    # @param html_attributes [Hash] Additional HTML attributes for the paragraph.
+    # @param kwargs [Hash] the various Shoes styles for this paragraph.
     #
     # @example
     #    Shoes.app do
@@ -31,17 +33,13 @@ class Shoes
     #
     #      p.replace "On top we'll switch to ", strong("bold"), "!"
     #    end
-    def initialize(*args, stroke: nil, size: :para, font: nil, **html_attributes)
-      kwargs = { stroke:, size:, font:, **html_attributes }.compact
-
+    def initialize(*args, **kwargs)
       # Don't pass text_children args to Drawable#initialize
       super(*[], **kwargs)
 
       # Text_children alternates strings and TextDrawables, so we can't just pass
       # it as a Shoes style. It won't serialize.
       update_text_children(args)
-
-      @html_attributes = html_attributes || {}
 
       create_display_drawable
     end

--- a/lacci/lib/shoes/drawables/stack.rb
+++ b/lacci/lib/shoes/drawables/stack.rb
@@ -14,6 +14,9 @@ class Shoes
       margin_right: nil, **options, &block)
 
       @options = options
+      unless @options.empty?
+        STDERR.puts "STACK OPTIONS: #{@options.inspect}"
+      end
 
       super
 

--- a/lacci/lib/shoes/errors.rb
+++ b/lacci/lib/shoes/errors.rb
@@ -27,4 +27,6 @@ module Shoes::Errors
   class SingletonError < Shoes::Error; end
 
   class MultipleShoesSpecRunsError < Shoes::Error; end
+
+  class UnsupportedFeature < Shoes::Error; end
 end

--- a/lacci/test/test_helper.rb
+++ b/lacci/test/test_helper.rb
@@ -35,6 +35,7 @@ class NienteTest < Minitest::Test
     timeout: 5.0,
     class_name: self.class,
     method_name: self.name,
+    expect_process_fail: false,
     display_service: "niente"
   )
     with_tempfiles([
@@ -52,12 +53,15 @@ class NienteTest < Minitest::Test
       )
     end
 
-    # Check if the process exited normally or crashed (segfault, failure, timeout)
-    unless $?.success?
-      assert(false, "Niente app failed with exit code: #{$?.exitstatus}")
+    if expect_process_fail
+      assert(false, "Expected app to fail but it succeeded!") if $?.success?
       return
     end
 
-
+    # Check if the process exited normally or crashed (segfault, failure, timeout)
+    unless $?.success?
+      assert(false, "App failed with exit code: #{$?.exitstatus}")
+      return
+    end
   end
 end

--- a/lacci/test/test_lacci.rb
+++ b/lacci/test/test_lacci.rb
@@ -82,4 +82,24 @@ class TestLacci < NienteTest
       end
     SHOES_SPEC
   end
+
+  def test_unsupported_feature
+    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC, expect_process_fail: true)
+      Shoes.app(features: :html) do
+        para "Not supported by Niente, though."
+      end
+    SHOES_APP
+      assert true
+    SHOES_SPEC
+  end
+
+  def test_unknown_feature
+    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
+      Shoes.app(features: :squid) do
+        para "No such feature, though."
+      end
+    SHOES_APP
+      assert true
+    SHOES_SPEC
+  end
 end

--- a/lib/scarpe/wv.rb
+++ b/lib/scarpe/wv.rb
@@ -63,6 +63,9 @@ Shoes::FONTS.push(
   "Monaco",
 )
 
+Shoes::FEATURES.push(:html)
+Shoes::EXTENSIONS.push(:scarpe)
+
 require_relative "shoes_spec"
 Shoes::Spec.instance = Scarpe::Test
 
@@ -100,3 +103,5 @@ require_relative "wv/video"
 require_relative "wv/check"
 require_relative "wv/progress"
 require_relative "wv/arrow"
+
+require_relative "wv/scarpe_extensions"

--- a/lib/scarpe/wv/scarpe_extensions.rb
+++ b/lib/scarpe/wv/scarpe_extensions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This may or may not stay. It's basically an example extension. It can be done
+# better, and there's no reason it should be specific to button.
+Shoes::Button.shoes_style :html_class, feature: :html
+
+# We have a number of real Scarpe extensions that need to be properly marked as such
+# and moved in here. Padding is a great example, as is html_attributes.

--- a/scarpe-components/lib/scarpe/components/calzini/button.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/button.rb
@@ -3,13 +3,15 @@
 module Scarpe::Components::Calzini
   def button_element(props)
     HTML.render do |h|
-      h.button(
+      button_props = {
         id: html_id,
         onclick: handler_js_code("click"),
         onmouseover: handler_js_code("hover"),
         style: button_style(props),
+        class: props["html_class"],
         title: props["tooltip"],
-      ) do
+      }.compact
+      h.button(**button_props) do
         props["text"]
       end
     end

--- a/scarpe-components/test/calzini/test_calzini_button.rb
+++ b/scarpe-components/test/calzini/test_calzini_button.rb
@@ -11,7 +11,11 @@ class TestCalziniButton < Minitest::Test
     assert_equal %{<button id="elt-1" onclick="handle('click')" onmouseover="handle('hover')"></button>}, @calzini.render("button", {})
   end
 
-  def test_button_all_properties_set
+ def test_button_with_html_class
+    assert_equal %{<button id="elt-1" onclick="handle('click')" onmouseover="handle('hover')" class="buttonish"></button>}, @calzini.render("button", { "html_class" => "buttonish" })
+  end
+
+  def test_button_all_standard_properties_set
     props = {
       "color" => "red",
       "padding_top" => "4",
@@ -32,7 +36,7 @@ class TestCalziniButton < Minitest::Test
       @calzini.render("button", props)
   end
 
-  def test_button_all_properties_nil
+  def test_button_all_standard_properties_nil
     props = {
       "color" => nil,
       "padding_top" => nil,

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -60,13 +60,18 @@ class TestWebviewImage < ScarpeWebviewTest
       "<img id=\"#{img.html_id}\" src=\"#{@url}\" />"\
       "</a>"
   end
+end
+
+class TestImageShoesSpec < ShoesSpecLoggedTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
 
   def test_image_size
-    url = "http://shoesrb.com/manual/static/shoes-icon.png"
-    expected_size = [128, 128]
-    img = Shoes::Image.new(url)
-    actual_size = img.size
-
-    assert_equal expected_size, actual_size
+    run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
+      Shoes.app do
+        image "http://shoesrb.com/manual/static/shoes-icon.png"
+      end
+    SCARPE_APP
+      assert_equal [128, 128], image().size
+    TEST_CODE
   end
 end

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -96,4 +96,29 @@ class TestWebviewScarpe < ShoesSpecLoggedTest
       end
     SCARPE_APP
   end
+
+  def test_html_class_extension
+    run_test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
+      Shoes.app(features: :html) do
+        stack do
+          para "Hello World"
+          button("OK", html_class: "itsabutton")
+        end
+      end
+    SCARPE_APP
+  end
+
+  def test_html_class_extension_fail
+    run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE', exit_immediately: true)
+      Shoes.app do
+        @s = stack do
+          para "Hello World"
+        end
+      end
+    SCARPE_APP
+      assert_raises Shoes::Errors::UnsupportedFeature do
+        stack("@s").button("OK", html_class: "itsabutton")
+      end
+    TEST_CODE
+  end
 end


### PR DESCRIPTION
### Description

Add Shoes::FEATURES and Shoes::EXTENSIONS so a display service and an app can negotiate extra APIs on top of old Shoes. Allow specifying what feature a given Shoes style is part of, and only use styles that the application has requested the right feature for.

This is written on top of #473.

### Checklist

- [x] Run tests locally
