### PR TITLE
Better CSS, use init_args on slots; flags!

### DIFF
--- a/examples/flags/finland.rb
+++ b/examples/flags/finland.rb
@@ -1,0 +1,15 @@
+Shoes.app(title: "Finland", width: 360, height: 220, ) do
+  background blue
+  stack width: 100, height: 80 do
+    background white
+  end
+  stack width: 100, height: 80, top: 140, left: 0 do
+    background white
+  end
+  stack width: 200, height: 80, top: 0, left: 160 do
+    background white
+  end
+  stack width: 200, height: 80, top: 140, left: 160 do
+    background white
+  end
+end

--- a/examples/flags/italy.rb
+++ b/examples/flags/italy.rb
@@ -1,0 +1,11 @@
+Shoes.app(height: 300) do
+  stack width: 0.33, height: 1.0 do
+    background green
+  end
+  stack width: 0.34, height: 1.0 do
+    background white
+  end
+  stack width: 0.33, height: 1.0 do
+    background red
+  end
+end

--- a/examples/flags/mauritius.rb
+++ b/examples/flags/mauritius.rb
@@ -1,0 +1,14 @@
+Shoes.app(title: "Mauritius", height: 300) do
+  stack width: 1.0, height: 0.25 do
+    background red
+  end
+  stack width: 1.0, height: 0.25 do
+    background blue
+  end
+  stack width: 1.0, height: 0.25 do
+    background yellow
+  end
+  stack width: 1.0, height: 0.25 do
+    background green
+  end
+end

--- a/lacci/lib/shoes/drawable.rb
+++ b/lacci/lib/shoes/drawable.rb
@@ -227,6 +227,9 @@ class Shoes
       end
     end
 
+    # Every Shoes drawable has positioning properties
+    shoes_styles :top, :left, :width, :height
+
     # Shoes uses a "hidden" style property for hide/show
     shoes_style :hidden
 

--- a/lacci/lib/shoes/drawables/document_root.rb
+++ b/lacci/lib/shoes/drawables/document_root.rb
@@ -4,12 +4,11 @@ class Shoes
   class DocumentRoot < Shoes::Flow
     shoes_events # No DocumentRoot-specific events yet
 
-    init_args
-    def initialize
-      @height = "100%"
-      @width = @margin = @padding = nil
-      @options = {}
+    Shoes::Drawable.drawable_default_styles[Shoes::DocumentRoot][:height] = "100%"
+    Shoes::Drawable.drawable_default_styles[Shoes::DocumentRoot][:width] = "100%"
 
+    init_args
+    def initialize(**kwargs, &block)
       super
     end
 

--- a/lacci/lib/shoes/drawables/flow.rb
+++ b/lacci/lib/shoes/drawables/flow.rb
@@ -6,15 +6,13 @@ class Shoes
     include Shoes::Border
     include Shoes::Spacing
 
+    Shoes::Drawable.drawable_default_styles[Shoes::Flow][:width] = "100%"
+
     shoes_styles :width, :height, :margin, :padding
     shoes_events
 
-    def initialize(width: "100%", height: nil, margin: nil, padding: nil, **options, &block)
+    def initialize(*args, **kwargs, &block)
       super
-      @options = options
-      unless @options.empty?
-        STDERR.puts "FLOW OPTIONS: #{@options.inspect}"
-      end
 
       # Create the display-side drawable *before* instance_eval, which will add child drawables with their display drawables
       create_display_drawable

--- a/lacci/lib/shoes/drawables/para.rb
+++ b/lacci/lib/shoes/drawables/para.rb
@@ -9,6 +9,7 @@ class Shoes
       unless ["left", "center", "right"].include?(val)
         raise(Shoes::Errors::InvalidAttributeValueError, "Align must be one of left, center or right!")
       end
+      val
     end
 
     Shoes::Drawable.drawable_default_styles[Shoes::Para][:size] = :para

--- a/lacci/lib/shoes/drawables/stack.rb
+++ b/lacci/lib/shoes/drawables/stack.rb
@@ -10,18 +10,13 @@ class Shoes
 
     shoes_events # No Stack-specific events
 
-    def initialize(width: nil, height: nil, margin: nil, padding: nil, scroll: false, margin_top: nil, margin_bottom: nil, margin_left: nil,
-      margin_right: nil, **options, &block)
-
-      @options = options
-      unless @options.empty?
-        STDERR.puts "STACK OPTIONS: #{@options.inspect}"
-      end
-
+    def initialize(*args, **kwargs, &block)
       super
 
       create_display_drawable
-      # Create the display-side drawable *before* running the block, which will add child drawables with their display drawables
+
+      # Create the display-side drawable *before* running the block.
+      # Then child drawables have a parent to add themselves to.
       Shoes::App.instance.with_slot(self, &block) if block_given?
     end
   end

--- a/scarpe-components/lib/scarpe/components/calzini.rb
+++ b/scarpe-components/lib/scarpe/components/calzini.rb
@@ -68,6 +68,10 @@ module Scarpe::Components::Calzini
             p {
               margin: 0;
             }
+            #wrapper-wvroot {
+              height: 100%;
+              width: 100%;
+            }
           </style>
         </head>
         <body id='body-wvroot'>
@@ -110,6 +114,19 @@ module Scarpe::Components::Calzini
     if props["hidden"]
       styles[:display] = "none"
     end
+
+    # Do we need to set CSS positioning here, especially if displace is set? Position: relative maybe?
+    # We need some Shoes3 screenshots and HTML-based tests here...
+
+    if props["top"] || props["left"]
+      styles[:position] = "absolute"
+    end
+
+    styles[:top] = dimensions_length(props["top"]) if props["top"]
+    styles[:left] = dimensions_length(props["left"]) if props["left"]
+    styles[:width] = dimensions_length(props["width"]) if props["width"]
+    styles[:height] = dimensions_length(props["height"]) if props["height"]
+
     styles
   end
 

--- a/scarpe-components/lib/scarpe/components/calzini/button.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/button.rb
@@ -26,14 +26,10 @@ module Scarpe::Components::Calzini
     styles[:"padding-top"] = props["padding_top"] if props["padding_top"]
     styles[:"padding-bottom"] = props["padding_bottom"] if props["padding_bottom"]
     styles[:color] = props["text_color"] if props["text_color"]
-    styles[:width] = dimensions_length(props["width"]) if props["width"]
-    styles[:height] = dimensions_length(props["height"]) if props["height"]
-    styles[:"font-size"] = props["font_size"] if props["font_size"]
 
-    styles[:top] = dimensions_length(props["top"]) if props["top"]
-    styles[:left] = dimensions_length(props["left"]) if props["left"]
-    styles[:position] = "absolute" if props["top"] || props["left"]
+    styles[:"font-size"] = props["font_size"] if props["font_size"]
     styles[:"font-size"] = dimensions_length(text_size(props["size"])) if props["size"]
+
     styles[:"font-family"] = props["font"] if props["font"]
 
     styles

--- a/scarpe-components/lib/scarpe/components/calzini/misc.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/misc.rb
@@ -29,7 +29,7 @@ module Scarpe::Components::Calzini
   end
 
   def image_element(props)
-    style = image_style(props)
+    style = drawable_style(props)
 
     if props["click"]
       HTML.render do |h|
@@ -118,19 +118,6 @@ module Scarpe::Components::Calzini
     styles = drawable_style(props)
 
     styles[:width] = dimensions_length(props["width"]) if props["width"]
-
-    styles
-  end
-
-  def image_style(props)
-    styles = drawable_style(props)
-
-    styles[:width] = dimensions_length(props["width"]) if props["width"]
-    styles[:height] = dimensions_length(props["height"]) if props["height"]
-
-    styles[:top] = dimensions_length(props["top"]) if props["top"]
-    styles[:left] = dimensions_length(props["left"]) if props["left"]
-    styles[:position] = "absolute" if props["top"] || props["left"]
 
     styles
   end

--- a/scarpe-components/lib/scarpe/components/calzini/para.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/para.rb
@@ -6,22 +6,23 @@ module Scarpe::Components::Calzini
   # messing with the display service or display objects.
   def para_element(props, &block)
     HTML.render do |h|
-      h.p(**para_options(props), &block)
+      if props["align"]
+        h.div(id: html_id, style: {"text-align": props["align"], width: "100%"}) do
+          h.p(style: para_style(props), &block)
+        end
+      else
+        h.p(id: html_id, style: para_style(props), &block)
+      end
     end
   end
 
   private
-
-  def para_options(props)
-    { id: html_id, style: para_style(props) }.compact
-  end
 
   def para_style(props)
     drawable_style(props).merge({
       color: rgb_to_hex(props["stroke"]),
       "font-size": para_font_size(props),
       "font-family": props["font"],
-      "text-align": props["align"],
     }.compact)
   end
 

--- a/scarpe-components/lib/scarpe/components/calzini/slots.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/slots.rb
@@ -38,6 +38,10 @@ module Scarpe::Components::Calzini
     styles[:width] = dimensions_length(props["width"]) if props["width"]
     styles[:height] = dimensions_length(props["height"]) if props["height"]
 
+    ## A new slot defines a new coordinate system, so absolutely-positioned children
+    ## are relative to it. But that's going to need a lot of testing and Shoes3 comparison.
+    #styles[:position] = "relative"
+
     styles
   end
 

--- a/scarpe-components/lib/scarpe/components/tiranti.rb
+++ b/scarpe-components/lib/scarpe/components/tiranti.rb
@@ -97,14 +97,11 @@ module Scarpe::Components::Tiranti
     styles[:"padding-top"] = props["padding_top"] if props["padding_top"]
     styles[:"padding-bottom"] = props["padding_bottom"] if props["padding_bottom"]
     styles[:color] = props["text_color"] if props["text_color"]
-    styles[:width] = dimensions_length(props["width"]) if props["width"]
-    styles[:height] = dimensions_length(props["height"]) if props["height"]
-    styles[:"font-size"] = props["font_size"] if props["font_size"]
 
-    styles[:top] = dimensions_length(props["top"]) if props["top"]
-    styles[:left] = dimensions_length(props["left"]) if props["left"]
-    styles[:position] = "absolute" if props["top"] || props["left"]
+    # How do we want to handle font size?
+    styles[:"font-size"] = props["font_size"] if props["font_size"]
     styles[:"font-size"] = dimensions_length(text_size(props["size"])) if props["size"]
+
     styles[:"font-family"] = props["font"] if props["font"]
 
     styles

--- a/scarpe-components/test/calzini/test_calzini_art_drawables.rb
+++ b/scarpe-components/test/calzini/test_calzini_art_drawables.rb
@@ -26,20 +26,20 @@ class TestCalziniArtDrawables < Minitest::Test
         "angle2" => 3.14 / 4,
       },
     )
-    ex_html_start = %{<div id="elt-1" style="left:17px;top:42px;width:200px;height:150px"><svg width="200" height="150"><path d="M100 75 L200 75 A100 75 0 1 0 170.73882691671997 128.01188858290243 Z" transform="rotate(, 100, 75)" /></svg></div>}
+    ex_html_start = %{<div id="elt-1" style="position:absolute;top:42px;left:17px;width:200px;height:150px"><svg width="200" height="150"><path d="M100 75 L200 75 A100 75 0 1 0 170.73882691671997 128.01188858290243 Z" transform="rotate(, 100, 75)" /></svg></div>}
     ex_html_end = %{" /></svg></div>}
     assert_start_and_finish(ex_html_start, ex_html_end, arc_example)
   end
 
   def test_line_example
-    assert_equal %{<div id="elt-1" style="left:7px;top:4px">} +
+    assert_equal %{<div id="elt-1" style="position:absolute;top:4px;left:7px">} +
       %{<svg width="100" height="104"><line x1="7" y1="4" x2="100" y2="104" style="stroke:black;stroke-width:4">} +
       %{</line></svg></div>},
       @calzini.render("line", { "top" => "4", "left" => "7", "x1" => "20", "y1" => "17", "x2" => "100", "y2" => "104" })
   end
 
   def test_line_draw_context
-    assert_equal %{<div id="elt-1" style="left:7px;top:4px">} +
+    assert_equal %{<div id="elt-1" style="position:absolute;top:4px;left:7px">} +
       %{<svg width="100" height="104"><line x1="7" y1="4" x2="100" y2="104" style="stroke:red;stroke-width:4">} +
       %{</line></svg></div>},
       @calzini.render(
@@ -49,21 +49,21 @@ class TestCalziniArtDrawables < Minitest::Test
   end
 
   def test_line_hidden
-    assert_equal %{<div id="elt-1" style="display:none;left:7px;top:4px">} +
+    assert_equal %{<div id="elt-1" style="display:none;position:absolute;top:4px;left:7px">} +
       %{<svg width="100" height="104"><line x1="7" y1="4" x2="100" y2="104" style="stroke:black;stroke-width:4">} +
       %{</line></svg></div>},
       @calzini.render("line", { "top" => "4", "left" => "7", "x1" => "20", "y1" => "17", "x2" => "100", "y2" => "104", "hidden" => true })
   end
 
   def test_rect_default_stroke
-    assert_equal %{<div id="elt-1" style="display:none">} +
+    assert_equal %{<div id="elt-1" style="display:none;position:absolute;top:9;left:12;width:147;height:91">} +
       %{<svg width="147" height="91"><rect x="12" y="9" width="147" height="91" transform="rotate( 73 45)" />} +
       %{</svg></div>},
       @calzini.render("rect", { "top" => "9", "left" => "12", "width" => "147", "height" => "91", "draw_context" => {}, "hidden" => true })
   end
 
   def test_rect_round_corners
-    assert_equal %{<div id="elt-1" style="display:none">} +
+    assert_equal %{<div id="elt-1" style="display:none;position:absolute;top:9;left:12;width:147;height:91">} +
       %{<svg width="177" height="121"><rect x="12" y="9" width="147" height="91" style="stroke:red" rx="15" transform="rotate( 88 60)" />} +
       %{</svg></div>},
       @calzini.render(
@@ -81,7 +81,7 @@ class TestCalziniArtDrawables < Minitest::Test
   end
 
   def test_rect_hidden
-    assert_equal %{<div id="elt-1" style="display:none">} +
+    assert_equal %{<div id="elt-1" style="display:none;position:absolute;top:4;left:7;width:20;height:17">} +
       %{<svg width="20" height="17"><rect x="7" y="4" width="20" height="17" transform="rotate( 10 8)" />} +
       %{</svg></div>},
       @calzini.render("rect", { "top" => "4", "left" => "7", "width" => "20", "height" => "17", "hidden" => true })

--- a/scarpe-components/test/calzini/test_calzini_button.rb
+++ b/scarpe-components/test/calzini/test_calzini_button.rb
@@ -30,9 +30,7 @@ class TestCalziniButton < Minitest::Test
       "font" => "Lucida",
     }
     assert_equal %{<button id="elt-1" onclick="handle('click')" onmouseover="handle('hover')" } +
-      %{style="background-color:red;padding-top:4;padding-bottom:5;color:blue;} +
-      %{width:201px;height:203px;font-size:17px;top:10;left:11;position:absolute;} +
-      %{font-family:Lucida"></button>},
+      %{style="position:absolute;top:10;left:11;width:201px;height:203px;background-color:red;padding-top:4;padding-bottom:5;color:blue;font-size:17px;font-family:Lucida"></button>},
       @calzini.render("button", props)
   end
 

--- a/scarpe-components/test/calzini/test_calzini_misc.rb
+++ b/scarpe-components/test/calzini/test_calzini_misc.rb
@@ -33,7 +33,7 @@ class TestCalziniMiscDrawables < Minitest::Test
   end
 
   def test_edit_box_simple
-    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" style="height:50;width:75">default</textarea>},
+    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" style="width:75;height:50">default</textarea>},
       @calzini.render("edit_box", { "height" => "50", "width" => "75", "text" => "default" })
   end
 
@@ -63,7 +63,7 @@ class TestCalziniMiscDrawables < Minitest::Test
   end
 
   def test_image_with_abs_positioning
-    assert_equal %{<img id="elt-1" src="https://example.com/example.png" style="width:150;height:200;top:15;left:20;position:absolute" />},
+    assert_equal %{<img id="elt-1" src="https://example.com/example.png" style="position:absolute;top:15;left:20;width:150;height:200" />},
       @calzini.render("image", { "url" => "https://example.com/example.png", "height" => "200", "width" => "150", "top" => "15", "left" => "20" })
   end
 
@@ -74,14 +74,14 @@ class TestCalziniMiscDrawables < Minitest::Test
 
   def test_list_box_simple
     assert_equal %{<select id="elt-1" onchange="handle('change', this.options[this.selectedIndex].value)"} +
-      %{ style="height:75;width:150"><option value="dog">dog</option>} +
+      %{ style="width:150;height:75"><option value="dog">dog</option>} +
       %{<option value="cat" selected="true">cat</option><option value="bird">bird</option></select>},
       @calzini.render("list_box", { "height" => "75", "width" => "150", "items" => ["dog", "cat", "bird"], "choose" => "cat" })
   end
 
   def test_list_box_none_selected
     assert_equal %{<select id="elt-1" onchange="handle('change', this.options[this.selectedIndex].value)"} +
-      %{ style="height:75;width:150"><option value="dog">dog</option>} +
+      %{ style="width:150;height:75"><option value="dog">dog</option>} +
       %{<option value="cat">cat</option><option value="bird">bird</option></select>},
       @calzini.render("list_box", { "height" => "75", "width" => "150", "items" => ["dog", "cat", "bird"] })
   end

--- a/scarpe-components/test/calzini/test_calzini_para.rb
+++ b/scarpe-components/test/calzini/test_calzini_para.rb
@@ -14,7 +14,7 @@ class TestCalziniPara < Minitest::Test
   end
 
   def test_para_with_align
-    assert_equal %{<p id="elt-1" style="text-align:right">OK</p>},
+    assert_equal %{<div id=\"elt-1\" style=\"text-align:right;width:100%\"><p>OK</p></div>},
       @calzini.render("para", { "align" => "right" }) { "OK" }
   end
 

--- a/test/test_edit_box.rb
+++ b/test/test_edit_box.rb
@@ -48,7 +48,7 @@ class TestEditBoxShoesSpec < ShoesSpecLoggedTest
         :textarea,
         id: html_id,
         oninput: "scarpeHandler('#{box.display.shoes_linkable_id}-change', this.value)",
-        style: "height:120px;width:100px" do
+        style: "width:100px;height:120px" do
         "Hello, World!"
       end
     TEST_CODE

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -35,7 +35,7 @@ class TestWebviewImage < ScarpeWebviewTest
     left = 5
     img = Scarpe::Webview::Image.new(@default_properties.merge(top:, left:))
 
-    assert_contains_html img.to_html, :img, id: img.html_id, src: @url, style: "top:#{top}px;left:#{left}px;position:absolute"
+    assert_contains_html img.to_html, :img, id: img.html_id, src: @url, style: "position:absolute;top:#{top}px;left:#{left}px"
   end
 
   def test_renders_image_with_specified_size_and_position
@@ -49,7 +49,7 @@ class TestWebviewImage < ScarpeWebviewTest
       :img,
       id: img.html_id,
       src: @url,
-      style: "width:#{width}px;height:#{height}px;top:#{top}px;left:#{left}px;position:absolute"
+      style: "position:absolute;top:#{top}px;left:#{left}px;width:#{width}px;height:#{height}px"
   end
 
   def test_renders_clickable_image


### PR DESCRIPTION
### Description

Set width/height/left/top styles on all drawables, not just divs.
Have stacks and flows use the now-standard init_args for initialize. Fix up CSS positions to more nearly line up stacks and flows where they should be. Re-add flags examples from a long-ago PR written by christhesoul.

### Image(if needed, helps for a faster review)

<img width="372" alt="Screenshot 2023-12-07 at 22 35 54" src="https://github.com/scarpe-team/scarpe/assets/82408/e5269d2e-4870-4b22-a0ba-7f1aaa03dba2">
<img width="496" alt="Screenshot 2023-12-07 at 22 36 08" src="https://github.com/scarpe-team/scarpe/assets/82408/3d9fbc27-056a-4120-b97f-b34b86bfd457">

### Checklist

- [ ] Run tests locally
