### PR TITLE
Move margin and padding styles from slots to all drawables

### DIFF
--- a/examples/margin_check.rb
+++ b/examples/margin_check.rb
@@ -1,0 +1,27 @@
+Shoes.app do
+  background blue
+
+  @stack1 = stack(width: 100, height: 100) do
+    background red
+    b = button("Push me", margin: [10, 5, 25, 10]) do
+      alert "Aha! Click!"
+    end
+  end
+
+  @stack1 = stack do
+    background aquamarine
+    b = button("Hash margin", margin: { left: 10, right: 5, top: 25, bottom: 10 }) do
+      alert "Aha! Click!"
+    end
+  end
+
+  stack(width: 100, height: 100) do
+    background yellow
+    button "Middle Button", margin: 5, margin_top: 30
+  end
+
+  @stack2 = stack(width: 100, height: 100) do
+    background green
+    button "OK 2"
+  end
+end

--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -38,7 +38,6 @@ require_relative "shoes/builtins"
 
 require_relative "shoes/background"
 require_relative "shoes/border"
-require_relative "shoes/spacing"
 
 require_relative "shoes/drawable"
 require_relative "shoes/app"

--- a/lacci/lib/shoes/drawable.rb
+++ b/lacci/lib/shoes/drawable.rb
@@ -230,6 +230,12 @@ class Shoes
     # Every Shoes drawable has positioning properties
     shoes_styles :top, :left, :width, :height
 
+    # Margins around drawable
+    shoes_styles :margin, :margin_top, :margin_bottom, :margin_left, :margin_right
+
+    # Padding around drawable
+    shoes_styles :padding, :padding_top, :padding_bottom, :padding_left, :padding_right
+
     # Shoes uses a "hidden" style property for hide/show
     shoes_style :hidden
 

--- a/lacci/lib/shoes/drawables/flow.rb
+++ b/lacci/lib/shoes/drawables/flow.rb
@@ -4,11 +4,9 @@ class Shoes
   class Flow < Shoes::Slot
     include Shoes::Background
     include Shoes::Border
-    include Shoes::Spacing
 
     Shoes::Drawable.drawable_default_styles[Shoes::Flow][:width] = "100%"
 
-    shoes_styles :width, :height, :margin, :padding
     shoes_events
 
     def initialize(*args, **kwargs, &block)

--- a/lacci/lib/shoes/drawables/stack.rb
+++ b/lacci/lib/shoes/drawables/stack.rb
@@ -4,9 +4,8 @@ class Shoes
   class Stack < Shoes::Slot
     include Shoes::Background
     include Shoes::Border
-    include Shoes::Spacing
 
-    shoes_styles :width, :height, :scroll
+    shoes_styles :scroll
 
     shoes_events # No Stack-specific events
 

--- a/lacci/lib/shoes/drawables/widget.rb
+++ b/lacci/lib/shoes/drawables/widget.rb
@@ -38,7 +38,6 @@
 class Shoes::Widget < Shoes::Slot
   include Shoes::Background
   include Shoes::Border
-  include Shoes::Spacing
 
   shoes_events
 

--- a/lacci/lib/shoes/spacing.rb
+++ b/lacci/lib/shoes/spacing.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class Shoes
-  module Spacing
-    def self.included(includer)
-      includer.shoes_styles :margin, :padding, :margin_top, :margin_left, :margin_right, :margin_bottom, :options
-    end
-  end
-end

--- a/scarpe-components/lib/scarpe/components/calzini.rb
+++ b/scarpe-components/lib/scarpe/components/calzini.rb
@@ -127,7 +127,61 @@ module Scarpe::Components::Calzini
     styles[:width] = dimensions_length(props["width"]) if props["width"]
     styles[:height] = dimensions_length(props["height"]) if props["height"]
 
+    styles = spacing_styles_for_attr("margin", props, styles)
+    styles = spacing_styles_for_attr("padding", props, styles)
+
     styles
+  end
+
+  SPACING_DIRECTIONS = [:left, :right, :top, :bottom]
+
+  # We extract the appropriate margin and padding from the margin and
+  # padding properties. If there are no margin or padding properties,
+  # we fall back to props["options"] margin or padding, if it exists.
+  #
+  # Margin or padding (in either props or props["options"]) can be
+  # a Hash with directions as keys, or an Array of left/right/top/bottom,
+  # or a constant, which means all four are that constant. You can
+  # also specify a "margin" plus "margin-top" which is constant but
+  # margin-top is overridden, or similar.
+  #
+  # If any margin or padding property exists in props then we don't
+  # check props["options"].
+  def spacing_styles_for_attr(attr, props, styles, with_options: true)
+    spacing_styles = {}
+
+    case props[attr]
+    when Hash
+      props[attr].each do |dir, value|
+        spacing_styles[:"#{attr}-#{dir}"] = dimensions_length value
+      end
+    when Array
+      SPACING_DIRECTIONS.zip(props[attr]).to_h.compact.each do |dir, value|
+        spacing_styles[:"#{attr}-#{dir}"] = dimensions_length(value)
+      end
+    when String, Numeric
+      spacing_styles[attr.to_sym] = dimensions_length(props[attr])
+    end
+
+    SPACING_DIRECTIONS.each do |dir|
+      if props["#{attr}_#{dir}"]
+        spacing_styles[:"#{attr}-#{dir}"] = dimensions_length props["#{attr}_#{dir}"]
+      end
+    end
+
+    unless spacing_styles.empty?
+      return styles.merge(spacing_styles)
+    end
+
+    # We should see if there are spacing properties in props["options"],
+    # unless we're currently doing that.
+    if with_options && props["options"]
+      spacing_styles = spacing_styles_for_attr(attr, props["options"], {}, with_options: false)
+      styles.merge spacing_styles
+    else
+      # No "options" or we already checked it? Return the styles we were given.
+      styles
+    end
   end
 
   # Convert an [r, g, b, a] array to an HTML hex color code

--- a/scarpe-components/lib/scarpe/components/calzini/slots.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/slots.rb
@@ -32,8 +32,6 @@ module Scarpe::Components::Calzini
     styles = drawable_style(props)
     styles = background_style(props, styles)
     styles = border_style(props, styles)
-    styles = spacing_styles_for_attr("margin", props, styles)
-    styles = spacing_styles_for_attr("padding", props, styles)
 
     styles[:width] = dimensions_length(props["width"]) if props["width"]
     styles[:height] = dimensions_length(props["height"]) if props["height"]
@@ -104,56 +102,5 @@ module Scarpe::Components::Calzini
     end
 
     styles.merge(background: color)
-  end
-
-  SPACING_DIRECTIONS = [:left, :right, :top, :bottom]
-
-  # We extract the appropriate margin and padding from the margin and
-  # padding properties. If there are no margin or padding properties,
-  # we fall back to props["options"] margin or padding, if it exists.
-  #
-  # Margin or padding (in either props or props["options"]) can be
-  # a Hash with directions as keys, or an Array of left/right/top/bottom,
-  # or a constant, which means all four are that constant. You can
-  # also specify a "margin" plus "margin-top" which is constant but
-  # margin-top is overridden, or similar.
-  #
-  # If any margin or padding property exists in props then we don't
-  # check props["options"].
-  def spacing_styles_for_attr(attr, props, styles, with_options: true)
-    spacing_styles = {}
-
-    case props[attr]
-    when Hash
-      props[attr].each do |dir, value|
-        spacing_styles[:"#{attr}-#{dir}"] = dimensions_length value
-      end
-    when Array
-      SPACING_DIRECTIONS.zip(props[attr]).to_h.compact.each do |dir, value|
-        spacing_styles[:"#{attr}-#{dir}"] = dimensions_length(value)
-      end
-    when String, Numeric
-      spacing_styles[attr.to_sym] = dimensions_length(props[attr])
-    end
-
-    SPACING_DIRECTIONS.each do |dir|
-      if props["#{attr}_#{dir}"]
-        spacing_styles[:"#{attr}-#{dir}"] = dimensions_length props["#{attr}_#{dir}"]
-      end
-    end
-
-    unless spacing_styles.empty?
-      return styles.merge(spacing_styles)
-    end
-
-    # We should see if there are spacing properties in props["options"],
-    # unless we're currently doing that.
-    if with_options && props["options"]
-      spacing_styles = spacing_styles_for_attr(attr, props["options"], {}, with_options: false)
-      styles.merge spacing_styles
-    else
-      # No "options" or we already checked it? Return the styles we were given.
-      styles
-    end
   end
 end

--- a/scarpe-components/test/calzini/test_calzini_button.rb
+++ b/scarpe-components/test/calzini/test_calzini_button.rb
@@ -30,7 +30,7 @@ class TestCalziniButton < Minitest::Test
       "font" => "Lucida",
     }
     assert_equal %{<button id="elt-1" onclick="handle('click')" onmouseover="handle('hover')" } +
-      %{style="position:absolute;top:10;left:11;width:201px;height:203px;background-color:red;padding-top:4;padding-bottom:5;color:blue;font-size:17px;font-family:Lucida"></button>},
+      %{style="position:absolute;top:10;left:11;width:201px;height:203px;padding-top:4;padding-bottom:5;background-color:red;color:blue;font-size:17px;font-family:Lucida"></button>},
       @calzini.render("button", props)
   end
 


### PR DESCRIPTION
### Description

Originally margin and padding were only on slots. This moves them to all drawables. The included examples shows this with a button.

Pairing PR w/ @noahgibbs and @zoomzam 

### Image(if needed, helps for a faster review)

<img width="491" alt="Screenshot 2023-12-09 at 12 31 42" src="https://github.com/scarpe-team/scarpe/assets/82408/dff89359-6add-4442-a48d-4bc2fb08acc0">

### Checklist

- [X] Run tests locally
