### PR TITLE
I wasn't supporting the button html_class extension in Tiranti. D'oh!

### DIFF
--- a/examples/scarpe_ext.rb
+++ b/examples/scarpe_ext.rb
@@ -1,4 +1,3 @@
-Shoes.app(features: :scarpe) do
-  para "This text could be CSS-ified", html_attributes: { class: "button_css_class" }
-  button "OK"
+Shoes.app(features: :html) do
+  button "OK", html_class: "btn-warning"
 end

--- a/scarpe-components/lib/scarpe/components/tiranti.rb
+++ b/scarpe-components/lib/scarpe/components/tiranti.rb
@@ -73,16 +73,16 @@ module Scarpe::Components::Tiranti
     HTML
   end
 
-  # def render_stack
-  # end
-  # def render_flow
-  # end
-
   # How do we want to handle theme-specific colours and primary/secondary buttons in Bootstrap?
   # "Disabled" could be checked in properties. Is there any way we can/should use "outline" buttons?
   def button_element(props)
     HTML.render do |h|
-      h.button(id: html_id, type: "button", class: "btn btn-primary", onclick: handler_js_code("click"), style: button_style(props)) do
+      h.button(
+        id: html_id,
+        type: "button",
+        class: props["html_class"] ? "btn #{props["html_class"]}" : "btn btn-primary",
+          onclick: handler_js_code("click"), style: button_style(props)
+      ) do
         props["text"]
       end
     end


### PR DESCRIPTION
Also, a little random cleanup

### Description

I added an html_class Scarpe extension for button. Tiranti is the obvious place to use it - Bootstrap has some good custom HTML classes. But Tiranti didn't support it. Fix that.

### Checklist

- [ ] Run tests locally
