### PR TITLE
Set Drawable parents when it's created, not later

### DIFF
--- a/lacci/lib/shoes/drawables/slot.rb
+++ b/lacci/lib/shoes/drawables/slot.rb
@@ -4,11 +4,12 @@ class Shoes::Slot < Shoes::Drawable
   # @incompatibility Shoes uses #content, not #children, for this. Scarpe does both.
   attr_reader :children
 
+  shoes_events # No Slot-specific events
+
   # This only shows this specific slot's settings, not its parent's.
   # Use current_draw_context to allow inheritance.
   attr_reader :draw_context
 
-  shoes_events # No Slot-specific events
 
   def initialize(...)
     # The draw context tracks current settings like fill and stroke,


### PR DESCRIPTION
### Description

The control flow for Drawables has been a little clunky. We create them, *then* we set their parent. That makes it awkward to do things at create time related to who your parent is -- you don't know yet.

With this PR we always create drawables in the current slot, which means we always know what the parent is going to be. When we do things like "@stack.button 'new'" that means we need to (briefly) push a new current slot, so we do that.

Also, added a bunch of tests for this in Niente. For now I'm going to assume that Scarpe already has reasonable create/remove drawable tests for its own display-specific stuff.

PR #513 (draw context) needs to know parents to set parent-inherited properties, so I built this as a stepping stone for it.

This PR also needs Lacci testing in decent shape, so it depends on #512. It would be good to merge #512 first, because this is committed on top of its commit.

This changes the Lacci drawable-create event. I put a note in the CHANGELOG about it and updated Scarpe-Webview and Niente. But Scarpe-Wasm will also need a (small) update when this gets merged.

### Checklist

- [X] Run tests locally
