### PR TITLE
Allow SSpec files as Scarpe tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ still making big changes.
 
 - Ovals!
 - Features! Shoes.app(feature: [:html, :scarpe]) lets apps declare dependencies on non-classic Shoes!
+- The html_class style is a feature to make it easier to do Bootstrap styling on your drawables
 - Directly run Shoes Specs, including with Niente
-- We use Minitest assertion DSL rather than our own nearly everywhere now
-- Better handling of :left, :top, :width and :height on more drawables
+- We use Minitest assertion DSL rather than our own everywhere now
+- Better handling of :left, :top, :width and :height, :margin and :padding on more drawables
 
 ### Bugs Fixed
 

--- a/lib/scarpe/wv/web_wrangler.rb
+++ b/lib/scarpe/wv/web_wrangler.rb
@@ -261,6 +261,7 @@ module Scarpe::Webview
           @log.debug("Scheduled JS: (#{this_eval_serial})\n#{wrapped_code}")
         else
           # We're mid-shutdown. No more scheduling things.
+          @log.warn "Mid-shutdown JS eval. Not scheduling JS!"
         end
       end
 

--- a/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_export_reporter.rb
@@ -25,10 +25,17 @@ module Minitest
     #
     # Based on https://gist.github.com/davidwessman/09a13840a8a80080e3842ac3051714c7
     class ShoesExportReporter < BaseReporter
+      class << self
+        attr_accessor :metadata
+        attr_accessor :export_file
+      end
+
       def self.activate!
         unless ENV["SHOES_MINITEST_EXPORT_FILE"]
           raise "ShoesExportReporter is available, but no export file was specified! Set SHOES_MINITEST_EXPORT_FILE!"
         end
+        ShoesExportReporter.export_file = File.expand_path(ENV["SHOES_MINITEST_EXPORT_FILE"])
+        ShoesExportReporter.metadata ||= {}
 
         Minitest::Reporters.use!
       end
@@ -58,6 +65,7 @@ module Minitest
             failures: failures,
             time: result.time,
             metadata: result.respond_to?(:metadata) ? result.metadata : {},
+            exporter_metadata: ShoesExportReporter.metadata,
             source_location: begin
               result.source_location
             rescue
@@ -66,7 +74,7 @@ module Minitest
           }
         end
 
-        out_file = File.expand_path ENV["SHOES_MINITEST_EXPORT_FILE"]
+        out_file = ShoesExportReporter.export_file
         #puts "Writing Minitest results to #{out_file.inspect}."
         File.write(out_file, JSON.dump(results))
       end

--- a/scarpe-components/lib/scarpe/components/minitest_result.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_result.rb
@@ -56,6 +56,32 @@ class Scarpe::Components::MinitestResult
     end
   end
 
+  def one_word_result
+    return "error" if self.error?
+    return "fail" if self.fail?
+    return "skip" if self.skip?
+    "success"
+  end
+
+  def check(expect_result: :success, min_asserts: nil, max_asserts: nil)
+    unless [:error, :fail, :skip, :success].include?(expect_result)
+      raise Scarpe::InternalError, "Expected test result should be one of [:success, :fail, :error, :skip]!"
+    end
+
+    if expect_result.to_s != one_word_result
+      return [false, "Expected #{expect_result} but got #{one_word_result}!"]
+    end
+
+    if min_asserts && @assertions < min_asserts
+      return [false, "Expected success with at least #{min_asserts} assertions but found only #{@assertions}!"]
+    end
+    if max_asserts && @assertions > max_asserts
+      return [false, "Expected success with no more than #{max_asserts} assertions but found only #{@assertions}!"]
+    end
+
+    [true, ""]
+  end
+
   def error?
     !@exceptions.empty?
   end

--- a/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
+++ b/scarpe-components/lib/scarpe/components/segmented_file_loader.rb
@@ -176,7 +176,7 @@ module Scarpe::Components
         "shoes" => proc { |seg_file| after_load { load seg_file } },
         "app_test" => proc do |seg_file|
           ENV["SHOES_SPEC_TEST"] = seg_file
-          ENV["SHOES_MINITEST_EXPORT_FILE"] = "sspec.json"
+          ENV["SHOES_MINITEST_EXPORT_FILE"] ||= "sspec.json"
         end,
       }
     end

--- a/scarpe-components/lib/scarpe/components/tiranti.rb
+++ b/scarpe-components/lib/scarpe/components/tiranti.rb
@@ -2,8 +2,8 @@
 
 # In Italian, tiranti are bootstraps -- the literal pull-on-a-boot kind, not a step to something better.
 # Tiranti.rb builds on calzini.rb, but renders a Bootstrap-decorated version of the HTML output.
-# You would ordinarily set either Calzini or Tiranti as the top-level HTML renderer, not both.
-# You'll include both if you use Tiranti, because it falls back to Calzini for a lot of its rendering.
+# You can set Tiranti as your HTML renderer and you'll get Bootstrap versions of all the drawables.
+# Tiranti requires Calzini's files because it falls back to Calzini for a lot of its rendering.
 
 require "scarpe/components/calzini"
 

--- a/test/test_sspec_infrastructure.rb
+++ b/test/test_sspec_infrastructure.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Having trouble here - need to make sure we're getting
+# assertions and exceptions as expected.
+class TestSSpecInfrastructure < ShoesSpecLoggedTest
+  self.logger_dir = File.expand_path("#{__dir__}/../logger")
+
+  def test_simple_assertion_success
+    run_scarpe_sspec_code(<<~'SSPEC')
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      assert_equal true, true
+    SSPEC
+  end
+
+  def test_exception
+    run_scarpe_sspec_code(<<~'SSPEC', expect_result: :error)
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      raise "Yup, that's an exception!"
+    SSPEC
+  end
+
+  def test_many_assertions
+    run_scarpe_sspec_code(<<~'SSPEC', expect_assertions_min: 10)
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      10.times { assert_equal true, true }
+    SSPEC
+  end
+
+  def test_skip
+    run_scarpe_sspec_code(<<~'SSPEC', expect_result: :skip)
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      skip
+    SSPEC
+  end
+
+  def test_assertion_fail
+    run_scarpe_sspec_code(<<~'SSPEC', expect_result: :fail)
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      assert_equal true, false, "This should always fail!"
+    SSPEC
+  end
+
+end


### PR DESCRIPTION
### Description

It turns out there was a bug in the file loader that was doing something I didn't want. This fixes that, adds tests and adds test_helper code so you can add Shoes-Spec sspec files as tests in Scarpe.

### Checklist

- [ ] Run tests locally
