### PR TITLE
More timeout options for sspec tests

### DIFF
--- a/scarpe-components/lib/scarpe/components/minitest_result.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_result.rb
@@ -63,13 +63,21 @@ class Scarpe::Components::MinitestResult
     "success"
   end
 
+  def result_and_message
+    return ["error", error_message] if self.error?
+    return ["fail", fail_message] if self.fail?
+    return ["skip", skip_message] if self.skip?
+    ["success", "OK"]
+  end
+
   def check(expect_result: :success, min_asserts: nil, max_asserts: nil)
     unless [:error, :fail, :skip, :success].include?(expect_result)
       raise Scarpe::InternalError, "Expected test result should be one of [:success, :fail, :error, :skip]!"
     end
 
-    if expect_result.to_s != one_word_result
-      return [false, "Expected #{expect_result} but got #{one_word_result}!"]
+    res, msg = result_and_message
+    if expect_result.to_s != res
+      return [false, "Expected #{expect_result} but got #{res}: #{msg}!"]
     end
 
     if min_asserts && @assertions < min_asserts

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,8 @@ class ShoesSpecLoggedTest < Minitest::Test
     expect_assertions_min: nil,
     expect_assertions_max: nil,
     expect_result: :success,
+    timeout: 10.0, # or :none for no timeout
+    wait_after_test: false,
     display_service: "wv_local",
     html_renderer: "calzini"
   )
@@ -61,6 +63,8 @@ class ShoesSpecLoggedTest < Minitest::Test
         "SCARPE_DISPLAY_SERVICE=#{display_service} " +
         "SCARPE_HTML_RENDERER=#{html_renderer} " +
         "SCARPE_LOG_CONFIG=\"#{scarpe_log_config}\" " +
+        "SCARPE_SSPEC_TIMEOUT=\"#{timeout}\" " +
+        "#{wait_after_test ? "SCARPE_SSPEC_TIMEOUT_WAIT_AFTER_TEST=Y" : ""} " +
         "SHOES_MINITEST_EXPORT_FILE=\"#{test_output}\" " +
         "SHOES_MINITEST_CLASS_NAME=\"#{test_class_name}\" " +
         "SHOES_MINITEST_METHOD_NAME=\"#{test_method_name}\" " +
@@ -72,7 +76,7 @@ class ShoesSpecLoggedTest < Minitest::Test
         if process_success
           assert false, "Expected sspec test process to return success and it failed! Exit code: #{$?.exitstatus}"
         else
-          assert false, "Expected sspec test process to return failure and it succeeded!"
+          assert false, "Expected sspec test process to return failure and it succeeded! Exit code: #{$?.exitstatus}"
         end
       end
     end

--- a/test/test_sspec_infrastructure.rb
+++ b/test/test_sspec_infrastructure.rb
@@ -18,6 +18,55 @@ class TestSSpecInfrastructure < ShoesSpecLoggedTest
     SSPEC
   end
 
+  def test_empty_assertions
+    run_scarpe_sspec_code(<<~'SSPEC')
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      # Without at least a comment, the file parser doesn't catch that this section is here.
+    SSPEC
+  end
+
+  # Here's a weird thing: we want to detect the test failure somehow. And right now we
+  # can't usefully tell the timeout to cause the *process* to fail just from the timeout.
+  # We'll still notice test failures or not hitting enough assertions.
+  def test_timeout_no_fail
+    run_scarpe_sspec_code(<<~'SSPEC', timeout: 1.0, wait_after_test: true, expect_assertions_min: 1)
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      assert_equal true, true
+    SSPEC
+  end
+
+  def test_timeout_test_fail
+    run_scarpe_sspec_code(<<~'SSPEC', timeout: 1.0, wait_after_test: true, expect_result: :fail)
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      assert_equal false, true
+    SSPEC
+  end
+
+  # Specify ":none" for timeout. In this case it will still finish promptly -- just checking
+  # that the setting works.
+  def test_no_timeout
+    run_scarpe_sspec_code(<<~'SSPEC', timeout: :none)
+      ---
+      ----------- app code
+      Shoes.app do
+      end
+      ----------- test code
+      assert_equal true, true
+    SSPEC
+  end
+
   def test_exception
     run_scarpe_sspec_code(<<~'SSPEC', expect_result: :error)
       ---


### PR DESCRIPTION
### Description

Our pre-Shoes-Spec test infrastructure had a bunch of timeout and failure options. Turns out I need some of those for testing display properties, too. So I'm adding them for Shoes-Spec.

### Checklist

- [X] Run tests locally
