### PR TITLE
PR for :emphasis property in issue#520

### DIFF
--- a/scarpe-components/lib/scarpe/components/calzini/para.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/para.rb
@@ -44,6 +44,16 @@ module Scarpe::Components::Calzini
       "font-family": props["font"],
       "text-decoration-line": strikethrough ? "line-through" : nil,
       "text-decoration-color": props["strikecolor"] ? rgb_to_hex(props["strikecolor"]) : nil,
+      :'font-style' => case props["emphasis"]
+            when "normal"
+                "normal"
+            when "oblique"
+                "oblique"
+            when "italic"
+                "italic"
+            else
+                nil
+            end
     }.compact
 
     s2 = {}
@@ -74,19 +84,6 @@ module Scarpe::Components::Calzini
     else
       # This should normally be unreachable
       raise Shoes::Errors::InvalidAttributeValueError, "Unexpected underline type #{props["underline"].inspect}!"
-    end
-
-    s1[:'font-style'] = case props["emphasis"]
-    when "normal"
-      "normal"
-    when "oblique"
-      "oblique"
-    when "italic"
-      "italic"
-    when nil
-      "normal" # Set a default value for nil
-    else
-      "normal" # Handle any unexpected value with a default
     end
 
     [s1, s2]

--- a/scarpe-components/lib/scarpe/components/calzini/para.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/para.rb
@@ -92,9 +92,6 @@ module Scarpe::Components::Calzini
     [s1, s2]
   end
 
-    [s1, s2]
-  end
-
   def para_font_size(props)
     return nil unless props["size"]
 

--- a/scarpe-components/lib/scarpe/components/calzini/para.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/para.rb
@@ -76,6 +76,22 @@ module Scarpe::Components::Calzini
       raise Shoes::Errors::InvalidAttributeValueError, "Unexpected underline type #{props["underline"].inspect}!"
     end
 
+    s1[:'font-style'] = case props["emphasis"]
+    when "normal"
+      "normal"
+    when "oblique"
+      "oblique"
+    when "italic"
+      "italic"
+    when nil
+      "normal" # Set a default value for nil
+    else
+      "normal" # Handle any unexpected value with a default
+    end
+
+    [s1, s2]
+  end
+
     [s1, s2]
   end
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to Scarpe! 💖
-->

### Description

for #520 
<!-- Please write a summary of the change, Please also include relevant motivation and context: -->
This PR introduces support for the :emphasis style within the text rendering functionalities of Scarpe. It enables the italicization of text elements such as em, span, and other applicable tags based on Shoes conventions.

Motivation and Context:

- Feature Enhancement: By incorporating support for the :emphasis style, Scarpe gains the ability to properly italicize text where necessary, improving visual representation and flexibility in text styling.

- Alignment with Specifications: This change aligns Scarpe's text styling capabilities with the expected behavior specified for the :emphasis style in Shoes. It allows for three settings: "normal," "oblique," and "italic," enabling versatile text formatting.

### Checklist

- [x] Run tests locally
