### PR TITLE
PR for :rise and :kerning in issue#520

### DIFF
--- a/scarpe-components/lib/scarpe/components/calzini/para.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/para.rb
@@ -55,7 +55,7 @@ module Scarpe::Components::Calzini
                 nil
             end,
       :'letter-spacing' => props["kerning"] ? "#{props["kerning"]}px" : nil,
-      :'baseline-shift' => props["rise"] ? "#{props["rise"]}px" : nil
+      :'vertical-align' => props["rise"] ? "#{props["rise"]}px" : nil
     }.compact
 
     s2 = {}

--- a/scarpe-components/lib/scarpe/components/calzini/para.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/para.rb
@@ -53,7 +53,9 @@ module Scarpe::Components::Calzini
                 "italic"
             else
                 nil
-            end
+            end,
+      :'letter-spacing' => props["kerning"] ? "#{props["kerning"]}px" : nil,
+      :'baseline-shift' => props["rise"] ? "#{props["rise"]}px" : nil
     }.compact
 
     s2 = {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to Scarpe! 💖
-->

### Description

for #520 

<!-- Please write a summary of the change, Please also include relevant motivation and context: -->
This PR introduces support for the :rise and :kerning style within the text rendering functionalities of Scarpe. 

For ":rise", it allows for the vertical adjustment of the font baseline, providing the ability to lift or plunge text elements based on the specified numeric value. This enhancement aligns Scarpe's text styling capabilities with the expected behavior specified for the :rise style in Shoes, offering increased control over the visual representation of text. 

And for ":kerning", it enables the adjustment of letter spacing in text elements, allowing for precise control over the natural spacing between letters. By incorporating support for :kerning, Scarpe enhances its text styling capabilities, aligning with the specified behavior in Shoes. This feature provides flexibility in text formatting, ensuring a visually appealing representation.


### Checklist

- [x] Run tests locally