### PR TITLE
When a checkbox is clicked, correctly call the handler if present.

### DIFF
--- a/examples/check.rb
+++ b/examples/check.rb
@@ -5,6 +5,8 @@ Shoes.app do
       flow { check; para "Kin-Dza-Dza by Georgi Danelia" }
       flow { check; para "Children of Heaven by Majid Majidi" }
       @btn = check; para "The White Balloon by Jafar Panahi"
+      @p = para ""
+      @btn.click { @p.replace("Clicked! Yay!") }
       flow do
         button "Mark me" do
           @btn.checked = true

--- a/lacci/lib/shoes/drawables/check.rb
+++ b/lacci/lib/shoes/drawables/check.rb
@@ -11,13 +11,15 @@ class Shoes
       @block = block
       super
 
-      bind_self_event("click") { click }
+      bind_self_event("click") do
+        self.checked = !checked?
+        @block.call(self) if @block
+      end
       create_display_drawable
     end
 
     def click(&block)
       @block = block
-      self.checked = !checked?
     end
 
     def checked?

--- a/test/wv/html_fixtures/check.html
+++ b/test/wv/html_fixtures/check.html
@@ -20,8 +20,9 @@
         </div>
         <input type="checkbox" id="14" onclick="scarpeHandler('14-click')" />
         <p id="15" style="font-size:12px">The White Balloon by Jafar Panahi</p>
-        <div id="16" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%">
-          <div style="height:100%;width:100%;position:relative"><button id="17" onclick="scarpeHandler('17-click')" onmouseover="scarpeHandler('17-hover')">Mark me</button><button id="18" onclick="scarpeHandler('18-click')" onmouseover="scarpeHandler('18-hover')">unmark me</button></div>
+        <p id="16" style="font-size:12px"></p>
+        <div id="17" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%">
+          <div style="height:100%;width:100%;position:relative"><button id="18" onclick="scarpeHandler('18-click')" onmouseover="scarpeHandler('18-hover')">Mark me</button><button id="19" onclick="scarpeHandler('19-click')" onmouseover="scarpeHandler('19-hover')">unmark me</button></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description

Turns out we weren't handling checkboxes correctly - calling click, which sets the handler, rather than calling the handler.

### Checklist

- [X] Run tests locally
