### PR TITLE
Added new Para Styles

### DIFF
--- a/examples/para_font_styles.rb
+++ b/examples/para_font_styles.rb
@@ -1,0 +1,9 @@
+Shoes.app do
+    
+    para "this text is in normal styl" , emphasis:"italic"
+
+    para "this text is in italic style" , font: "italic normal bold 16px/1.5 'Times New Roman', serif;"
+
+    para "this text is in oblique style " , family: "'Pacifico', cursive;"
+end
+

--- a/examples/para_font_variant.rb
+++ b/examples/para_font_variant.rb
@@ -1,0 +1,6 @@
+Shoes.app do
+    para "This is Normal Variant" ,font_variant: "normal"
+
+    para "This is Small Caps Variant " ,font_variant: "small-caps"
+
+  end

--- a/lacci/lib/shoes/drawables/para.rb
+++ b/lacci/lib/shoes/drawables/para.rb
@@ -2,7 +2,7 @@
 
 class Shoes
   class Para < Shoes::Drawable
-    shoes_styles :text_items, :size, :font, :font_weight
+    shoes_styles :text_items, :size, :family, :font_weight, :font, :font_variant, :emphasis
     shoes_style(:stroke) { |val, _name| Shoes::Colors.to_rgb(val) }
     shoes_style(:fill) { |val, _name| Shoes::Colors.to_rgb(val) }
 

--- a/scarpe-components/lib/scarpe/components/calzini/para.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/para.rb
@@ -39,10 +39,12 @@ module Scarpe::Components::Calzini
     strikethrough = props["strikethrough"]
     strikethrough = nil if strikethrough == "" || strikethrough == "none"
     s1 = {
+      "font": props["font"],
+      "font-variant": props["font_variant"],
       "color": rgb_to_hex(props["stroke"]),
       "background-color": rgb_to_hex(props["fill"]),
       "font-size": para_font_size(props),
-      "font-family": props["font"],
+      "font-family": props["family"],
       "text-decoration-line": strikethrough ? "line-through" : nil,
       "text-decoration-color": props["strikecolor"] ? rgb_to_hex(props["strikecolor"]) : nil,
       "font-weight": props["font_weight"]? props["font_weight"] : nil,

--- a/scarpe-components/test/calzini/test_calzini_para.rb
+++ b/scarpe-components/test/calzini/test_calzini_para.rb
@@ -19,7 +19,7 @@ class TestCalziniPara < Minitest::Test
 
   def test_para_with_stroke_and_font
     assert_equal %{<p id="elt-1" style="color:#FF0000;font-family:Lucida">OK</p>},
-      @calzini.render("para", { "stroke" => [1.0, 0.0, 0.0], "font" => "Lucida" }) { "OK" }
+      @calzini.render("para", { "stroke" => [1.0, 0.0, 0.0], "family" => "Lucida" }) { "OK" }
   end
 
   def test_para_with_string_banner

--- a/scarpe-components/test/calzini/test_calzini_text_drawables.rb
+++ b/scarpe-components/test/calzini/test_calzini_text_drawables.rb
@@ -31,7 +31,7 @@ class TestCalziniTextDrawables < Minitest::Test
           html_id: "1",
           items: ["is"],
           props: {
-            "font" => "Lucida",
+            "family" => "Lucida",
             "size" => 13,
             "stroke" => "#FF00FF",
             "fill" => "#0000FF"

--- a/tasks/check_html_fixtures.rb
+++ b/tasks/check_html_fixtures.rb
@@ -71,7 +71,10 @@ end
 
 file_names.each do |file_name|
   # Read the entire file
+
   content = File.read(File.join(File.expand_path("../examples", __dir__),"#{file_name}"))
+ 
+
   # Skip this file if it contains the magic comment
   next if content.include?("# html_ci: false")
 
@@ -108,8 +111,10 @@ file_names.each do |file_name|
   # Compare to fixture
   dir_path = "test/wv/html_fixtures"
   file_path = "#{dir_path}/#{file_name.split(".")[0]}.html"
-  expected_output = File.read(file_path)
 
+
+  expected_output = File.read(file_path)
+ 
   # Do the comparison
   # diff = Diff::LCS.diff(pretty_html, expected_output)
   diff_output = diff_as_string(pretty_html, expected_output, file_name)

--- a/test/wv/html_fixtures/para_font_styles.html
+++ b/test/wv/html_fixtures/para_font_styles.html
@@ -1,0 +1,9 @@
+<div id="2" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%;height:100%">
+  <div style="height:100%;width:100%;position:relative">
+    <p id="3" style="font-size:12px;font-style:italic">this text is in normal styl</p>
+    <p id="4" style="font:italic normal bold 16px/1.5 'Times New Roman', serif;;font-size:12px">this text is in italic style</p>
+    <p id="5" style="font-size:12px;font-family:'Pacifico', cursive;">this text is in oblique style </p>
+    <div id="root-fonts"></div>
+    <div id="root-alerts"> </div>
+  </div>
+</div>

--- a/test/wv/html_fixtures/para_font_variant.html
+++ b/test/wv/html_fixtures/para_font_variant.html
@@ -1,8 +1,7 @@
 <div id="2" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%;height:100%">
   <div style="height:100%;width:100%;position:relative">
-    <p id="3" style="font:Arial;font-size:20px">Hello, world!</p>
-    <p id="4" style="font:Courier;font-size:20px">Hello, world!</p>
-    <p id="5" style="font:MS Gothic;font-size:20px">Hello, world!</p>
+    <p id="3" style="font-variant:normal;font-size:12px">This is Normal Variant</p>
+    <p id="4" style="font-variant:small-caps;font-size:12px">This is Small Caps Variant </p>
     <div id="root-fonts"></div>
     <div id="root-alerts"> </div>
   </div>


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to Scarpe! 💖
-->

### Description
Added some more para styles like font-variant, font 
updated some para styles like font-family, emphasis

emphasis wasn't working before because it wasn't mentioned in shoes styles in lacci/lib/shoes/drawables/para.rb
font-family was mentioned as font in shoes styles so i changed it to family .

```
Shoes.app do
    
    para "this text is in normal styl" , emphasis:"italic"

    para "this text is in italic style" , font: "italic normal bold 16px/1.5 'Times New Roman', serif;"

    para "this text is in oblique style " , family: "'Pacifico', cursive;"

end
```
```
Shoes.app do

    para "This is Normal Variant" ,font_variant: "normal"


    para "This is Small Caps Variant " ,font_variant: "small-caps"

  end
```

### Image(if needed, helps for a faster review)

<img width="473" alt="Screenshot 2024-01-30 at 7 26 17 PM" src="https://github.com/scarpe-team/scarpe/assets/151559388/489a296e-9c5b-41a7-9176-447ef251554f">

<img width="490" alt="Screenshot 2024-01-30 at 7 27 17 PM" src="https://github.com/scarpe-team/scarpe/assets/151559388/b01b1c13-a09a-4181-8d49-8d90663d9b10">

### Checklist

- [ ] Run tests locally
