### PR TITLE
Added font and tooltip to edit-box

### DIFF
--- a/examples/Edit_box_Styles.rb
+++ b/examples/Edit_box_Styles.rb
@@ -1,0 +1,8 @@
+Shoes.app do
+    para "Anything:",size:"30px"
+    lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim."
+    @manuscript = edit_box(lorem, width: "100%", font:"italic normal bold 25px 'Times New Roman', serif;", tooltip:"This is a tooltip") do |box|
+      @char_count.replace("#{box.text.length} characters")
+    end
+    @char_count = para "#{@manuscript.text.length} characters" ,size:"20px"
+  end

--- a/lacci/lib/shoes/drawables/edit_box.rb
+++ b/lacci/lib/shoes/drawables/edit_box.rb
@@ -2,7 +2,7 @@
 
 class Shoes
   class EditBox < Shoes::Drawable
-    shoes_styles :text, :height, :width
+    shoes_styles :text, :height, :width ,:tooltip, :font
     shoes_events :change
 
     init_args

--- a/lib/scarpe/wv/edit_box.rb
+++ b/lib/scarpe/wv/edit_box.rb
@@ -2,7 +2,7 @@
 
 module Scarpe::Webview
   class EditBox < Drawable
-    attr_reader :text, :height, :width
+    attr_reader :text, :height, :width, :tooltip , :font
 
     def initialize(properties)
       super
@@ -10,6 +10,9 @@ module Scarpe::Webview
       # The JS handler sends a "change" event, which we forward to the Shoes drawable tree
       bind("change") do |new_text|
         send_self_event(new_text, event_name: "change")
+      end
+      bind("hover") do
+        send_self_event(event_name: "hover")
       end
     end
 

--- a/scarpe-components/lib/scarpe/components/calzini/misc.rb
+++ b/scarpe-components/lib/scarpe/components/calzini/misc.rb
@@ -16,7 +16,7 @@ module Scarpe::Components::Calzini
     oninput = handler_js_code("change", "this.value")
 
     HTML.render do |h|
-      h.textarea(id: html_id, oninput: oninput, style: edit_box_style(props)) { props["text"] }
+      h.textarea(id: html_id, oninput: oninput,onmouseover: handler_js_code("hover"), style: edit_box_style(props),title: props["tooltip"]) { props["text"] }
     end
   end
 
@@ -111,6 +111,7 @@ module Scarpe::Components::Calzini
     drawable_style(props).merge({
       height: dimensions_length(props["height"]),
       width: dimensions_length(props["width"]),
+      font: props["font"]? parse_font(props) : nil
     }.compact)
   end
 

--- a/scarpe-components/test/calzini/test_calzini_misc.rb
+++ b/scarpe-components/test/calzini/test_calzini_misc.rb
@@ -23,17 +23,17 @@ class TestCalziniMiscDrawables < Minitest::Test
   end
 
   def test_edit_box_default
-    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)"></textarea>},
+    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)"  onmouseover="handle('hover')"></textarea>},
       @calzini.render("edit_box", {})
   end
 
   def test_edit_box_hidden
-    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" style="display:none"></textarea>},
+    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" style="display:none"  onmouseover="handle('hover')" ></textarea>},
       @calzini.render("edit_box", { "hidden" => true })
   end
 
   def test_edit_box_simple
-    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" style="width:75;height:50">default</textarea>},
+    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" onmouseover="handle('hover')" style="width:75;height:50">default</textarea>},
       @calzini.render("edit_box", { "height" => "50", "width" => "75", "text" => "default" })
   end
 

--- a/scarpe-components/test/calzini/test_calzini_misc.rb
+++ b/scarpe-components/test/calzini/test_calzini_misc.rb
@@ -23,12 +23,12 @@ class TestCalziniMiscDrawables < Minitest::Test
   end
 
   def test_edit_box_default
-    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)"  onmouseover="handle('hover')"></textarea>},
+    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" onmouseover="handle('hover')"></textarea>},
       @calzini.render("edit_box", {})
   end
 
   def test_edit_box_hidden
-    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" style="display:none"  onmouseover="handle('hover')" ></textarea>},
+    assert_equal %{<textarea id="elt-1" oninput="handle('change', this.value)" onmouseover="handle('hover')" style="display:none"></textarea>},
       @calzini.render("edit_box", { "hidden" => true })
   end
 

--- a/test/test_edit_box.rb
+++ b/test/test_edit_box.rb
@@ -12,7 +12,7 @@ class TestEditBoxShoesSpec < ShoesSpecLoggedTest
       end
     SCARPE_APP
       box_disp = edit_box.display
-      assert_contains_html box_disp.to_html, :textarea, id: box_disp.html_id, oninput: "scarpeHandler('#{box_disp.shoes_linkable_id}-change', this.value)" do
+      assert_contains_html box_disp.to_html, :textarea, id: box_disp.html_id, oninput: "scarpeHandler('#{box_disp.shoes_linkable_id}-change', this.value)",onmouseover:"scarpeHandler('#{box_disp.shoes_linkable_id}-hover')" do
         "Hello, World!"
       end
     TEST_CODE
@@ -28,7 +28,7 @@ class TestEditBoxShoesSpec < ShoesSpecLoggedTest
       box = edit_box
       box.text = "Awwww yeah"
       html_id = box.display.html_id
-      assert_contains_html edit_box.display.to_html, :textarea, id: html_id, oninput: "scarpeHandler('#{box.display.shoes_linkable_id}-change', this.value)" do
+      assert_contains_html edit_box.display.to_html, :textarea, id: html_id, oninput: "scarpeHandler('#{box.display.shoes_linkable_id}-change', this.value)", onmouseover:"scarpeHandler('#{box.display.shoes_linkable_id}-hover')" do
         "Awwww yeah"
       end
       # Shoes3 does *not* fire a change event when manually replacing text
@@ -48,6 +48,7 @@ class TestEditBoxShoesSpec < ShoesSpecLoggedTest
         :textarea,
         id: html_id,
         oninput: "scarpeHandler('#{box.display.shoes_linkable_id}-change', this.value)",
+        onmouseover:"scarpeHandler('#{box.display.shoes_linkable_id}-hover')",
         style: "width:100px;height:120px" do
         "Hello, World!"
       end

--- a/test/wv/html_fixtures/Edit_box_Styles.html
+++ b/test/wv/html_fixtures/Edit_box_Styles.html
@@ -1,0 +1,9 @@
+<div id="2" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%;height:100%">
+  <div style="height:100%;width:100%;position:relative">
+    <p id="3" style="font-size:30px">Anything:</p>
+    <textarea id="4" oninput="scarpeHandler('4-change', this.value)" onmouseover="scarpeHandler('4-hover')" style="width:100%;font:italic normal bold 25px 'Times New Roman',serif;" title="This is a tooltip">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim.</textarea>
+    <p id="5" style="font-size:20px">141 characters</p>
+    <div id="root-fonts"></div>
+    <div id="root-alerts"> </div>
+  </div>
+</div>

--- a/test/wv/html_fixtures/edit_box.html
+++ b/test/wv/html_fixtures/edit_box.html
@@ -1,7 +1,7 @@
 <div id="2" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%;height:100%">
   <div style="height:100%;width:100%;position:relative">
     <p id="3" style="font-size:12px">Manuscript:</p>
-    <textarea id="4" oninput="scarpeHandler('4-change', this.value)" style="width:100%">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim.</textarea>
+    <textarea id="4" oninput="scarpeHandler('4-change', this.value)" onmouseover="scarpeHandler('4-hover')" style="width:100%">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim.</textarea>
     <p id="5" style="font-size:12px">141 characters</p>
     <div id="root-fonts"></div>
     <div id="root-alerts"> </div>

--- a/test/wv/html_fixtures/motion_events.html
+++ b/test/wv/html_fixtures/motion_events.html
@@ -6,7 +6,7 @@
         <div onclick="scarpeHandler('7-click', arguments[0].button, arguments[0].x, arguments[0].y)" onmouseenter="scarpeHandler('8-hover')" id="5" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%">
           <div style="height:100%;width:100%;position:relative"><button id="6" onclick="scarpeHandler('6-click')" onmouseover="scarpeHandler('6-hover')" style="width:75px">button 1</button></div>
         </div>
-        <textarea id="9" oninput="scarpeHandler('9-change', this.value)" style="width:500px;height:350px"></textarea>
+        <textarea id="9" oninput="scarpeHandler('9-change', this.value)" onmouseover="scarpeHandler('9-hover')" style="width:500px;height:350px"></textarea>
       </div>
     </div>
     <div id="root-fonts"></div>

--- a/test/wv/html_fixtures/ruby_racer.html
+++ b/test/wv/html_fixtures/ruby_racer.html
@@ -5,13 +5,13 @@
         <div id="4" style="display:flex;flex-direction:column;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:45.0%;margin:5px">
           <div style="height:100%;width:100%;position:relative">
             <p id="5" style="font-size:14px">Racer 1</p>
-            <textarea id="6" oninput="scarpeHandler('6-change', this.value)" style="width:100%;height:100px">for i in 1..10n  a = "1"nendn</textarea>
+            <textarea id="6" oninput="scarpeHandler('6-change', this.value)" onmouseover="scarpeHandler('6-hover')" style="width:100%;height:100px">for i in 1..10n  a = "1"nendn</textarea>
           </div>
         </div>
         <div id="7" style="display:flex;flex-direction:column;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:45.0%;margin:5px">
           <div style="height:100%;width:100%;position:relative">
             <p id="8" style="font-size:14px">Racer 2</p>
-            <textarea id="9" oninput="scarpeHandler('9-change', this.value)" style="width:100%;height:100px">10.times don  a = "1"nendn</textarea>
+            <textarea id="9" oninput="scarpeHandler('9-change', this.value)" onmouseover="scarpeHandler('9-hover')" style="width:100%;height:100px">10.times don  a = "1"nendn</textarea>
           </div>
         </div>
       </div>

--- a/test/wv/html_fixtures/shoes_school.html
+++ b/test/wv/html_fixtures/shoes_school.html
@@ -9,7 +9,7 @@
       <div style="height:100%;width:100%;position:relative">
         <div id="6" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%">
           <div style="height:100%;width:100%;position:relative">
-            <textarea id="7" oninput="scarpeHandler('7-change', this.value)" style="width:100%;height:300px">n        Shoes.app don          para "Hello World"n        endn      </textarea>
+            <textarea id="7" oninput="scarpeHandler('7-change', this.value)" onmouseover="scarpeHandler('7-hover')" style="width:100%;height:300px">n        Shoes.app don          para "Hello World"n        endn      </textarea>
           </div>
         </div>
         <div id="8" style="display:flex;flex-direction:row;flex-wrap:wrap;align-content:flex-start;justify-content:flex-start;align-items:flex-start;width:100%">


### PR DESCRIPTION
### Description
This PR adds:-
1. font-shorthand property to edit-box which allows users to decide how their text should look inside the edit box, and they can write any property in any order if they maintain the white space gap between the properties.

2. Tooltip which can used to give suggestions to people while they input something in the edit box, u can write anything u want to be shown when someone is hovering over the input field (text area), it goes away as soon as someone starts writing not causing any  distraction

```
Shoes.app do
    para "Anything:",size:"30px"
    lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim."
    @manuscript = edit_box(lorem, width: "100%", font:"italic normal bold 25px 'Times New Roman', serif;", tooltip:"This is a tooltip") do |box|
      @char_count.replace("#{box.text.length} characters")
    end
    @char_count = para "#{@manuscript.text.length} characters" ,size:"20px"
  end
```



### Image(if needed, helps for a faster review)


<img width="476" alt="Screenshot 2024-02-02 at 4 25 19 PM" src="https://github.com/scarpe-team/scarpe/assets/151559388/acf2a452-c29b-438f-9278-ecbef1ba52b0">


### Checklist

- [ ] Run tests locally
