### PR TITLE
Add console summary method for printing Minitest results to console

### DIFF
--- a/scarpe-components/lib/scarpe/components/minitest_result.rb
+++ b/scarpe-components/lib/scarpe/components/minitest_result.rb
@@ -70,6 +70,13 @@ class Scarpe::Components::MinitestResult
     ["success", "OK"]
   end
 
+  def console_summary
+    return "Error(s): #{@exceptions.inspect}" if self.error?
+    return "Failure: #{@failures.inspect}" if self.fail?
+    return "Skip: #{skip_message.inspect}" if self.skip?
+    "Success!"
+  end
+
   def check(expect_result: :success, min_asserts: nil, max_asserts: nil)
     unless [:error, :fail, :skip, :success].include?(expect_result)
       raise Scarpe::InternalError, "Expected test result should be one of [:success, :fail, :error, :skip]!"

--- a/scarpe-components/test/test_minitest_result.rb
+++ b/scarpe-components/test/test_minitest_result.rb
@@ -58,4 +58,11 @@ class TestMinitestResult < Minitest::Test
     refute res.passed?
     assert_equal "Just skipping", res.skip_message
   end
+
+  def test_mtr_console_summary
+    path = File.join __dir__, "mtr_data/skipped_w_msg.json"
+    res = Scarpe::Components::MinitestResult.new(path)
+
+    assert res.console_summary.include?("Skip:")
+  end
 end


### PR DESCRIPTION
### Description

This generates a text summary for a Minitest result. That lets us print something like "Skip:" and the skip reason or test failures/exceptions without printing out the whole blob of JSON.

### Checklist

- [ ] Run tests locally
