### PR TITLE
Add ProcessHelpers to Scarpe-Components

### DIFF
--- a/scarpe-components/lib/scarpe/components/process_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/process_helpers.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# These can be used for unit tests, but also more generally.
+
+require_relative "file_helpers"
+
+module Scarpe::Components::ProcessHelpers
+  include Scarpe::Components::FileHelpers
+
+  # Run the command and capture its stdout and stderr output, and whether
+  # it succeeded or failed. Return after the command has completed.
+  # The awkward name is because this is normally a component of another
+  # library. Ordinarily you'd want to raise a library-specific exception
+  # on failure, print a library-specific message or delimiter, or otherwise
+  # handle success and failure. This is too general as-is.
+  #
+  # @param cmd [String,Array<String>] the command to run in Kernel#spawn format
+  # @return [Array(String,String,bool)] the stdout output, stderr output and success/failure of the command in a 3-element Array
+  def run_out_err_result(cmd)
+    out_str = ""
+    err_str = ""
+    success = nil
+
+    with_tempfiles([
+      ["scarpe_cmd_stdout", ""],
+      ["scarpe_cmd_stderr", ""],
+    ]) do |stdout_file, stderr_file|
+      pid = Kernel.spawn(cmd, out: stdout_file, err: stderr_file)
+      Process.wait(pid)
+      success = $?.success?
+      out_str = File.read stdout_file
+      err_str = File.read stderr_file
+    end
+
+    [out_str, err_str, success]
+  end
+end

--- a/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
@@ -5,6 +5,7 @@ require "json"
 require "fileutils"
 
 require "scarpe/components/file_helpers"
+require "scarpe/components/process_helpers"
 
 module Scarpe::Test; end
 
@@ -20,6 +21,7 @@ ALREADY_SET_UP_LOGGED_TEST_FAILURES = { setup: false }
 module Scarpe::Test::Helpers
   # Very useful for tests
   include Scarpe::Components::FileHelpers
+  include Scarpe::Components::ProcessHelpers
 
   # Temporarily set env vars for the block of code inside. The old environment
   # variable values will be restored after the block finishes.

--- a/scarpe-components/test/test_components.rb
+++ b/scarpe-components/test/test_components.rb
@@ -3,7 +3,36 @@
 require_relative "test_helper"
 
 class TestScarpeComponents < Minitest::Test
-  def test_truth
-    assert_equal true, true
+  # Top-level tests go here?
+end
+
+require "scarpe/components/process_helpers"
+class TestComponentHelpers < Minitest::Test
+  include Scarpe::Components::ProcessHelpers
+
+  def test_process_runner_stdout
+    out, err, success = run_out_err_result("echo ok")
+    assert success, "Echoing okay should succeed!"
+    assert_equal "", err
+    assert_includes out, "ok"
+  end
+
+  def test_process_runner_stderr
+    out, err, success = run_out_err_result("echo ok 1>&2")
+    assert success, "Echoing okay to stderr should succeed!"
+    assert_equal "", out
+    assert_includes err, "ok"
+  end
+
+  def test_process_runner_fail
+    out, err, success = run_out_err_result("ls no_such_file_exists")
+    assert !success, "ls on nonexistent file should return failure!"
+    assert_equal "", out
+    assert err != "", "ls on nonexistent file should give non-empty error output"
+  end
+
+  def test_process_runner_command_array
+    out, err, success = run_out_err_result(["echo", "ok"])
+    assert success, "Echoing okay via command array should succeed!"
   end
 end

--- a/scarpe-components/test/test_helper.rb
+++ b/scarpe-components/test/test_helper.rb
@@ -39,5 +39,4 @@ class CalziniRenderer
 end
 
 class Minitest::Test
-  include Scarpe::Test::Helpers
 end

--- a/scarpe-components/test/test_segmented_app_files.rb
+++ b/scarpe-components/test/test_segmented_app_files.rb
@@ -7,6 +7,8 @@ require "scarpe/components/segmented_file_loader"
 SEG_TEST_DATA = {}
 
 class TestSegmentedAppFiles < Minitest::Test
+  include Scarpe::Test::Helpers
+
   def setup
     @orig_file_loaders = Shoes.file_loaders
     Shoes.reset_file_loaders # create new loaders array with no overlap with @orig_file_loaders


### PR DESCRIPTION
### Description

Add Scarpe::Components::ProcessHelpers#run_out_err_result. It will:
* run a command
* check its success or failure
* separately capture its stdout and stderr

Also add tests for it. And refactor the Scarpe::Components tests a bit - only include Scarpe::Components helpers where they're needed, which makes it much easier to properly test the helpers themselves -- e.g. I initially forgot to include FileHelpers in ProcessHelpers. Just including FileHelpers into Minitest::Test, like I was doing earlier, masked that bug.

### Checklist

- [X] Run tests locally
