### PR TITLE
Get CI working again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: brew install pkg-config portaudio
+      - name: Configure library dirs from Homebrew for gems w/ native extensions
+        run: bundle config build.bloops --with-portaudio-dir=`brew --prefix portaudio`
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Ruby and install gems

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,11 +52,13 @@ class ShoesSpecLoggedTest < Minitest::Test
     display_service: "wv_local",
     html_renderer: "calzini"
   )
-    test_output = File.expand_path(File.join __dir__, "sspec.json")
     test_method_name = self.name
     test_class_name = self.class.name
 
-    with_tempfile("scarpe_log_config.json", JSON.dump(log_config_for_test)) do |scarpe_log_config|
+    with_tempfiles([
+      [["scarpe_log_config", "json"], JSON.dump(log_config_for_test)],
+      [["sspec_test_output", "json"], ""]
+    ]) do |scarpe_log_config, test_output|
       # Start the application using the exe/scarpe utility
       # For unit testing always supply --debug so we get the most logging
       cmd = \
@@ -79,15 +81,15 @@ class ShoesSpecLoggedTest < Minitest::Test
           assert false, "Expected sspec test process to return failure and it succeeded! Exit code: #{$?.exitstatus}"
         end
       end
-    end
 
-    result = Scarpe::Components::MinitestResult.new(test_output)
-    correct, msg = result.check(expect_result:, min_asserts: expect_assertions_min, max_asserts: expect_assertions_max)
+      result = Scarpe::Components::MinitestResult.new(test_output)
+      correct, msg = result.check(expect_result:, min_asserts: expect_assertions_min, max_asserts: expect_assertions_max)
 
-    if correct
-      assert_equal true, true # Yup, worked fine
-    else
-      assert false, "Minitest result: #{msg}"
+      if correct
+        assert_equal true, true # Yup, worked fine
+      else
+        assert false, "Minitest result: #{msg}"
+      end
     end
   end
 

--- a/test/test_sspec_infrastructure.rb
+++ b/test/test_sspec_infrastructure.rb
@@ -33,7 +33,7 @@ class TestSSpecInfrastructure < ShoesSpecLoggedTest
   # can't usefully tell the timeout to cause the *process* to fail just from the timeout.
   # We'll still notice test failures or not hitting enough assertions.
   def test_timeout_no_fail
-    run_scarpe_sspec_code(<<~'SSPEC', timeout: 1.0, wait_after_test: true, expect_assertions_min: 1)
+    run_scarpe_sspec_code(<<~'SSPEC', timeout: 2.0, wait_after_test: true, expect_assertions_min: 1)
       ---
       ----------- app code
       Shoes.app do
@@ -44,7 +44,7 @@ class TestSSpecInfrastructure < ShoesSpecLoggedTest
   end
 
   def test_timeout_test_fail
-    run_scarpe_sspec_code(<<~'SSPEC', timeout: 1.0, wait_after_test: true, expect_result: :fail)
+    run_scarpe_sspec_code(<<~'SSPEC', timeout: 2.0, wait_after_test: true, expect_result: :fail)
       ---
       ----------- app code
       Shoes.app do


### PR DESCRIPTION
Right now CI is broken, apparently as a result of the switch from x86-based OSX CI workers to ARM-based. I'm attempting to fix it. I don't have an ARM-based Mac, so I'm mostly using CI to get my results.

### Description

* Fix Homebrew dirs for GitHub changing over to ARM-based OSX workers
* For top-level Scarpe tests, including TestSSpecInfrastructure, use a new clean sspec.json file instead of reusing the same filename
* Longer timeouts on some TestSSpecInfrastructure tests

### Checklist

- [X] Run tests locally
