### PR TITLE
Fix timeout errors in current CI

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -106,7 +106,7 @@ class ShoesSpecLoggedTest < Minitest::Test
   def run_test_scarpe_app(
     test_app_location,
     app_test_code: "",
-    timeout: 10.0,
+    timeout: 12.0,
     exit_immediately: false,
     allow_fail: false,
     display_service: "wv_local"

--- a/test/test_sspec_infrastructure.rb
+++ b/test/test_sspec_infrastructure.rb
@@ -33,7 +33,7 @@ class TestSSpecInfrastructure < ShoesSpecLoggedTest
   # can't usefully tell the timeout to cause the *process* to fail just from the timeout.
   # We'll still notice test failures or not hitting enough assertions.
   def test_timeout_no_fail
-    run_scarpe_sspec_code(<<~'SSPEC', timeout: 2.0, wait_after_test: true, expect_assertions_min: 1)
+    run_scarpe_sspec_code(<<~'SSPEC', timeout: 5.0, wait_after_test: true, expect_assertions_min: 1)
       ---
       ----------- app code
       Shoes.app do


### PR DESCRIPTION
### Description

Increase timeout in frequently-failing test -- maybe the ARM workers are slower?

### Checklist

- [X] Run tests locally
