### PR TITLE
Bump version numbers for release 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,27 @@
 PATH
   remote: .
   specs:
-    scarpe (0.3.0)
+    scarpe (0.4.0)
       bloops (~> 0.5)
-      fastimage
-      lacci
+      fastimage (~> 2.2.7)
+      lacci (~> 0.4.0)
       logging (~> 2.3.1)
-      nokogiri
-      scarpe-components
-      sqlite3
-      webrick
+      nokogiri (~> 1.15.2)
+      scarpe-components (~> 0.4.0)
+      sqlite3 (~> 1.6.3)
+      webrick (~> 1.7.0)
       webview_ruby (~> 0.1.1)
 
 PATH
   remote: lacci
   specs:
-    lacci (0.3.0)
-      scarpe-components
+    lacci (0.4.0)
+      scarpe-components (~> 0.4.0)
 
 PATH
   remote: scarpe-components
   specs:
-    scarpe-components (0.3.0)
+    scarpe-components (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lacci/Gemfile.lock
+++ b/lacci/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ../scarpe-components
   specs:
-    scarpe-components (0.3.0)
+    scarpe-components (0.4.0)
 
 PATH
   remote: .
   specs:
-    lacci (0.3.0)
-      scarpe-components
+    lacci (0.4.0)
+      scarpe-components (~> 0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lacci/lacci.gemspec
+++ b/lacci/lacci.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/scarpe-team/scarpe"
+  #spec.metadata["source_code_uri"] = "https://github.com/scarpe-team/scarpe"
   spec.metadata["changelog_uri"] = "https://github.com/scarpe-team/scarpe/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.

--- a/lacci/lacci.gemspec
+++ b/lacci/lacci.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "scarpe-components" # Scarpe-Components has no dependencies, and includes useful infrastructure
+  spec.add_dependency "scarpe-components", "~>0.4.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lacci/lib/lacci/version.rb
+++ b/lacci/lib/lacci/version.rb
@@ -9,5 +9,5 @@
 # mostly invisible. Instead, look at the {Shoes} module
 # to see what's in Lacci.
 module Lacci
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/lib/scarpe/version.rb
+++ b/lib/scarpe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scarpe
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/scarpe-components/Gemfile.lock
+++ b/scarpe-components/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ../lacci
   specs:
-    lacci (0.3.0)
-      scarpe-components
+    lacci (0.4.0)
+      scarpe-components (~> 0.4.0)
 
 PATH
   remote: .
   specs:
-    scarpe-components (0.3.0)
+    scarpe-components (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/scarpe-components/lib/scarpe/components/version.rb
+++ b/scarpe-components/lib/scarpe/components/version.rb
@@ -2,6 +2,6 @@
 
 module Scarpe
   module Components
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/scarpe-components/scarpe-components.gemspec
+++ b/scarpe-components/scarpe-components.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/scarpe-team/scarpe"
+  #spec.metadata["source_code_uri"] = "https://github.com/scarpe-team/scarpe"
   spec.metadata["changelog_uri"] = "https://github.com/scarpe-team/scarpe/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.

--- a/scarpe.gemspec
+++ b/scarpe.gemspec
@@ -30,13 +30,13 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fastimage"
-  spec.add_dependency "nokogiri"
-  spec.add_dependency "sqlite3"
-  spec.add_dependency "webrick"
+  spec.add_dependency "fastimage", "~>2.2.7"
+  spec.add_dependency "nokogiri", "~>1.15.2"
+  spec.add_dependency "sqlite3", "~>1.6.3"
+  spec.add_dependency "webrick", "~>1.7.0"
 
-  spec.add_dependency "lacci"
-  spec.add_dependency "scarpe-components"
+  spec.add_dependency "lacci", "~>0.4.0"
+  spec.add_dependency "scarpe-components", "~>0.4.0"
 
   spec.add_dependency "bloops", "~>0.5"
   spec.add_dependency "logging", "~>2.3.1"

--- a/scarpe.gemspec
+++ b/scarpe.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/scarpe-team/scarpe"
+  #spec.metadata["source_code_uri"] = "https://github.com/scarpe-team/scarpe"
   spec.metadata["changelog_uri"] = "https://github.com/scarpe-team/scarpe/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
### Description

Bump versions for Scarpe-Components, Lacci and Scarpe to 0.4.0. Add explicit dependencies for Scarpe's various gem dependencies. Let gems build w/o warnings.

### Checklist

- [X] Run tests locally
