### PR TITLE
Optional settings in Shoes::App

### DIFF
--- a/lacci/lib/shoes.rb
+++ b/lacci/lib/shoes.rb
@@ -75,6 +75,7 @@ class Shoes
     # @param height [Integer] The new app window height
     # @param resizable [Boolean] Whether the app window should be resizeable
     # @param features [Symbol,Array<Symbol>] Additional Shoes extensions requested by the app
+    # @param settings [Object] Additional Shoes settings, specific to the Shoes implementation
     # @return [void]
     # @see Shoes::App#new
     def app(
@@ -83,10 +84,11 @@ class Shoes
       height: 420,
       resizable: true,
       features: [],
+      settings: {},
       &app_code_body
     )
       f = [features].flatten # Make sure this is a list, not a single symbol
-      app = Shoes::App.new(title:, width:, height:, resizable:, features: f, &app_code_body)
+      app = Shoes::App.new(title:, width:, height:, resizable:, features: f, settings:,  &app_code_body)
       app.init
       app.run
       nil

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -17,7 +17,11 @@ class Shoes
 
     shoes_styles :title, :width, :height, :resizable, :features
 
-    # This is defined to avoid the linkable-id check in the Shoes-style method_missing def'n
+    # This is entirely different for different Shoes implementations. But it allows passing
+    # implementation-specific settings information that Lacci can't directly use.
+    attr_reader :settings
+
+    # This is defined ahead of time to avoid the linkable-id check in the Shoes-style method_missing def'n
     def features
       @features
     end
@@ -31,6 +35,7 @@ class Shoes
       height: 420,
       resizable: true,
       features: [],
+      settings: {},
       &app_code_body
     )
       log_init("Shoes::App")
@@ -49,6 +54,7 @@ class Shoes
       @event_loop_type = "displaylib" # the default
 
       @features = features
+      @settings = settings
 
       unknown_ext = features - Shoes::FEATURES - Shoes::EXTENSIONS
       unsupported_features = unknown_ext & Shoes::KNOWN_FEATURES


### PR DESCRIPTION
### Description

Add settings for Shoes::App which will be ignored by the Lacci side.

A Shoes application can be specific to a particular Shoes implementation, and can have settings that are specific to that implementation. A gtk-scarpe application might want to specify a particular GTK+ theme. A scarpe-wasm app might specify how much local storage it wants reserved on its behalf. A SpaceShoes app might want to specify the Ruby version for ruby.wasm or the div to use for displaying output.

For that, we want Lacci to permit (optional) settings that will be passed through to the Scarpe implementation.

Like "features" (a list of symbols and symbol-lists which cannot contain significant data), this is an optional extension to Shoes. Shoes3 did not have this parameter.

Possible future work: should this parameter be gated behind the :scarpe feature?

### Checklist

- [ ] Run tests locally
