### PR TITLE
Fix stale dynamicRubyCallback mock expectations in test/test_web_wrangler.rb

### DIFF
--- a/test/test_web_wrangler.rb
+++ b/test/test_web_wrangler.rb
@@ -39,7 +39,7 @@ class TestWebWranglerMocked < LoggedScarpeTest
 
   def with_mocked_webview(wrangler_opts: {}, &block)
     @mocked_webview = Minitest::Mock.new
-    ["puts", "scarpeAsyncEvalResult", "scarpeHeartbeat"].each do |bound_method|
+    ["puts", "dynamicRubyCallback", "scarpeAsyncEvalResult", "scarpeHeartbeat"].each do |bound_method|
       @mocked_webview.expect :bind, nil, [bound_method]
     end
     @mocked_webview.expect :init, nil, [String]


### PR DESCRIPTION
## Description:

Fixes stale mocked bind expectations in `test/test_web_wrangler.rb`.

`Scarpe::Webview::WebWrangler#initialize` now binds `dynamicRubyCallback`, but the mocked webview helper still expected only the older bind list. That caused all tests in `TestWebWranglerMocked` to fail during setup with `MockExpectationError`.

This PR updates the mocked webview expectations to include `dynamicRubyCallback` in the same order used by `WebWrangler#initialize`.

This is a test only change and does not change runtime behavior.

Closes #581.

## Checklist:

- [x] I reproduced the failure on latest `main` in a clean checkout using `bundle exec ruby -Itest test/test_web_wrangler.rb --name /TestWebWranglerMocked/`.
- [x] I ran focused tests using `bundle exec ruby -Itest test/test_web_wrangler.rb --name /TestWebWranglerMocked/`.
- [x] I ran `bundle exec ruby -Itest test/test_web_wrangler.rb`.

### Before the fix

<img width="1500" height="380" alt="image" src="https://github.com/user-attachments/assets/8242a2bf-b018-43d0-afa6-3246f95803a8" />

### After the fix

<img width="906" height="820" alt="image" src="https://github.com/user-attachments/assets/c37e0026-d0ab-4656-811a-18de39bb9e78" />
