### PR TITLE
Pass filename and line to ShoesSpec eval backtraces

### DIFF
--- a/lacci/lib/scarpe/niente/shoes_spec.rb
+++ b/lacci/lib/scarpe/niente/shoes_spec.rb
@@ -6,7 +6,7 @@ require "scarpe/components/string_helpers"
 module Niente; end
 
 class Niente::Test
-  def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
+  def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil, filename: "(eval)", line: 1)
     if @shoes_spec_init
       raise Shoes::Errors::MultipleShoesSpecRunsError, "Niente can only run a single Shoes spec per process!"
     end
@@ -30,7 +30,7 @@ class Niente::Test
     Object.const_set(Scarpe::Components::StringHelpers.camelize(class_name), test_class)
     test_name = "test_" + test_name unless test_name.start_with?("test_")
     test_class.define_method(test_name) do
-      eval(code)
+      eval(code, nil, filename, line)
     end
   end
 end

--- a/lacci/lib/shoes-spec.rb
+++ b/lacci/lib/shoes-spec.rb
@@ -43,8 +43,10 @@ class Shoes
     # @param code [String] the ShoesSpec code to execute
     # @param class_name [String|NilClass] the Minitest class name for reporting or nil
     # @param test_name [String|NilClass] the Minitest test name for reporting or nil
+    # @param filename [String] the filename to use for backtraces when eval'ing code
+    # @param line [Integer] the starting line number to use for backtraces when eval'ing code
     # @return [void]
-    def run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
+    def run_shoes_spec_test_code(code, class_name: nil, test_name: nil, filename: "(eval)", line: 1)
       raise "Child class should override this!"
     end
   end

--- a/lacci/lib/shoes/app.rb
+++ b/lacci/lib/shoes/app.rb
@@ -98,7 +98,7 @@ class Shoes
         test_code = File.read ENV['SHOES_SPEC_TEST']
         unless test_code.empty?
           Shoes::App.set_test_code = true
-          Shoes::Spec.instance.run_shoes_spec_test_code test_code
+          Shoes::Spec.instance.run_shoes_spec_test_code test_code, filename: ENV['SHOES_SPEC_TEST'], line: 1
         end
       end
 

--- a/lacci/test/test_niente_test_infra.rb
+++ b/lacci/test/test_niente_test_infra.rb
@@ -24,6 +24,21 @@ class TestNienteTestInfra < NienteTest
     SHOES_SPEC
   end
 
+  def test_app_fail_in_spec_backtrace_uses_test_filename
+    error = assert_raises(RuntimeError) do
+      run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
+        Shoes.app do
+          @b = button "OK"
+        end
+      SHOES_APP
+        raise "ERROR!"
+      SHOES_SPEC
+    end
+
+    assert_match(/shoes_spec_code.*:1:in /, error.message)
+    refute_match(/\(eval\):1:in /, error.message)
+  end
+
   def test_multi_app_find
     run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
       Shoes.app do

--- a/lib/scarpe/shoes_spec.rb
+++ b/lib/scarpe/shoes_spec.rb
@@ -147,7 +147,7 @@ end
 module Scarpe::Test
   # Is it at all reasonable to define more than one test to run in the same Shoes run? Probably not.
   # They'll leave in-memory residue.
-  def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil)
+  def self.run_shoes_spec_test_code(code, class_name: nil, test_name: nil, filename: "(eval)", line: 1)
     if @shoes_spec_init
       raise Shoes::Errors::MultipleShoesSpecRunsError, "Scarpe-Webview can only run a single Shoes spec per process!"
     end
@@ -189,7 +189,7 @@ module Scarpe::Test
     Object.const_set(Scarpe::Components::StringHelpers.camelize(class_name), test_class)
     test_name = "test_" + test_name unless test_name.start_with?("test_")
     test_class.define_method(test_name) do
-      eval(code)
+      eval(code, nil, filename, line)
     end
   end
 

--- a/test/test_sspec_infrastructure.rb
+++ b/test/test_sspec_infrastructure.rb
@@ -78,6 +78,20 @@ class TestSSpecInfrastructure < ShoesSpecLoggedTest
     SSPEC
   end
 
+  def test_exception_backtrace_uses_test_filename
+    error = assert_raises(RuntimeError) do
+      run_test_scarpe_code(<<-'SCARPE_APP', app_test_code: <<-'TEST_CODE')
+        Shoes.app do
+        end
+      SCARPE_APP
+        raise "Yup, that's an exception!"
+      TEST_CODE
+    end
+
+    assert_match(/scarpe_app_test\.rb.*:3:in /, error.message)
+    refute_match(/\(eval\):3:in /, error.message)
+  end
+
   def test_many_assertions
     run_scarpe_sspec_code(<<~'SSPEC', expect_assertions_min: 10)
       ---


### PR DESCRIPTION
## Description:

Issue #453 reported that ShoesSpec backtraces were less useful because the Scarpe and Niente ShoesSpec runners still used bare `eval(code)`, which reports `(eval):...` instead of the test file path.

This PR updates both ShoesSpec runners to accept `filename` and `line`, and evaluates test code with `eval(code, nil, filename, line)`.

It also updates the Shoes app test path to pass the `SHOES_SPEC_TEST` filename into `run_shoes_spec_test_code`, and adds regression tests for both Scarpe and Niente to verify that backtraces now include the test filename instead of `(eval):...`.

Closes #453.

## Checklist:

- [x] I reproduced the issue on latest `main` in a clean checkout.
- [x] I ran focused tests using `bundle exec ruby -Itest test/test_sspec_infrastructure.rb --name "/test_exception_backtrace_uses_test_filename|test_exception/"`.
- [x] I ran focused tests using `bundle exec ruby -Ilacci/test lacci/test/test_niente_test_infra.rb --name "/test_app_fail_in_spec_backtrace_uses_test_filename|test_app_fail_in_spec/"`.
- [x] I ran `bundle exec ruby -Itest test/test_sspec_infrastructure.rb`.
- [x] I ran `bundle exec ruby -Ilacci/test lacci/test/test_niente_test_infra.rb`.

### The validation screenshots of the tests run, locally:

<img width="984" height="536" alt="image" src="https://github.com/user-attachments/assets/e38bfa5b-8288-47da-90c8-b3047210ac87" />

<img width="984" height="350" alt="image" src="https://github.com/user-attachments/assets/4b86ff88-7e1f-42a9-8e7b-5df52831eef8" />

### Before the fix:

<img width="900" height="288" alt="image" src="https://github.com/user-attachments/assets/fa005709-3d2a-4d97-9b8d-de811fb8b638" />

### After the fix:

<img width="1140" height="288" alt="image" src="https://github.com/user-attachments/assets/29d40af8-c97f-47de-a9e1-18611f865d4c" />
