### PR TITLE
Fix Slot#destroy to cascade to children (drawable registry leak)

### DIFF
--- a/lacci/lib/shoes/drawables/slot.rb
+++ b/lacci/lib/shoes/drawables/slot.rb
@@ -210,8 +210,17 @@ class Shoes::Slot < Shoes::Drawable
 
   # Override destroy to fire finish callbacks before actual destruction.
   # This matches Shoes3 behavior where finish is a removal/cleanup event.
+  #
+  # A Slot owns its children, so tearing it down must tear down the whole
+  # subtree. The base Drawable#destroy only unhooks self; without cascading,
+  # a cleared slot's descendants stay pinned in the class-level registry
+  # (Shoes::Drawable @drawables_by_id) and keep their event subscriptions
+  # alive — an unbounded leak for apps that rebuild via clear { ... }
+  # (Clock, Pong, long-running dashboards). Children destroy first so each
+  # detaches its own DOM node before this slot's removal.
   def destroy
     fire_finish_callbacks
+    @children&.dup&.each(&:destroy)
     super
   end
 

--- a/lacci/test/test_parenting.rb
+++ b/lacci/test/test_parenting.rb
@@ -91,6 +91,45 @@ class TestParenting < NienteTest
     SHOES_SPEC
   end
 
+  # Regression: clearing a slot must unregister its WHOLE subtree from the
+  # class-level Shoes::Drawable registry, not just its direct children. Before
+  # the cascading Slot#destroy fix, nested descendants (the para/button inside
+  # an inner stack) stayed pinned in @drawables_by_id forever, leaking on every
+  # clear { ... } rebuild — fatal for long-running apps (Clock, Pong, dashboards).
+  def test_clear_unregisters_nested_descendants
+    run_test_niente_code(<<~SHOES_APP, app_test_code: <<~SHOES_SPEC)
+      Shoes.app do
+        @outer = stack do
+          stack do            # inner slot; its children are GRANDCHILDREN of @outer
+            @deep_para = para "deep"
+            @deep_btn  = button "deep btn"
+          end
+        end
+        @clear = button "Clear" do
+          @outer.clear
+        end
+      end
+    SHOES_APP
+      # Grab the deep descendants' registry keys while they still exist.
+      deep_para_id = para("@deep_para").obj.linkable_id
+      deep_btn_id  = button("@deep_btn").obj.linkable_id
+
+      # Sanity: they're registered before the clear.
+      refute_nil Shoes::Drawable.drawable_by_id(deep_para_id, none_ok: true)
+      refute_nil Shoes::Drawable.drawable_by_id(deep_btn_id, none_ok: true)
+
+      button("@clear").trigger_click
+
+      # Outer slot empties out...
+      assert_equal [], stack("@outer").contents
+      # ...and the nested descendants are no longer pinned in the registry.
+      assert_nil Shoes::Drawable.drawable_by_id(deep_para_id, none_ok: true),
+        "nested para leaked in the drawable registry after clear"
+      assert_nil Shoes::Drawable.drawable_by_id(deep_btn_id, none_ok: true),
+        "nested button leaked in the drawable registry after clear"
+    SHOES_SPEC
+  end
+
   # I don't think Shoes does this. We have to use Lacci-specific methods.
   # It's still good to have a test for it.
   def test_drawable_reparent


### PR DESCRIPTION
## Summary

`Slot#destroy` fires its `finish` callbacks and unhooks itself, but the base `Drawable#destroy` never recurses into the slot's children. Clearing or destroying a slot leaves every **nested** descendant (grandchildren and deeper) pinned in the class-level `Shoes::Drawable` registry (`@drawables_by_id`), with their Shoes event subscriptions still attached.

Direct children are already cleaned up, because `Slot#clear` calls `destroy` on them. The gap is purely that `destroy` didn't propagate one level further down.

For a one-shot UI this is invisible. For any app that repeatedly rebuilds its contents with `clear { ... }` (the `clock` and `pong` examples, or any long-running animated UI), every rebuild leaks the entire previous subtree. The registry grows without bound until the process runs out of memory and dies.

## Fix

`Slot#destroy` now destroys its children before tearing down itself:

```ruby
def destroy
  fire_finish_callbacks
  @children&.dup&.each(&:destroy)
  super
end
```

- Children destroy **first**, so each detaches its own DOM node before the parent slot is removed (removal is already null-safe in `ElementWrangler#on_each`, so there's no double-remove hazard).
- Nested slots recurse naturally, which also means `finish` callbacks now fire for nested slots on a parent clear, not just for top-level ones.

## Test plan

- [x] New lacci regression test `test_clear_unregisters_nested_descendants` (in `lacci/test/test_parenting.rb`): builds a slot containing an inner slot with a `para` + `button`, clears the outer slot, and asserts the nested descendants are gone from `Shoes::Drawable.drawable_by_id`. **Fails before this change** (the nested para survives, still parented to an already-destroyed slot), passes after.
- [x] Full `rake lacci_test` green: 104 tests, 188 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)