### PR TITLE
Make LoggedTest cleanup tolerate missing log files

### DIFF
--- a/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
+++ b/scarpe-components/lib/scarpe/components/unit_test_helpers.rb
@@ -157,7 +157,7 @@ module Scarpe::Test::LoggedTest
 
     ALREADY_SET_UP_LOGGED_TEST_FAILURES[:setup] = true
     # Delete stale test failures, if any, before starting the first failure-logged test
-    Dir["#{log_dir}/test_failure*.log"].each { |fn| File.unlink(fn) }
+    Dir["#{log_dir}/test_failure*.log"].each { |fn| FileUtils.rm_f(fn) }
 
     Minitest.after_run do
       # Print test failure notice to console
@@ -213,7 +213,7 @@ module Scarpe::Test::LoggedTest
     Dir["#{self.class.logger_dir}/test_failure*.log"].each do |f|
       next if f.include?(".out.log") # Don't delete saved logs
 
-      File.unlink(f)
+      FileUtils.rm_f(f)
     end
   end
 end

--- a/scarpe-components/test/test_unit_test_helpers.rb
+++ b/scarpe-components/test/test_unit_test_helpers.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "tmpdir"
+
+class DummyLoggedTest
+  include Scarpe::Test::LoggedTest
+
+  class << self
+    attr_accessor :logger_dir
+  end
+end
+
+class TestUnitTestHelpers < Minitest::Test
+  def setup
+    @logger_dir = Dir.mktmpdir("logged-test-cleanup")
+    DummyLoggedTest.logger_dir = @logger_dir
+    ALREADY_SET_UP_LOGGED_TEST_FAILURES[:setup] = false
+  end
+
+  def teardown
+    ALREADY_SET_UP_LOGGED_TEST_FAILURES[:setup] = false
+    FileUtils.remove_entry(@logger_dir) if File.directory?(@logger_dir)
+  end
+
+  def test_logged_test_setup_ignores_stale_glob_entries
+    File.write(File.join(@logger_dir, "test_failure_demo.log"), "demo")
+
+    with_stale_globbed_log_paths do
+      DummyLoggedTest.new.send(:set_up_test_failures)
+    end
+
+    assert ALREADY_SET_UP_LOGGED_TEST_FAILURES[:setup]
+  end
+
+  def test_remove_unsaved_logs_ignores_stale_glob_entries
+    File.write(File.join(@logger_dir, "test_failure_demo.log"), "demo")
+
+    with_stale_globbed_log_paths do
+      DummyLoggedTest.new.send(:remove_unsaved_logs)
+    end
+
+    assert_empty Dir["#{@logger_dir}/test_failure*.log"]
+  end
+
+  private
+
+  def with_stale_globbed_log_paths
+    dir_singleton = class << Dir
+      self
+    end
+    original = Dir.method(:[])
+
+    dir_singleton.send(:define_method, :[]) do |pattern|
+      results = original.call(pattern)
+      results.each { |f| FileUtils.rm_f(f) }
+      results
+    end
+
+    yield
+  ensure
+    dir_singleton.send(:define_method, :[], original)
+  end
+end


### PR DESCRIPTION
## Description:

Issue #586 reported that `Scarpe::Test::LoggedTest` cleanup could raise `Errno::ENOENT` when a globbed test failure log disappeared before `File.unlink` ran.

This PR updates the LoggedTest cleanup paths to use `FileUtils.rm_f` in both setup cleanup and `remove_unsaved_logs`, so missing files are treated as best-effort deletes.

It also adds regression tests that simulate stale glob results in both cleanup paths.

Closes #586.

## Checklist:

- [x] I have run focused tests using `bundle exec ruby -Iscarpe-components/test scarpe-components/test/test_unit_test_helpers.rb`.
- [x] I have run broader component tests using `bundle exec ruby -Iscarpe-components/test -e 'Dir["scarpe-components/test/**/*.rb"].sort.each { |file| require File.expand_path(file) unless file.end_with?("test_helper.rb") }'`.

### Before the fix:

<img width="1118" height="158" alt="image" src="https://github.com/user-attachments/assets/968c33a6-79b8-4260-bdd4-aa8d22df9126" />

### After the fix: 

<img width="568" height="141" alt="image" src="https://github.com/user-attachments/assets/694bfd8a-113f-4d9b-8b6a-37106768b778" />

### The validation screenshot of the focused test run:

<img width="828" height="192" alt="image" src="https://github.com/user-attachments/assets/feb6c6a1-29b8-42c8-9e26-12046279d427" />
