### PR TITLE
test: use temp export file for run_test_scarpe_app

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -117,16 +117,14 @@ class ShoesSpecLoggedTest < Minitest::Test
       #{app_test_code}
     TEST_CODE
 
-    test_output = File.expand_path(File.join __dir__, "sspec.json")
-    File.unlink test_output rescue nil
-
     test_method_name = self.name
     test_class_name = self.class.name
 
     with_tempfiles([
       ["scarpe_log_config.json", JSON.dump(log_config_for_test)],
       ["scarpe_app_test.rb", full_test_code],
-    ]) do |scarpe_log_config, app_test_path|
+      [["sspec_test_output", ".json"], ""],
+    ]) do |scarpe_log_config, app_test_path, test_output|
       # Start the application using the exe/scarpe utility
       # For unit testing always supply --debug so we get the most logging
       system(
@@ -138,30 +136,30 @@ class ShoesSpecLoggedTest < Minitest::Test
         "SHOES_MINITEST_METHOD_NAME=\"#{test_method_name}\" " +
         "LOCALAPPDATA=\"#{Dir.tmpdir}\"" +
         "ruby #{SCARPE_EXE} --debug --dev #{test_app_location}")
-    end
 
-    # TODO: this should *require* the process to fail, not allow it.
-    if allow_fail
-      assert true
-      return
-    end
+      # TODO: this should *require* the process to fail, not allow it.
+      if allow_fail
+        assert true
+        return
+      end
 
-    # Check if the process exited normally or crashed (segfault, failure, timeout)
-    unless $?.success?
-      assert(false, "Scarpe app failed with exit code: #{$?.exitstatus}")
-      return
-    end
+      # Check if the process exited normally or crashed (segfault, failure, timeout)
+      unless $?.success?
+        assert(false, "Scarpe app failed with exit code: #{$?.exitstatus}")
+        return
+      end
 
-    result = Scarpe::Components::MinitestResult.new(test_output)
-    if result.error?
-      raise result.error_message
-    elsif result.fail?
-      assert false, result.fail_message
-    elsif result.skip?
-      skip
-    else
-      # Count out the correct number of assertions
-      result.assertions.times { assert true }
+      result = Scarpe::Components::MinitestResult.new(test_output)
+      if result.error?
+        raise result.error_message
+      elsif result.fail?
+        assert false, result.fail_message
+      elsif result.skip?
+        skip
+      else
+        # Count out the correct number of assertions
+        result.assertions.times { assert true }
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -123,7 +123,7 @@ class ShoesSpecLoggedTest < Minitest::Test
     with_tempfiles([
       ["scarpe_log_config.json", JSON.dump(log_config_for_test)],
       ["scarpe_app_test.rb", full_test_code],
-      [["sspec_test_output", ".json"], ""],
+      [["sspec_test_output", "json"], ""],
     ]) do |scarpe_log_config, app_test_path, test_output|
       # Start the application using the exe/scarpe utility
       # For unit testing always supply --debug so we get the most logging

--- a/test/test_sspec_infrastructure.rb
+++ b/test/test_sspec_infrastructure.rb
@@ -92,6 +92,20 @@ class TestSSpecInfrastructure < ShoesSpecLoggedTest
     refute_match(/\(eval\):3:in /, error.message)
   end
 
+  def test_run_test_scarpe_app_uses_temp_export_file
+    test_output = File.expand_path(File.join(__dir__, "sspec.json"))
+    File.unlink(test_output) if File.exist?(test_output)
+
+    run_test_scarpe_code(<<~'SCARPE_APP', app_test_code: <<~'TEST_CODE')
+      Shoes.app do
+      end
+    SCARPE_APP
+      assert_equal true, true
+    TEST_CODE
+
+    refute File.exist?(test_output), "run_test_scarpe_app should not recreate test/sspec.json"
+  end
+
   def test_many_assertions
     run_scarpe_sspec_code(<<~'SSPEC', expect_assertions_min: 10)
       ---


### PR DESCRIPTION
## Description:

Issue #585 reported that `run_test_scarpe_app` in `test/test_helper.rb` wrote ShoesSpec export results to the fixed repo path `test/sspec.json`.

This PR updates `run_test_scarpe_app` to allocate its export JSON with the existing tempfile helper, matching `run_scarpe_sspec` and isolating each test run from repo-local output files.

It also adds a regression test that proves `run_test_scarpe_app` no longer recreates `test/sspec.json`.

Closes #585.

## Checklist:

- [x] I reproduced the issue on latest `origin/main` with `bundle exec ruby -Itest test/test_sspec_infrastructure.rb --name test_exception_backtrace_uses_test_filename`.
- [x] I ran focused tests using `bundle exec ruby -Itest test/test_sspec_infrastructure.rb`.

### Before the fix:

<img width="821" height="488" alt="image" src="https://github.com/user-attachments/assets/9a7d3228-6218-45d1-abd7-81de9f4b62f8" />

### After the fix:

<img width="1510" height="776" alt="image" src="https://github.com/user-attachments/assets/51072022-cb1c-4c76-9820-d99349ed142d" />

### The validation screenshot of the focused tests run:

<img width="938" height="744" alt="image" src="https://github.com/user-attachments/assets/38e64a3e-b219-4667-8b55-5e5a673f8187" />
